### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CosmicFrontierLabs/coast-sim/security/code-scanning/2](https://github.com/CosmicFrontierLabs/coast-sim/security/code-scanning/2)

To fix this problem, add a `permissions` key to the workflow YAML file, specifically at the workflow level (root) since all jobs only need read access to the repository contents to function. This follows best practices and covers all jobs, ensuring that the `GITHUB_TOKEN` is limited appropriately without granting unnecessary write access. Edit `.github/workflows/python-lint.yml` by inserting the following block after the `name:` field and before the `on:` field:

```yaml
permissions:
  contents: read
```

This grants all jobs and steps in the workflow read-only permission on repository contents, which is the least privilege necessary for running linters and formatters.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
