### PR TITLE
Fix charging mode not exiting when battery full

### DIFF
--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -698,6 +698,11 @@ class ACS:
         """
         print("Ending battery charge")
 
+        # Clear the charging slew state immediately so _is_in_charging_mode returns False
+        # This prevents staying in CHARGING mode while slewing back to science
+        if self.last_slew is not None and self.last_slew.obstype == "CHARGE":
+            self.last_slew = None
+
         # Return to the previous science PPT if one exists
         if self.last_ppt is not None:
             print(


### PR DESCRIPTION
This pull request makes a targeted fix to the battery charging logic in the `acs.py` simulation module. The main change ensures that the system immediately exits charging mode by clearing the charging slew state, which prevents it from incorrectly remaining in CHARGING mode during the transition back to science operations.

- Battery charging logic fix:
  * In the `_end_battery_charge` method of `acs.py`, the charging slew state (`last_slew`) is now cleared immediately when ending a charge if the last slew was for charging. This ensures `_is_in_charging_mode` returns `False` and prevents the system from remaining in CHARGING mode while slewing back to science operations.