### PR TITLE
Fix random docs stuff

### DIFF
--- a/docs/api/conops.common.enums.rst
+++ b/docs/api/conops.common.enums.rst
@@ -1,0 +1,8 @@
+conops.common.enums
+===================
+
+.. automodule:: conops.common.enums
+   :members: ACSCommandType, ACSMode, AntennaType, ChargeState, Polarization
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/conops.config.acs.rst
+++ b/docs/api/conops.config.acs.rst
@@ -1,0 +1,8 @@
+conops.config.acs
+=================
+
+.. automodule:: conops.config.acs
+   :members: AttitudeControlSystem
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/conops.config.data_generator.rst
+++ b/docs/api/conops.config.data_generator.rst
@@ -1,0 +1,8 @@
+conops.config.data\_generator
+=============================
+
+.. automodule:: conops.config.data_generator
+   :members: DataGeneration
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/conops.config.fault_management.rst
+++ b/docs/api/conops.config.fault_management.rst
@@ -1,0 +1,8 @@
+conops.config.fault\_management
+===============================
+
+.. automodule:: conops.config.fault_management
+   :members: FaultConstraint, FaultEvent, FaultManagement, FaultState, FaultThreshold
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/conops.config.observation_categories.rst
+++ b/docs/api/conops.config.observation_categories.rst
@@ -1,0 +1,8 @@
+conops.config.observation\_categories
+=====================================
+
+.. automodule:: conops.config.observation_categories
+   :members: ObservationCategories, ObservationCategory
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/conops.config.power.rst
+++ b/docs/api/conops.config.power.rst
@@ -1,0 +1,8 @@
+conops.config.power
+===================
+
+.. automodule:: conops.config.power
+   :members: PowerDraw
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/conops.config.spacecraft_bus.rst
+++ b/docs/api/conops.config.spacecraft_bus.rst
@@ -1,0 +1,8 @@
+conops.config.spacecraft\_bus
+=============================
+
+.. automodule:: conops.config.spacecraft_bus
+   :members: SpacecraftBus
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/conops.config.thermal.rst
+++ b/docs/api/conops.config.thermal.rst
@@ -1,0 +1,8 @@
+conops.config.thermal
+=====================
+
+.. automodule:: conops.config.thermal
+   :members: Heater
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/conops.ditl.ditl.rst
+++ b/docs/api/conops.ditl.ditl.rst
@@ -2,7 +2,8 @@ conops.ditl.ditl
 ==================
 
 .. automodule:: conops.ditl.ditl
-   :members:
+   :members: DITL, DITLs
    :undoc-members:
    :show-inheritance:
    :special-members: __init__
+   :no-index:

--- a/docs/api/conops.ditl.ditl_event.rst
+++ b/docs/api/conops.ditl.ditl_event.rst
@@ -1,7 +1,8 @@
-conops.ditl.ditl_event
+conops.ditl.ditl\_event
 =======================
 
 .. automodule:: conops.ditl.ditl_event
-   :members:
+   :members: DITLEvent
    :undoc-members:
    :show-inheritance:
+   :no-index:

--- a/docs/api/conops.ditl.ditl_log.rst
+++ b/docs/api/conops.ditl.ditl_log.rst
@@ -1,7 +1,8 @@
-conops.ditl.ditl_log
+conops.ditl.ditl\_log
 =====================
 
 .. automodule:: conops.ditl.ditl_log
-   :members:
+   :members: DITLLog
    :undoc-members:
    :show-inheritance:
+   :no-index:

--- a/docs/api/conops.ditl.ditl_log_store.rst
+++ b/docs/api/conops.ditl.ditl_log_store.rst
@@ -1,4 +1,4 @@
-conops.ditl.ditl_log_store
+conops.ditl.ditl\_log\_store
 ==========================
 
 DITLLogStore is implemented as a Pydantic model for simple validation and
@@ -6,6 +6,7 @@ ergonomic construction. The SQLite connection is held as a private attribute
 and excluded from serialization.
 
 .. automodule:: conops.ditl.ditl_log_store
-   :members:
+   :members: DITLLogStore
    :undoc-members:
    :show-inheritance:
+   :no-index:

--- a/docs/api/conops.ditl.ditl_mixin.rst
+++ b/docs/api/conops.ditl.ditl_mixin.rst
@@ -1,8 +1,9 @@
-conops.ditl.ditl_mixin
+conops.ditl.ditl\_mixin
 =========================
 
 .. automodule:: conops.ditl.ditl_mixin
-   :members:
+   :members: DITLMixin
    :undoc-members:
    :show-inheritance:
    :special-members: __init__
+   :no-index:

--- a/docs/api/conops.ditl.ditl_stats.rst
+++ b/docs/api/conops.ditl.ditl_stats.rst
@@ -1,0 +1,8 @@
+conops.ditl.ditl\_stats
+=======================
+
+.. automodule:: conops.ditl.ditl_stats
+   :members: DITLStats
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/conops.ditl.queue_ditl.rst
+++ b/docs/api/conops.ditl.queue_ditl.rst
@@ -1,8 +1,9 @@
-conops.ditl.queue_ditl
+conops.ditl.queue\_ditl
 ========================
 
 .. automodule:: conops.ditl.queue_ditl
-   :members:
+   :members: QueueDITL
    :undoc-members:
    :show-inheritance:
    :special-members: __init__
+   :no-index:

--- a/docs/api/conops.schedulers.scheduler.rst
+++ b/docs/api/conops.schedulers.scheduler.rst
@@ -2,7 +2,8 @@ conops.schedulers.scheduler
 ============================
 
 .. automodule:: conops.schedulers.scheduler
-   :members:
+   :members: DumbScheduler
    :undoc-members:
    :show-inheritance:
    :special-members: __init__
+   :no-index:

--- a/docs/api/conops.simulation.acs.rst
+++ b/docs/api/conops.simulation.acs.rst
@@ -1,0 +1,8 @@
+conops.simulation.acs
+=====================
+
+.. automodule:: conops.simulation.acs
+   :members: ACS
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/conops.simulation.acs_command.rst
+++ b/docs/api/conops.simulation.acs_command.rst
@@ -1,0 +1,8 @@
+conops.simulation.acs\_command
+==============================
+
+.. automodule:: conops.simulation.acs_command
+   :members: ACSCommand
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/conops.simulation.roll.rst
+++ b/docs/api/conops.simulation.roll.rst
@@ -1,0 +1,8 @@
+conops.simulation.roll
+======================
+
+.. automodule:: conops.simulation.roll
+   :members: optimum_roll, optimum_roll_sidemount
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/conops.targets.plan_entry.rst
+++ b/docs/api/conops.targets.plan_entry.rst
@@ -1,8 +1,9 @@
-conops.targets.plan_entry
+conops.targets.plan\_entry
 ==========================
 
 .. automodule:: conops.targets.plan_entry
-   :members:
+   :members: PlanEntry
    :undoc-members:
    :show-inheritance:
    :special-members: __init__
+   :no-index:

--- a/docs/api/conops.targets.pointing.rst
+++ b/docs/api/conops.targets.pointing.rst
@@ -2,7 +2,8 @@ conops.targets.pointing
 ========================
 
 .. automodule:: conops.targets.pointing
-   :members:
+   :members: Pointing
    :undoc-members:
    :show-inheritance:
    :special-members: __init__
+   :no-index:

--- a/docs/api/conops.targets.target_queue.rst
+++ b/docs/api/conops.targets.target_queue.rst
@@ -1,8 +1,9 @@
-conops.targets.target_queue
+conops.targets.target\_queue
 ============================
 
 .. automodule:: conops.targets.target_queue
-   :members:
+   :members: Queue, TargetQueue
    :undoc-members:
    :show-inheritance:
    :special-members: __init__
+   :no-index:

--- a/docs/api/conops.visualization.rst
+++ b/docs/api/conops.visualization.rst
@@ -1,0 +1,8 @@
+conops.visualization
+====================
+
+.. automodule:: conops.visualization
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :no-index:

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -10,15 +10,26 @@ Core Modules
    :maxdepth: 2
 
    conops.config
+   conops.config.acs
    conops.config.communications
+   conops.config.data_generator
+   conops.config.fault_management
+   conops.config.observation_categories
+   conops.config.power
+   conops.config.spacecraft_bus
+   conops.config.thermal
    conops.ditl
    conops.ditl.ditl
    conops.ditl.ditl_event
    conops.ditl.ditl_log
    conops.ditl.ditl_log_store
    conops.ditl.ditl_mixin
+   conops.ditl.ditl_stats
    conops.ditl.queue_ditl
    conops.simulation
+   conops.simulation.acs
+   conops.simulation.acs_command
+   conops.simulation.roll
 
 Scheduling and Planning
 -----------------------
@@ -82,4 +93,13 @@ Utilities
    :maxdepth: 2
 
    conops.common
+   conops.common.enums
    conops.constants
+
+Visualization
+-------------
+
+.. toctree::
+   :maxdepth: 2
+
+   conops.visualization

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,6 +117,86 @@ autodoc_default_options = {
     "inherited-members": False,
 }
 
+
+# Exclude imported names from documentation - these are imports from other modules
+# that appear as module members but aren't part of that module's actual API
+def autodoc_skip_member(app, what, name, obj, skip, options):
+    """Skip imported members that aren't defined in the module."""
+    # List of common imports to always exclude
+    excluded_names = {
+        # Pydantic imports
+        "field_validator",
+        "model_validator",
+        "Field",
+        "BaseModel",
+        "ConfigDict",
+        "PrivateAttr",
+        "computed_field",
+        "validator",
+        # Typing imports
+        "Any",
+        "Dict",
+        "List",
+        "Optional",
+        "Tuple",
+        "Union",
+        "Callable",
+        "TypeVar",
+        "Generic",
+        "Literal",
+        "ClassVar",
+        "TYPE_CHECKING",
+        # Dataclass imports
+        "dataclass",
+        "field",
+        # Common stdlib imports
+        "Path",
+        "datetime",
+        "timedelta",
+        "Enum",
+        "auto",
+        # NumPy
+        "np",
+        "numpy",
+        "ndarray",
+    }
+    if name in excluded_names:
+        return True
+
+    # Skip objects that are imported from other modules (not defined here)
+    # This prevents showing e.g. MissionConfig under conops.ditl.ditl when it's
+    # only imported there, not defined in that module.
+    if what in ("class", "function", "exception"):
+        try:
+            obj_module = getattr(obj, "__module__", None)
+            if obj_module:
+                # Get the module we're documenting from the fully qualified name
+                # The 'name' parameter is like 'MissionConfig' and we need parent
+                parent = getattr(options, "objpath", [])
+                if not parent:
+                    # Try to get from __globals__ if it's a function
+                    pass
+                # Check the object's actual module
+                if obj_module.startswith("conops."):
+                    # Get documented module from env if available
+                    env = getattr(app, "env", None)
+                    if env:
+                        docname = getattr(env, "docname", "")
+                        if docname.startswith("api/conops."):
+                            # Extract module name from docname like "api/conops.ditl.ditl"
+                            documented_module = docname.replace("api/", "")
+                            if obj_module != documented_module:
+                                return True
+        except Exception:
+            pass
+
+    return skip
+
+
+def setup(app):
+    app.connect("autodoc-skip-member", autodoc_skip_member)
+
+
 # Mock imports for packages that might not be available during doc build
 autodoc_mock_imports: list = [
     "conops.battery",


### PR DESCRIPTION
This pull request adds and updates API documentation for several modules in the `conops` package, improving coverage, clarity, and consistency in the Sphinx-generated docs. The changes include new documentation files for previously undocumented modules, updates to list specific members, and standardization of formatting and options across the API docs.

**New API documentation coverage:**

* Added new documentation files for the following modules, including their key classes and members: `conops.common.enums`, `conops.config.acs`, `conops.config.data_generator`, `conops.config.fault_management`, `conops.config.observation_categories`, `conops.config.power`, `conops.config.spacecraft_bus`, `conops.config.thermal`, `conops.ditl.ditl_stats`, `conops.simulation.acs`, `conops.simulation.acs_command`, and `conops.simulation.roll`. [[1]](diffhunk://#diff-4151a3b057abc5634d2a3ff5b1ebff9fc459d4c876d8cda188b282fc9c20583fR1-R8) [[2]](diffhunk://#diff-389dd907bfe2ab3c68769bd2c1cc939199bf4ef0e205e87cf2736ce3828d220cR1-R8) [[3]](diffhunk://#diff-63c0a2e9e265ed875b80460234907e0ea2d2f0cf63aa47ae6182089bae892cd2R1-R8) [[4]](diffhunk://#diff-5e37a0ff6e9370d2659240b3d030c1356e0d65c2cdc8dbbc5def9a5043ec7bf1R1-R8) [[5]](diffhunk://#diff-9bc0f85826b389e2e670c293fa147be13520345cfe147028ecf8c1f9e57c1996R1-R8) [[6]](diffhunk://#diff-f751e4e20b7a869b499687bd05f0ccd7d7605664eb91086ef7565a60094abb34R1-R8) [[7]](diffhunk://#diff-51db0b6bb874fe6e3e68fd77cc5269a2a8d0f4afdc38feca0ac7f7150c5eaab8R1-R8) [[8]](diffhunk://#diff-6b8be4a730505107e8c1cb219f7844967273ca160e37bbb9609eef66e7735bafR1-R8) [[9]](diffhunk://#diff-34984d9a7baaf14ba9fa87ad9f6ed1de4e23966873273c9759af64fe5dcdfcffR1-R8) [[10]](diffhunk://#diff-eb75298b8872a47ccf3bbc178157a596ef919a56ece46dc1c96e370a29b4d928R1-R8) [[11]](diffhunk://#diff-3cbaefa46b36b62cbb5fea60eadb1e1428be6e69c8e90cf22880b54651f0c1eaR1-R8) [[12]](diffhunk://#diff-039579dc25a71fd96a1e1ec9f9dd085287d1e719c9ea302c58a5fd4c4c4b3918R1-R8)

**Improvements to existing documentation:**

* Updated existing module docs to explicitly list important members (classes/functions) instead of using generic `:members:`. This makes the documentation more focused and helpful for users. [[1]](diffhunk://#diff-22743c7b3a788687819801593ed682e2ec6b55e8df37f73178fdb04d0bc44353L5-R9) [[2]](diffhunk://#diff-a9bcfa98171b8affbb4f1be5fe9dad1a1a4410bd8a97bc3251c44adc1280c685L1-R8) [[3]](diffhunk://#diff-a70138617a2671352d463e9a816d31f96f6e43839273bab33cab5e2573c64b42L1-R8) [[4]](diffhunk://#diff-f2a99059ed5f4b31a2a65312e04870d569dab83033ea72b1eb0255c627b0ab5eL1-R12) [[5]](diffhunk://#diff-ad6bfa8215502266b550a6a6a462e6f10f34f2a06e8e760fdd078f24830c471bL1-R9) [[6]](diffhunk://#diff-a15cea2686880647854f9060fc11eac80898159e649e1a566e2ff27783e3ec92L1-R9) [[7]](diffhunk://#diff-0351208578aacbca1db2db2767c351ebe70fb75bfb978e0b6b9f5d6911dd1df3L5-R9) [[8]](diffhunk://#diff-143d275309bcfc9e5aa74b59697d865e75de4efc14ac64636d15b1760e6fc726L1-R9)

**Standardization and formatting:**

* Standardized module titles and formatting, including consistent use of underscores in module names and addition of the `:no-index:` option to prevent indexing of these API pages. [[1]](diffhunk://#diff-a9bcfa98171b8affbb4f1be5fe9dad1a1a4410bd8a97bc3251c44adc1280c685L1-R8) [[2]](diffhunk://#diff-a70138617a2671352d463e9a816d31f96f6e43839273bab33cab5e2573c64b42L1-R8) [[3]](diffhunk://#diff-f2a99059ed5f4b31a2a65312e04870d569dab83033ea72b1eb0255c627b0ab5eL1-R12) [[4]](diffhunk://#diff-ad6bfa8215502266b550a6a6a462e6f10f34f2a06e8e760fdd078f24830c471bL1-R9) [[5]](diffhunk://#diff-a15cea2686880647854f9060fc11eac80898159e649e1a566e2ff27783e3ec92L1-R9) [[6]](diffhunk://#diff-143d275309bcfc9e5aa74b59697d865e75de4efc14ac64636d15b1760e6fc726L1-R9) [[7]](diffhunk://#diff-22743c7b3a788687819801593ed682e2ec6b55e8df37f73178fdb04d0bc44353L5-R9) [[8]](diffhunk://#diff-0351208578aacbca1db2db2767c351ebe70fb75bfb978e0b6b9f5d6911dd1df3L5-R9)

These changes will make the API documentation more complete, easier to navigate, and more useful for developers working with the `conops` codebase.