### PR TITLE
fix: add release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,11 @@
+{
+  "packages": {
+    ".": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "python",
+      "include-v-in-tag": true,
+      "include-component-in-tag": false
+    }
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
+}


### PR DESCRIPTION
This pull request adds a `release-please-config.json` configuration file to the repository. The configuration sets up automated release management for a Python project, specifying how changelogs and tags should be handled.

Release management configuration:

* Added `release-please-config.json` to enable automated releases, configure changelog path, specify Python release type, and set tag formatting options.