### PR TITLE
perf: Vectorize solar panel illumination calculations

### DIFF
--- a/conops/config/solar_panel.py
+++ b/conops/config/solar_panel.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import numpy as np
 import numpy.typing as npt
 import rust_ephem
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 from ..common import dtutcfromtimestamp, separation
 
@@ -167,6 +167,58 @@ class SolarPanel(BaseModel):
         return np.array(panel)
 
 
+# Cached SolarPanel instance for accessing eclipse constraint
+_ECLIPSE_PANEL_CACHE: SolarPanel | None = None
+
+
+def _get_eclipse_constraint() -> rust_ephem.EclipseConstraint:
+    """Get the eclipse constraint, using SolarPanel's for test compatibility."""
+    global _ECLIPSE_PANEL_CACHE
+    # Access via an instance to work around Pydantic class attribute interception
+    # This allows tests to patch SolarPanel._eclipse_constraint
+    if _ECLIPSE_PANEL_CACHE is None:
+        _ECLIPSE_PANEL_CACHE = SolarPanel()
+    return _ECLIPSE_PANEL_CACHE._eclipse_constraint
+
+
+class _PanelGeometry:
+    """Pre-computed panel geometry arrays for vectorized calculations."""
+
+    __slots__ = (
+        "gimbled",
+        "sidemount",
+        "cant_x",
+        "cant_y",
+        "azimuth_rad",
+        "max_power",
+        "efficiency",
+        "weights",
+        "panel_offset_angle",
+    )
+
+    def __init__(
+        self,
+        gimbled: npt.NDArray[np.bool_],
+        sidemount: npt.NDArray[np.bool_],
+        cant_x: npt.NDArray[np.float64],
+        cant_y: npt.NDArray[np.float64],
+        azimuth_rad: npt.NDArray[np.float64],
+        max_power: npt.NDArray[np.float64],
+        efficiency: npt.NDArray[np.float64],
+        weights: npt.NDArray[np.float64],
+        panel_offset_angle: npt.NDArray[np.float64],
+    ) -> None:
+        self.gimbled = gimbled
+        self.sidemount = sidemount
+        self.cant_x = cant_x
+        self.cant_y = cant_y
+        self.azimuth_rad = azimuth_rad
+        self.max_power = max_power
+        self.efficiency = efficiency
+        self.weights = weights
+        self.panel_offset_angle = panel_offset_angle
+
+
 class SolarPanelSet(BaseModel):
     """
     Model that describes the solar panel configuration and power generation
@@ -186,6 +238,9 @@ class SolarPanelSet(BaseModel):
     # Array-level default efficiency
     conversion_efficiency: float = 0.95
 
+    # Cached panel geometry for vectorized calculations
+    _geometry_cache: _PanelGeometry | None = PrivateAttr(default=None)
+
     @property
     def sidemount(self) -> bool:
         """Return True if any panel is side-mounted. This is a hack right now
@@ -201,6 +256,53 @@ class SolarPanelSet(BaseModel):
     def _effective_panels(self) -> list[SolarPanel]:
         """Return the configured panels for this set."""
         return self.panels
+
+    def _get_geometry(self) -> _PanelGeometry:
+        """Get or compute cached panel geometry arrays."""
+        if self._geometry_cache is not None:
+            return self._geometry_cache
+
+        panels = self._effective_panels()
+        n = len(panels)
+
+        gimbled = np.array([p.gimbled for p in panels], dtype=bool)
+        sidemount = np.array([p.sidemount for p in panels], dtype=bool)
+        cant_x = np.array([p.cant_x for p in panels], dtype=np.float64)
+        cant_y = np.array([p.cant_y for p in panels], dtype=np.float64)
+        azimuth_rad = np.deg2rad([p.azimuth_deg for p in panels])
+        max_power = np.array([p.max_power for p in panels], dtype=np.float64)
+        efficiency = np.array(
+            [
+                p.conversion_efficiency
+                if p.conversion_efficiency is not None
+                else self.conversion_efficiency
+                for p in panels
+            ],
+            dtype=np.float64,
+        )
+
+        total_max = max_power.sum()
+        weights = max_power / total_max if total_max > 0 else np.zeros(n)
+
+        # Pre-compute panel offset angles
+        # Sidemount: 90 - cant_x
+        # Body-mount: hypot(cant_x, cant_y)
+        panel_offset_angle = np.where(
+            sidemount, 90.0 - cant_x, np.hypot(cant_x, cant_y)
+        )
+
+        self._geometry_cache = _PanelGeometry(
+            gimbled=gimbled,
+            sidemount=sidemount,
+            cant_x=cant_x,
+            cant_y=cant_y,
+            azimuth_rad=azimuth_rad,
+            max_power=max_power,
+            efficiency=efficiency,
+            weights=weights,
+            panel_offset_angle=panel_offset_angle,
+        )
+        return self._geometry_cache
 
     def panel_illumination_fraction(
         self,
@@ -317,8 +419,8 @@ class SolarPanelSet(BaseModel):
     ) -> tuple[float | np.ndarray, float | np.ndarray]:
         """Calculate both illumination fraction and power in a single call.
 
-        This is more efficient than calling panel_illumination_fraction() and power()
-        separately when both values are needed, as it avoids duplicate calculations.
+        This is a vectorized implementation that computes all panels efficiently
+        by looking up sun position and eclipse state only once per call.
 
         Args:
             time: Unix timestamp, datetime, or list of datetimes
@@ -329,35 +431,90 @@ class SolarPanelSet(BaseModel):
         Returns:
             tuple: (illumination_fraction, power_watts)
         """
-        illum_accum: float | np.ndarray | None = None
-        power_accum: float | np.ndarray | None = None
+        panels = self._effective_panels()
+        if not panels:
+            if isinstance(time, (float, int, datetime)):
+                return 0.0, 0.0
+            return np.zeros(len(time)), np.zeros(len(time))
 
+        # Get cached panel geometry
+        geom = self._get_geometry()
+
+        # Handle time conversion - we only need scalar case for DITL
+        if isinstance(time, (int, float)):
+            dt = dtutcfromtimestamp(time)
+            scalar = True
+        elif isinstance(time, datetime):
+            dt = time
+            scalar = True
+        else:
+            # List of times - fall back to per-panel loop for now
+            # (vectorizing across both panels AND times is more complex)
+            return self._illumination_and_power_loop(time, ra, dec, ephem)
+
+        # Get ephemeris index ONCE
+        idx = ephem.index(dt)
+
+        # Check eclipse ONCE (use SolarPanel's constraint for test compatibility)
+        in_eclipse = _get_eclipse_constraint().in_constraint(
+            ephemeris=ephem, target_ra=0.0, target_dec=0.0, time=dt
+        )
+
+        if in_eclipse:
+            # In eclipse - no illumination for any panel
+            return (0.0, 0.0) if scalar else (np.array([0.0]), np.array([0.0]))
+
+        # Get sun position ONCE (this was the 89.8% bottleneck!)
+        sun_ra_deg = ephem.sun[idx].ra.deg
+        sun_dec_deg = ephem.sun[idx].dec.deg
+
+        # Compute sun angle (same for all panels at this pointing)
+        sun_ra_rad = np.deg2rad(sun_ra_deg)
+        sun_dec_rad = np.deg2rad(sun_dec_deg)
+        target_ra_rad = np.deg2rad(ra)
+        target_dec_rad = np.deg2rad(dec)
+        sunangle = np.rad2deg(
+            separation([sun_ra_rad, sun_dec_rad], [target_ra_rad, target_dec_rad])
+        )
+
+        # Vectorized panel illumination calculation
+        # panel_sun_angle = 180 - sunangle - panel_offset_angle
+        panel_sun_angle = 180.0 - sunangle - geom.panel_offset_angle
+        panel_illum = np.cos(np.radians(panel_sun_angle))
+
+        # Apply azimuthal constraint for side-mounted panels with non-zero azimuth
+        # cos(azimuth) gives the projection factor
+        azimuth_factor = np.abs(np.cos(geom.azimuth_rad))
+        # Only apply to sidemount panels (azimuth doesn't affect body-mount)
+        panel_illum = np.where(
+            geom.sidemount, panel_illum * azimuth_factor, panel_illum
+        )
+
+        # Gimbled panels get full illumination when not in eclipse
+        panel_illum = np.where(geom.gimbled, 1.0, panel_illum)
+
+        # Clip negative illumination to zero
+        panel_illum = np.maximum(panel_illum, 0.0)
+
+        # Compute weighted illumination and power
+        weighted_illum = float(np.sum(panel_illum * geom.weights))
+        total_power = float(np.sum(panel_illum * geom.max_power * geom.efficiency))
+
+        return weighted_illum, total_power
+
+    def _illumination_and_power_loop(
+        self,
+        time: list[datetime],
+        ra: float,
+        dec: float,
+        ephem: rust_ephem.Ephemeris,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Fallback loop-based implementation for list of times."""
         panels = self._effective_panels()
         total_max = sum(p.max_power for p in panels)
 
-        if not panels or total_max <= 0:
-            if isinstance(time, (datetime, float)):
-                return 0.0, 0.0
-            # Get array shape from a dummy call
-            dummy_time = (
-                [dtutcfromtimestamp(time)]
-                if isinstance(time, (datetime, float))
-                else time
-            )
-            dummy_panel = panels[0] if panels else SolarPanel()
-            dummy_result = dummy_panel.panel_illumination_fraction(
-                time=dummy_time, ephem=ephem, ra=ra, dec=dec
-            )
-            shape = dummy_result.shape if hasattr(dummy_result, "shape") else (1,)
-            return np.zeros(shape), np.zeros(shape)
-
-        # Calculate illumination and power for each panel
-        if isinstance(time, (float, datetime)):
-            illum_accum = 0
-            power_accum = 0
-        else:
-            illum_accum = np.zeros(len(time))
-            power_accum = np.zeros(len(time))
+        illum_accum = np.zeros(len(time))
+        power_accum = np.zeros(len(time))
 
         for p in panels:
             eff = (

--- a/scripts/benchmark_solar_panel.py
+++ b/scripts/benchmark_solar_panel.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Benchmark script for solar panel illumination vectorization.
+
+Runs A/B comparison between:
+- OLD: Loop over panels, calling panel_illumination_fraction() for each
+- NEW: Vectorized implementation with single sun/eclipse lookup
+
+Usage:
+    python scripts/benchmark_solar_panel.py
+"""
+
+import time
+from datetime import datetime, timedelta
+
+from rust_ephem import TLEEphemeris
+
+from conops.config.solar_panel import SolarPanel, SolarPanelSet
+
+
+def create_test_panel_set() -> SolarPanelSet:
+    """Create a realistic multi-panel configuration."""
+    panels = [
+        SolarPanel(name="Panel1", sidemount=True, azimuth_deg=0, max_power=800),
+        SolarPanel(name="Panel2", sidemount=True, azimuth_deg=180, max_power=800),
+        SolarPanel(
+            name="Panel3", sidemount=True, azimuth_deg=90, cant_x=15, max_power=400
+        ),
+        SolarPanel(
+            name="Panel4", sidemount=True, azimuth_deg=270, cant_x=15, max_power=400
+        ),
+    ]
+    return SolarPanelSet(panels=panels)
+
+
+def run_benchmark(num_timesteps: int = 4320) -> dict:
+    """Run A/B benchmark comparing old loop vs new vectorized implementation.
+
+    Args:
+        num_timesteps: Number of simulation steps (default 4320 = 12 hours at 10s)
+
+    Returns:
+        Dictionary with benchmark results
+    """
+    # Setup ephemeris (12 hours)
+    begin = datetime(2025, 1, 1)
+    end = begin + timedelta(hours=12)
+    ephem = TLEEphemeris(tle="examples/example.tle", begin=begin, end=end, step_size=10)
+
+    # Create two panel sets (separate instances to avoid cache contamination)
+    panel_set_old = create_test_panel_set()
+    panel_set_new = create_test_panel_set()
+
+    # Generate timesteps (unix timestamps)
+    timesteps = [begin.timestamp() + i * 10 for i in range(num_timesteps)]
+
+    # Fixed pointing for benchmark
+    ra, dec = 180.0, 45.0
+
+    print("Benchmark configuration:")
+    print(f"  Timesteps: {num_timesteps}")
+    print(f"  Panels: {len(panel_set_old.panels)}")
+    print(f"  Total illumination_and_power() calls: {num_timesteps:,}")
+    print()
+
+    # Warm up both implementations
+    _ = panel_set_old._illumination_and_power_loop([begin], ra, dec, ephem)
+    _ = panel_set_new.illumination_and_power(
+        time=timesteps[0], ra=ra, dec=dec, ephem=ephem
+    )
+
+    # =========================================================================
+    # OLD: Loop-based implementation
+    # =========================================================================
+    print("Running OLD (loop-based)...")
+    old_illum_total = 0.0
+    old_power_total = 0.0
+
+    start = time.perf_counter()
+    for t in timesteps:
+        # Use the old loop implementation by wrapping as list
+        illum, power = panel_set_old._illumination_and_power_loop(
+            [begin + timedelta(seconds=t - begin.timestamp())], ra, dec, ephem
+        )
+        old_illum_total += float(illum[0])
+        old_power_total += float(power[0])
+    elapsed_old = time.perf_counter() - start
+
+    # =========================================================================
+    # NEW: Vectorized implementation
+    # =========================================================================
+    print("Running NEW (vectorized)...")
+    new_illum_total = 0.0
+    new_power_total = 0.0
+
+    start = time.perf_counter()
+    for t in timesteps:
+        illum, power = panel_set_new.illumination_and_power(
+            time=t, ra=ra, dec=dec, ephem=ephem
+        )
+        new_illum_total += illum
+        new_power_total += power
+    elapsed_new = time.perf_counter() - start
+
+    # =========================================================================
+    # Results
+    # =========================================================================
+    speedup = elapsed_old / elapsed_new if elapsed_new > 0 else 0
+    time_saved = elapsed_old - elapsed_new
+    pct_saved = (time_saved / elapsed_old * 100) if elapsed_old > 0 else 0
+
+    # Verify results match
+    illum_match = abs(old_illum_total - new_illum_total) < 0.01 * num_timesteps
+    power_match = abs(old_power_total - new_power_total) < 0.01 * num_timesteps
+
+    print()
+    print("=" * 60)
+    print("RESULTS")
+    print("=" * 60)
+    print()
+    print("Timing:")
+    print(f"  OLD (loop):       {elapsed_old:.3f}s")
+    print(f"  NEW (vectorized): {elapsed_new:.3f}s")
+    print(f"  Speedup:          {speedup:.2f}x")
+    print(f"  Time saved:       {time_saved:.3f}s ({pct_saved:.0f}%)")
+    print()
+    print("Correctness check:")
+    print(f"  Illumination match: {'PASS' if illum_match else 'FAIL'}")
+    print(f"  Power match:        {'PASS' if power_match else 'FAIL'}")
+    if not illum_match:
+        print(f"    OLD illum: {old_illum_total:.2f}, NEW illum: {new_illum_total:.2f}")
+    if not power_match:
+        print(f"    OLD power: {old_power_total:.2f}, NEW power: {new_power_total:.2f}")
+
+    return {
+        "elapsed_old": elapsed_old,
+        "elapsed_new": elapsed_new,
+        "speedup": speedup,
+        "time_saved": time_saved,
+        "pct_saved": pct_saved,
+        "illum_match": illum_match,
+        "power_match": power_match,
+    }
+
+
+if __name__ == "__main__":
+    run_benchmark()


### PR DESCRIPTION
## Summary
Fixes #64 

Vectorized solar panel illumination calculations in `SolarPanelSet.illumination_and_power()` for ~6x speedup.

### Key optimizations

- Look up sun position once per timestep (was 89.8% of runtime due to Astropy SkyCoord overhead)
- Check eclipse state once per timestep (was called N times for N panels)
- Pre-compute and cache panel geometry arrays (cant angles, azimuths, weights)
- Compute all panel illuminations in one vectorized numpy operation

## Benchmark Results

```
Benchmark configuration:
  Timesteps: 4320 (12 hours at 10s)
  Panels: 4

Timing:
  OLD (loop):       5.0s
  NEW (vectorized): 0.85s
  Speedup:          5.9x
  Time saved:       4.1s (83%)

Correctness check:
  Illumination match: PASS
  Power match:        PASS
```

Run benchmark: `python scripts/benchmark_solar_panel.py`