### PR TITLE
Skip scheduling observations with exptime < ss_min

### DIFF
--- a/conops/targets/target_queue.py
+++ b/conops/targets/target_queue.py
@@ -151,6 +151,10 @@ class TargetQueue:
             print(msg)
         # Check each candidate target
         for target in targets:
+            # Skip targets with remaining exposure less than minimum snapshot
+            if target.exptime is not None and target.exptime < target.ss_min:
+                continue
+
             target.slewtime = target.calc_slewtime(ra, dec)
 
             # Calculate observation window

--- a/tests/target_queue/conftest.py
+++ b/tests/target_queue/conftest.py
@@ -15,6 +15,7 @@ def mock_target():
     target = Mock(spec=Pointing)
     target.merit = 100
     target.done = False
+    target.exptime = 1000
     target.ss_min = 60
     target.ss_max = 120
     target.slewtime = 10
@@ -38,6 +39,7 @@ def mock_targets(mock_target):
         t = Mock(spec=Pointing)
         t.merit = 100 - i * 10
         t.done = False
+        t.exptime = 1000
         t.ss_min = 60
         t.ss_max = 120
         t.slewtime = 10


### PR DESCRIPTION
## Summary
Fixes #66 

Skip scheduling observations where remaining exposure time is less than the minimum snapshot duration.

Previously, the scheduler would select targets regardless of whether their remaining `exptime` met the `ss_min` requirement. This could result in slewing to a target only to collect a sub-minimum observation that may not be scientifically useful.

## Changes

- Add `exptime < ss_min` check in `TargetQueue.get()` to skip unsuitable targets
- Add `exptime` attribute to test fixtures for compatibility