### PR TITLE
feat(vector): Vectorize separation() to support array inputs

### DIFF
--- a/conops/config/acs.py
+++ b/conops/config/acs.py
@@ -105,7 +105,11 @@ class AttitudeControlSystem(BaseModel):
             Tuple of (slew_distance, slew_path) where slew_path is (ra_array, dec_array)
         """
         slewdist = (
-            separation([startra * DTOR, startdec * DTOR], [endra * DTOR, enddec * DTOR])
+            float(
+                separation(
+                    [startra * DTOR, startdec * DTOR], [endra * DTOR, enddec * DTOR]
+                )
+            )
             / DTOR
         )
         slewpath = great_circle(startra, startdec, endra, enddec, steps)

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -144,9 +144,11 @@ class Pass(BaseModel):
         # Convert to radians
 
         return (
-            separation(
-                [spacecraft_ra * DTOR, spacecraft_dec * DTOR],
-                [target_ra * DTOR, target_dec * DTOR],
+            float(
+                separation(
+                    [spacecraft_ra * DTOR, spacecraft_dec * DTOR],
+                    [target_ra * DTOR, target_dec * DTOR],
+                )
             )
             / DTOR
         )

--- a/tests/solar_panel/test_solar_panel_comprehensive.py
+++ b/tests/solar_panel/test_solar_panel_comprehensive.py
@@ -1994,9 +1994,6 @@ class TestIlluminationAndPower:
         assert np.all(illumination == 0.0)
         assert np.all(power == 0.0)
 
-    @pytest.mark.skip(
-        reason="Array times with non-scalar indices breaks separation() - needs production fix"
-    )
     def test_illumination_and_power_with_array_times(self, mock_ephemeris):
         """Test illumination_and_power with array of times."""
         from datetime import datetime, timezone


### PR DESCRIPTION
## Summary

- Vectorize `radec2vec()` and `separation()` to handle both scalar and array RA/Dec inputs
- Enable batch angular distance calculations for `SolarPanelSet.illumination_and_power()`
- Enable previously skipped test

Fixes #75

## Changes

| File | Change |
|------|--------|
| `conops/common/vector.py` | `radec2vec()` returns (n, 3) for arrays, (3,) for scalars |
| `conops/common/vector.py` | `separation()` uses vectorized path for arrays |
| `conops/config/acs.py` | Add `float()` cast for mypy compatibility |
| `conops/simulation/passes.py` | Add `float()` cast for mypy compatibility |
| `tests/solar_panel/test_solar_panel_comprehensive.py` | Remove `@pytest.mark.skip` decorator |

## Test plan

- [x] All 1480 tests pass
- [x] `test_illumination_and_power_with_array_times` now runs and passes
- [x] mypy strict mode passes