### PR TITLE
Fix 1-step mode gaps in QueueDITL simulation

### DIFF
--- a/tests/queue/conftest.py
+++ b/tests/queue/conftest.py
@@ -125,6 +125,8 @@ def queue_ditl(mock_config, mock_ephem):
         mock_acs.passrequests = mock_pt
         mock_acs.slew_dists = []
         mock_acs.last_slew = None
+        mock_acs.ra = 0.0  # Current pointing RA
+        mock_acs.dec = 0.0  # Current pointing Dec
         # Set acsmode to a real ACSMode enum value for logging
         from conops import ACSMode
 
@@ -511,6 +513,8 @@ def queue_ditl_no_queue_log(mock_config, mock_ephem):
         mock_acs.passrequests = mock_pt
         mock_acs.slew_dists = []
         mock_acs.last_slew = None
+        mock_acs.ra = 0.0  # Current pointing RA
+        mock_acs.dec = 0.0  # Current pointing Dec
         # Set acsmode to a real ACSMode enum value for logging
         from conops import ACSMode
 
@@ -567,6 +571,8 @@ def queue_ditl_acs_no_ephem(mock_config, mock_ephem):
         mock_acs.passrequests = mock_pt
         mock_acs.slew_dists = []
         mock_acs.last_slew = None
+        mock_acs.ra = 0.0  # Current pointing RA
+        mock_acs.dec = 0.0  # Current pointing Dec
         # Set acsmode to a real ACSMode enum value for logging
         from conops import ACSMode
 


### PR DESCRIPTION
## Summary

Fixes #79

- Re-query ACS mode after operations to prevent 1-step mode gaps when commands are enqueued during the timestep
- Fetch new PPT immediately after emergency charging terminates to avoid undefined observing state
- Add `mock_acs.ra`/`mock_acs.dec` to queue test fixtures

## Test plan

- [x] All 1479 tests pass
- [x] Queue tests specifically verify charging termination behavior