### PR TITLE
fix: Address misc bugs missed in previous updates

### DIFF
--- a/conops/simulation/emergency_charging.py
+++ b/conops/simulation/emergency_charging.py
@@ -174,6 +174,10 @@ class EmergencyCharging:
 
         Returns the created charging Pointing or None if not possible.
         """
+        charging_ppt = self.create_charging_pointing(utime, ephem, lastra, lastdec)
+        if charging_ppt is None:
+            return None
+
         if current_ppt is not None and not getattr(current_ppt, "done", False):
             self._log_or_print(
                 utime,
@@ -183,7 +187,7 @@ class EmergencyCharging:
             current_ppt.end = utime
             current_ppt.done = True
 
-        return self.create_charging_pointing(utime, ephem, lastra, lastdec)
+        return charging_ppt
 
     def _is_in_sunlight(self, utime: float, ephem: rust_ephem.Ephemeris) -> bool:
         """

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -428,6 +428,8 @@ class PassTimes:
                 global_end_idx = (
                     startindex + end_idx
                 )  # end_idx is already the first point below threshold
+                # Clamp to last valid index to avoid overflow on short ephemeris windows
+                global_end_idx = min(global_end_idx, len(timestamp_unix) - 1)
 
                 passstart = timestamp_unix[global_start_idx]
                 passend = timestamp_unix[global_end_idx]

--- a/conops/simulation/saa.py
+++ b/conops/simulation/saa.py
@@ -263,10 +263,10 @@ class SAA:
             raise ValueError("Ephemeris must be set before checking SAA status")
 
         i = self.ephem.index(dtutcfromtimestamp(utime))
-        self.long = self.ephem.long[i]  # type: ignore[attr-defined]
-        self.lat = self.ephem.lat[i]  # type: ignore[attr-defined]
+        self.long = self.ephem.longitude_deg[i]
+        self.lat = self.ephem.latitude_deg[i]
 
-        return self.saapoly.contains(Point(self.long, self.lat))
+        return bool(self.saapoly.contains(Point(self.long, self.lat)))
 
     def calc(self) -> None:
         """

--- a/tests/saa/conftest.py
+++ b/tests/saa/conftest.py
@@ -13,8 +13,8 @@ class DummyEphem:
         from datetime import datetime, timezone
 
         self.utime = np.array(utime)
-        self.long = np.array(longs)
-        self.lat = np.array(lats)
+        self.longitude_deg = np.array(longs)
+        self.latitude_deg = np.array(lats)
         # Add timestamp as list of datetime objects for helper functions
         self.timestamp = [datetime.fromtimestamp(t, tz=timezone.utc) for t in utime]
 


### PR DESCRIPTION
## Summary

- **SAA rust-ephem 0.3.0 fix**: Use `longitude_deg`/`latitude_deg` API instead of deprecated `long`/`lat`
- **PassTimes index overflow fix**: Clamp end index to avoid IndexError on short ephemeris windows
- **EmergencyCharging order fix**: Create charging pointing before terminating current PPT to prevent orphaned terminations

## Details

### SAA
The `insaa_calc()` method was missed during the rust-ephem 0.3.0 migration (#72). Updated to use the new attribute names and added explicit `bool()` cast for mypy strictness.

### PassTimes
When a ground station pass ends exactly at the ephemeris boundary, `global_end_idx` could exceed the array length, causing IndexError. Added `min()` clamp.

### EmergencyCharging
`initiate_emergency_charging()` was terminating the current science PPT before creating the charging pointing. If charging creation failed (e.g., spacecraft in eclipse), the science observation was terminated with nothing to replace it. Reordered to create charging pointing first.

## Test plan
- [x] All 1480 tests pass
- [x] SAA tests updated to use new `longitude_deg`/`latitude_deg` attributes
- [x] mypy strict checks pass