### PR TITLE
feat: Serialize DITL generated plans to disk

### DIFF
--- a/conops/common/__init__.py
+++ b/conops/common/__init__.py
@@ -6,7 +6,14 @@ from .common import (
     unixtime2date,
     unixtime2yearday,
 )
-from .enums import ACSCommandType, ACSMode, AntennaType, ChargeState, Polarization
+from .enums import (
+    ACSCommandType,
+    ACSMode,
+    AntennaType,
+    ChargeState,
+    ObsType,
+    Polarization,
+)
 from .vector import (
     angular_separation,
     great_circle,
@@ -21,8 +28,9 @@ __all__ = [
     "ACSCommandType",
     "ACSMode",
     "AntennaType",
-    "Polarization",
     "ChargeState",
+    "ObsType",
+    "Polarization",
     "angular_separation",
     "dtutcfromtimestamp",
     "givename",

--- a/conops/common/enums.py
+++ b/conops/common/enums.py
@@ -38,8 +38,7 @@ class ObsType(str, Enum):
     AT = "AT"  # Astronomical Target (queue-scheduled observation)
     TOO = "TOO"  # Target of Opportunity (unplanned high-priority observation)
     SAFE = "SAFE"  # Safe-mode pointing
-    SUNPOINT = "SUNPOINT"  # Sun-pointing (power recovery)
-    CHARGE = "CHARGE"  # Battery-charging slew
+    CHARGE = "CHARGE"  # Battery-charging / sun-pointing maneuver
     GSP = "GSP"  # Ground Station Pass
 
 

--- a/conops/common/enums.py
+++ b/conops/common/enums.py
@@ -31,6 +31,18 @@ class ACSCommandType(Enum):
     ENTER_SAFE_MODE = auto()
 
 
+class ObsType(str, Enum):
+    """Observation / slew type codes used throughout the simulation."""
+
+    PPT = "PPT"  # Pre-Programmed Target (default scheduled observation)
+    AT = "AT"  # Astronomical Target (queue-scheduled observation)
+    TOO = "TOO"  # Target of Opportunity (unplanned high-priority observation)
+    SAFE = "SAFE"  # Safe-mode pointing
+    SUNPOINT = "SUNPOINT"  # Sun-pointing (power recovery)
+    CHARGE = "CHARGE"  # Battery-charging slew
+    GSP = "GSP"  # Ground Station Pass
+
+
 class AntennaType(str, Enum):
     """Antenna mounting and pointing configuration."""
 

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -5,7 +5,13 @@ import numpy as np
 import rust_ephem
 from pydantic import BaseModel
 
-from ..common import ACSMode, angular_separation, dtutcfromtimestamp, unixtime2date
+from ..common import (
+    ACSMode,
+    ObsType,
+    angular_separation,
+    dtutcfromtimestamp,
+    unixtime2date,
+)
 from ..common.enums import ACSCommandType
 from ..config import MissionConfig
 from ..simulation.acs_command import ACSCommand
@@ -733,7 +739,7 @@ class QueueDITL(DITLMixin, DITLStats):
             slew.startdec = dec
             slew.endra = next_pass.gsstartra
             slew.enddec = next_pass.gsstartdec
-            slew.obstype = "GSP"  # Ground Station Pass slew
+            slew.obstype = ObsType.GSP  # Ground Station Pass slew
             command = ACSCommand(
                 command_type=ACSCommandType.SLEW_TO_TARGET,
                 execution_time=utime,
@@ -914,7 +920,7 @@ class QueueDITL(DITLMixin, DITLStats):
             slew.slewrequest = utime
             slew.endra = self.ppt.ra
             slew.enddec = self.ppt.dec
-            slew.obstype = "PPT"
+            slew.obstype = ObsType.PPT
             slew.obsid = self.ppt.obsid
 
             # Use the PPT from the queue which already has visibility calculated

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -5,6 +5,7 @@ import rust_ephem
 from ..common import (
     ACSCommandType,
     ACSMode,
+    ObsType,
     dtutcfromtimestamp,
     unixtime2date,
     unixtime2yearday,
@@ -81,7 +82,7 @@ class ACS:
 
         # Current state
         self.roll = 0.0
-        self.obstype = "PPT"
+        self.obstype = ObsType.PPT
         self.acsmode = ACSMode.SCIENCE  # Start in science/pointing mode
         self.in_eclipse = False  # Initialize eclipse state
         self.in_safe_mode = False  # Safe mode flag - once True, cannot be exited
@@ -272,7 +273,9 @@ class ACS:
             f"{unixtime2date(utime)}: Initiating slew to safe mode pointing at RA={safe_ra:.2f} Dec={safe_dec:.2f}",
         )
         # Enqueue slew to safe pointing with a special obsid
-        self._enqueue_slew(safe_ra, safe_dec, obsid=-999, utime=utime, obstype="SAFE")
+        self._enqueue_slew(
+            safe_ra, safe_dec, obsid=-999, utime=utime, obstype=ObsType.SAFE
+        )
 
     def _start_slew(self, slew: Slew, utime: float) -> None:
         """Start executing a slew.
@@ -313,7 +316,7 @@ class ACS:
         dec: float,
         obsid: int,
         utime: float,
-        obstype: str = "PPT",
+        obstype: ObsType = ObsType.PPT,
         roll: float | None = None,
     ) -> bool:
         """Create and enqueue a slew command.
@@ -868,7 +871,7 @@ class ACS:
                 command.dec,
                 command.obsid,
                 utime,
-                obstype="CHARGE",
+                obstype=ObsType.CHARGE,
                 roll=command.roll,
             )
 

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -38,7 +38,7 @@ class ACS:
     ra: float
     dec: float
     roll: float
-    obstype: str
+    obstype: ObsType
     acsmode: ACSMode
     command_queue: list[ACSCommand]
     executed_commands: list[ACSCommand]
@@ -139,7 +139,7 @@ class ACS:
             command.command_type == ACSCommandType.SLEW_TO_TARGET
             and hasattr(command, "slew")
             and command.slew is not None
-            and command.slew.obstype == "SAFE"
+            and command.slew.obstype == ObsType.SAFE
         )
 
         # Prevent any commands from being enqueued in safe mode (except SAFE slews)
@@ -308,7 +308,7 @@ class ACS:
 
     def _is_science_pointing(self, slew: Slew) -> bool:
         """Check if slew represents a science pointing (not a pass)."""
-        return slew.obstype == "PPT" and isinstance(slew, Slew)
+        return slew.obstype == ObsType.PPT and isinstance(slew, Slew)
 
     def _enqueue_slew(
         self,
@@ -341,7 +341,7 @@ class ACS:
         slew.obsid = obsid
 
         # For SAFE mode, skip visibility checking (emergency situation)
-        if obstype == "SAFE":
+        if obstype == ObsType.SAFE:
             # Initialize slew positions without target
             is_first_slew = self._initialize_slew_positions(slew, utime)
             slew.at = None  # No visibility constraint in safe mode
@@ -393,7 +393,7 @@ class ACS:
             roll=roll if roll is not None else 0.0,
             obsid=slew.obsid,
         )
-        target.isat = slew.obstype != "PPT"
+        target.isat = slew.obstype != ObsType.PPT
 
         year, day = unixtime2yearday(utime)
         target.visibility()
@@ -418,9 +418,9 @@ class ACS:
         slew.startroll = self.roll
         return True
 
-    def _is_slew_valid(self, visstart: float, obstype: str, utime: float) -> bool:
+    def _is_slew_valid(self, visstart: float, obstype: ObsType, utime: float) -> bool:
         """Check if the requested slew is valid (target is visible)."""
-        if not visstart and obstype == "PPT":
+        if not visstart and obstype == ObsType.PPT:
             self._log_or_print(
                 utime,
                 "SLEW",
@@ -453,7 +453,7 @@ class ACS:
             )
 
         # Wait for target visibility if constrained
-        if visstart > execution_time and slew.obstype == "PPT":
+        if visstart > execution_time and slew.obstype == ObsType.PPT:
             self._log_or_print(
                 utime,
                 "SLEW",
@@ -524,13 +524,15 @@ class ACS:
                 "Current slew must be set when actively slewing"
             )
             # Check if slewing for charging - but only report CHARGING if in sunlight
-            if self.current_slew.obstype == "CHARGE":
+            if self.current_slew.obstype == ObsType.CHARGE:
                 # Check eclipse state - no point being in CHARGING mode during eclipse
                 if self.in_eclipse:
                     return ACSMode.SLEWING  # In eclipse, treat as normal slew
                 return ACSMode.CHARGING
             return (
-                ACSMode.PASS if self.current_slew.obstype == "GSP" else ACSMode.SLEWING
+                ACSMode.PASS
+                if self.current_slew.obstype == ObsType.GSP
+                else ACSMode.SLEWING
             )
 
         # Check if dwelling in charging mode (after slew to charge pointing)
@@ -560,7 +562,7 @@ class ACS:
         # Must have completed a CHARGE slew and not be actively slewing
         if not (
             self.last_slew is not None
-            and self.last_slew.obstype == "CHARGE"
+            and self.last_slew.obstype == ObsType.CHARGE
             and not self._is_actively_slewing(utime)
         ):
             return False
@@ -591,7 +593,7 @@ class ACS:
             isinstance(self.last_slew, Slew)
             and self.last_slew.at is not None
             and not isinstance(self.last_slew.at, bool)
-            and self.last_slew.obstype == "PPT"
+            and self.last_slew.obstype == ObsType.PPT
             and self.constraint.in_constraint(
                 self.last_slew.at.ra, self.last_slew.at.dec, utime
             )
@@ -736,7 +738,7 @@ class ACS:
         # If actively slewing to safe mode position, use slew interpolation
         if (
             self.current_slew is not None
-            and self.current_slew.obstype == "SAFE"
+            and self.current_slew.obstype == ObsType.SAFE
             and self.current_slew.is_slewing(utime)
         ):
             self.ra, self.dec = self.current_slew.ra_dec(utime)
@@ -884,7 +886,7 @@ class ACS:
 
         # Clear the charging slew state immediately so _is_in_charging_mode returns False
         # This prevents staying in CHARGING mode while slewing back to science
-        if self.last_slew is not None and self.last_slew.obstype == "CHARGE":
+        if self.last_slew is not None and self.last_slew.obstype == ObsType.CHARGE:
             self.last_slew = None
 
         # Return to the previous science PPT if one exists

--- a/conops/simulation/emergency_charging.py
+++ b/conops/simulation/emergency_charging.py
@@ -10,6 +10,7 @@ import rust_ephem
 from conops.config.battery import Battery
 
 from ..common import unixtime2date
+from ..common.enums import ObsType
 from ..common.vector import angular_separation
 from ..config import MissionConfig
 from .roll import optimum_roll
@@ -535,6 +536,7 @@ class EmergencyCharging:
             obsid=self.next_charging_obsid,
             exptime=86400,
         )
+        charging_ppt.obstype = ObsType.CHARGE
         self.next_charging_obsid += 1
         charging_ppt.begin = int(utime)
         charging_ppt.end = int(utime + 86400)  # Set far end time

--- a/conops/simulation/slew.py
+++ b/conops/simulation/slew.py
@@ -4,6 +4,7 @@ import numpy as np
 import rust_ephem
 
 from ..common import roll_over_angle, unixtime2date
+from ..common.enums import ObsType
 from ..config import AttitudeControlSystem, Constraint, MissionConfig
 
 if TYPE_CHECKING:
@@ -29,7 +30,7 @@ class Slew:
     slewpath: tuple[list[float], list[float]]
     slewsecs: list[float]
     slewdist: float
-    obstype: str
+    obstype: ObsType
     obsid: int
     mode: int
     slewrequest: float
@@ -65,7 +66,7 @@ class Slew:
         self.slewtime = 0
         self.slewdist = 0
 
-        self.obstype = "PPT"
+        self.obstype = ObsType.PPT
         self.obsid = 0
         self.mode = 0
         self.at = None  # What's the target associated with this slew?

--- a/conops/targets/__init__.py
+++ b/conops/targets/__init__.py
@@ -1,10 +1,13 @@
 from .plan import Plan, TargetList
 from .plan_entry import PlanEntry
+from .plan_schema import PlanEntrySchema, PlanSchema
 from .pointing import Pointing
 from .target_queue import Queue, TargetQueue
 
 __all__ = [
     "PlanEntry",
+    "PlanEntrySchema",
+    "PlanSchema",
     "Pointing",
     "Plan",
     "TargetList",

--- a/conops/targets/plan.py
+++ b/conops/targets/plan.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .plan_entry import PlanEntry
+
+if TYPE_CHECKING:
+    from .plan_schema import PlanSchema
 
 
 class TargetList:
@@ -55,3 +60,47 @@ class Plan:
 
     def append(self, ppt: PlanEntry) -> None:
         self.entries.append(ppt)
+
+    def save(self, path: str | Path, *, indent: int = 2) -> Path:
+        """Serialise the plan to a JSON file.
+
+        Delegates to :meth:`~conops.targets.plan_schema.PlanSchema.save`.
+
+        Parameters
+        ----------
+        path:
+            Destination file path.
+        indent:
+            JSON indentation level (default 2).
+
+        Returns
+        -------
+        Path
+            The resolved path of the written file.
+        """
+        from .plan_schema import PlanSchema
+
+        return PlanSchema.from_plan(self).save(path, indent=indent)
+
+    @classmethod
+    def load(cls, path: str | Path) -> PlanSchema:
+        """Load a plan from a JSON file previously written by :meth:`save`.
+
+        Delegates to :meth:`~conops.targets.plan_schema.PlanSchema.load` and
+        returns a :class:`~conops.targets.plan_schema.PlanSchema` (a Pydantic
+        model) rather than a plain :class:`Plan`, so that metadata such as
+        ``version`` and ``created_at`` is preserved.
+
+        Parameters
+        ----------
+        path:
+            Source file path.
+
+        Returns
+        -------
+        PlanSchema
+            The deserialised schema object.
+        """
+        from .plan_schema import PlanSchema
+
+        return PlanSchema.load(path)

--- a/conops/targets/plan.py
+++ b/conops/targets/plan.py
@@ -69,7 +69,9 @@ class Plan:
         Parameters
         ----------
         path:
-            Destination file path.
+            Destination file path or directory.  When a directory is given,
+            the filename is auto-generated from the plan's start/end times and
+            version.  Parent directories are created automatically.
         indent:
             JSON indentation level (default 2).
 

--- a/conops/targets/plan_entry.py
+++ b/conops/targets/plan_entry.py
@@ -5,6 +5,7 @@ from typing import Literal
 import rust_ephem
 
 from ..common import givename, unixtime2date
+from ..common.enums import ObsType
 from ..config import Constraint, MissionConfig
 from ..simulation.saa import SAA
 
@@ -54,7 +55,7 @@ class PlanEntry:
         self.saa = None
         self.merit = 101
         self.windows = list()
-        self.obstype = "PPT"
+        self.obstype: ObsType = ObsType.PPT
         self.slewpath = ([], [])
         self.slewdist = 0.0
         self.ss_min = 1000

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -127,7 +127,8 @@ class PlanSchema(BaseModel):
     coast_sim_version:
         COASTSim package version that produced this file.
     created_at:
-        ISO-8601 UTC timestamp of when the file was written.
+        ISO-8601 UTC timestamp of when this schema instance was created or
+        validated (typically just before it is written to disk).
     start:
         Unix timestamp of the first entry's ``begin`` time (or 0 if empty).
     end:

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -107,7 +107,7 @@ class PlanEntrySchema(BaseModel):
                 "exporig": data._exporig,
                 "isat": getattr(data, "isat", False),
                 "done": getattr(data, "done", False),
-                "exposure": data.exposure,
+                "exposure": data.end - data.begin - data.slewtime - data.insaa,
             }
         return data
 

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -195,9 +195,21 @@ class PlanSchema(BaseModel):
         return data
 
     @model_validator(mode="after")
-    def _sync_num_entries(self) -> PlanSchema:
-        """Keep num_entries consistent with the actual entries list."""
+    def _reconcile_metadata(self) -> PlanSchema:
+        """Keep num_entries, start, and end consistent with the entries list.
+
+        This corrects metadata that may be missing or stale in legacy JSON
+        files (e.g. files written before ``num_entries`` / ``start`` / ``end``
+        were stored, or files whose entry list was modified after creation).
+        """
         self.num_entries = len(self.entries)
+        if self.entries:
+            computed_start = self.entries[0].begin
+            computed_end = self.entries[-1].end
+            if self.start == 0.0:
+                self.start = computed_start
+            if self.end == 0.0:
+                self.end = computed_end
         return self
 
     # ── Convenience constructors ───────────────────────────────────────────────

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -1,0 +1,187 @@
+"""Pydantic schema for serialising :class:`~conops.targets.Plan` to / from JSON.
+
+Usage
+-----
+Write a plan produced by a DITL run to disk::
+
+    from conops.targets.plan_schema import PlanSchema
+
+    schema = PlanSchema.from_plan(ditl.plan)
+    schema.save("plan_20251201.json")
+
+Load it back::
+
+    schema = PlanSchema.load("plan_20251201.json")
+
+Round-trip via ``model_validate`` with ``from_attributes=True`` (e.g. in tests)::
+
+    schema = PlanSchema.model_validate(ditl.plan, from_attributes=True)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from .._version import __version__
+from .plan import Plan
+from .plan_entry import PlanEntry
+
+
+class PlanEntrySchema(BaseModel):
+    """Pydantic representation of a single :class:`~conops.targets.PlanEntry`.
+
+    All fields that are serialisable scalars from ``PlanEntry`` / ``Pointing``
+    are captured here.  Ephemeris, config, and slew-path arrays are excluded
+    because they are too large / not portable.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    name: str = ""
+    ra: float = 0.0
+    dec: float = 0.0
+    roll: float = -1.0
+    begin: float = 0.0
+    end: float = 0.0
+    merit: float = 0.0
+    slewtime: int = 0
+    insaa: int = 0
+    obsid: int = 0
+    obstype: str = "PPT"
+    slewdist: float = 0.0
+    ss_min: float = 300.0
+    ss_max: float = 1_000_000.0
+    exptime: int = 1000
+    exporig: int = 1000
+    isat: bool = False
+    done: bool = False
+    exposure: int = 0
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_from_plan_entry(cls, data: Any) -> Any:
+        """Accept either a dict (JSON round-trip) or a PlanEntry instance."""
+        if isinstance(data, PlanEntry):
+            return {
+                "name": data.name,
+                "ra": data.ra,
+                "dec": data.dec,
+                "roll": data.roll,
+                "begin": data.begin,
+                "end": data.end,
+                "merit": data.merit,
+                "slewtime": data.slewtime,
+                "insaa": data.insaa,
+                "obsid": data.obsid,
+                "obstype": data.obstype,
+                "slewdist": data.slewdist,
+                "ss_min": data.ss_min,
+                "ss_max": data.ss_max,
+                "exptime": data.exptime,
+                "exporig": data._exporig,
+                "isat": getattr(data, "isat", False),
+                "done": getattr(data, "done", False),
+                "exposure": data.exposure,
+            }
+        return data
+
+
+class PlanSchema(BaseModel):
+    """Top-level schema for a serialised :class:`~conops.targets.Plan`.
+
+    Contains metadata (version, timestamps, entry count) alongside the plan
+    entries themselves.
+
+    Attributes
+    ----------
+    version:
+        COASTSim package version that produced this file.
+    created_at:
+        ISO-8601 UTC timestamp of when the schema was created.
+    start:
+        Unix timestamp of the first entry's ``begin`` time (or 0 if empty).
+    end:
+        Unix timestamp of the last entry's ``end`` time (or 0 if empty).
+    num_entries:
+        Total number of plan entries.
+    entries:
+        The serialised plan entries.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    version: str = Field(default_factory=lambda: __version__)
+    created_at: str = Field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    start: float = 0.0
+    end: float = 0.0
+    num_entries: int = 0
+    entries: list[PlanEntrySchema] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_from_plan(cls, data: Any) -> Any:
+        """Accept a raw :class:`Plan` object in addition to dicts."""
+        if isinstance(data, Plan):
+            entries = list(data.entries)
+            return {
+                "version": __version__,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "start": entries[0].begin if entries else 0.0,
+                "end": entries[-1].end if entries else 0.0,
+                "num_entries": len(entries),
+                "entries": entries,
+            }
+        return data
+
+    # ── Convenience constructors ───────────────────────────────────────────────
+
+    @classmethod
+    def from_plan(cls, plan: Plan) -> PlanSchema:
+        """Build a :class:`PlanSchema` from a :class:`Plan` instance."""
+        return cls.model_validate(plan, from_attributes=True)
+
+    # ── I/O ───────────────────────────────────────────────────────────────────
+
+    def save(self, path: str | Path, *, indent: int = 2) -> Path:
+        """Serialise the plan to a JSON file.
+
+        Parameters
+        ----------
+        path:
+            Destination file path.  Parent directories must already exist.
+        indent:
+            JSON indentation level (default 2).
+
+        Returns
+        -------
+        Path
+            The resolved path of the written file.
+        """
+        dest = Path(path)
+        payload = self.model_dump(mode="json")
+        dest.write_text(json.dumps(payload, indent=indent), encoding="utf-8")
+        return dest.resolve()
+
+    @classmethod
+    def load(cls, path: str | Path) -> PlanSchema:
+        """Load a :class:`PlanSchema` from a JSON file.
+
+        Parameters
+        ----------
+        path:
+            Source file path.
+
+        Returns
+        -------
+        PlanSchema
+            The deserialised schema object.
+        """
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+        return cls.model_validate(raw)

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -21,13 +21,15 @@ Round-trip via ``model_validate`` with ``from_attributes=True`` (e.g. in tests):
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .._version import __version__
+from ..common.enums import ObsType
 from .plan import Plan
 from .plan_entry import PlanEntry
 
@@ -52,7 +54,7 @@ class PlanEntrySchema(BaseModel):
     slewtime: int = 0
     insaa: int = 0
     obsid: int = 0
-    obstype: str = "PPT"
+    obstype: ObsType = ObsType.PPT
     slewdist: float = 0.0
     ss_min: float = 300.0
     ss_max: float = 1_000_000.0
@@ -100,9 +102,13 @@ class PlanSchema(BaseModel):
     Attributes
     ----------
     version:
+        Integer plan version.  Starts at 0 and is incremented automatically
+        each time a new plan is saved to the same directory for the same
+        time window.
+    coast_sim_version:
         COASTSim package version that produced this file.
     created_at:
-        ISO-8601 UTC timestamp of when the schema was created.
+        ISO-8601 UTC timestamp of when the file was written.
     start:
         Unix timestamp of the first entry's ``begin`` time (or 0 if empty).
     end:
@@ -115,7 +121,8 @@ class PlanSchema(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    version: str = Field(default_factory=lambda: __version__)
+    version: int = 0
+    coast_sim_version: str = Field(default_factory=lambda: __version__)
     created_at: str = Field(
         default_factory=lambda: datetime.now(timezone.utc).isoformat()
     )
@@ -124,6 +131,17 @@ class PlanSchema(BaseModel):
     num_entries: int = 0
     entries: list[PlanEntrySchema] = Field(default_factory=list)
 
+    @field_validator("version", mode="before")
+    @classmethod
+    def _coerce_version(cls, v: Any) -> int:
+        """Accept integer versions; coerce legacy semver strings to 0."""
+        if isinstance(v, int):
+            return v
+        try:
+            return int(v)
+        except (ValueError, TypeError):
+            return 0
+
     @model_validator(mode="before")
     @classmethod
     def _coerce_from_plan(cls, data: Any) -> Any:
@@ -131,7 +149,8 @@ class PlanSchema(BaseModel):
         if isinstance(data, Plan):
             entries = list(data.entries)
             return {
-                "version": __version__,
+                "version": 0,
+                "coast_sim_version": __version__,
                 "created_at": datetime.now(timezone.utc).isoformat(),
                 "start": entries[0].begin if entries else 0.0,
                 "end": entries[-1].end if entries else 0.0,
@@ -149,13 +168,59 @@ class PlanSchema(BaseModel):
 
     # ── I/O ───────────────────────────────────────────────────────────────────
 
+    def _default_filename(self) -> str:
+        """Generate a filename from plan metadata.
+
+        Format: ``plan_<start>_<end>_v<version>.json``
+        e.g.   ``plan_20251201T000000Z_20251201T235900Z_v3.json``
+        """
+
+        def _fmt(ts: float) -> str:
+            return datetime.fromtimestamp(ts, tz=timezone.utc).strftime(
+                "%Y%m%dT%H%M%SZ"
+            )
+
+        start_str = _fmt(self.start) if self.start else "unknown"
+        end_str = _fmt(self.end) if self.end else "unknown"
+        return f"plan_{start_str}_{end_str}_v{self.version}.json"
+
+    def _next_version(self, directory: Path) -> int:
+        """Scan *directory* for existing plan files and return the next version number.
+
+        Looks for files matching ``plan_<start>_<end>_v<N>.json`` where ``N``
+        is a non-negative integer.  Returns ``max(N) + 1``, or ``0`` if no
+        matching files exist.
+        """
+
+        def _fmt(ts: float) -> str:
+            return datetime.fromtimestamp(ts, tz=timezone.utc).strftime(
+                "%Y%m%dT%H%M%SZ"
+            )
+
+        start_str = _fmt(self.start) if self.start else "unknown"
+        end_str = _fmt(self.end) if self.end else "unknown"
+        pattern = re.compile(
+            rf"^plan_{re.escape(start_str)}_{re.escape(end_str)}_v(\d+)\.json$"
+        )
+        versions = [
+            int(m.group(1))
+            for f in directory.iterdir()
+            if f.is_file() and (m := pattern.match(f.name))
+        ]
+        return max(versions) + 1 if versions else 0
+
     def save(self, path: str | Path, *, indent: int = 2) -> Path:
         """Serialise the plan to a JSON file.
 
         Parameters
         ----------
         path:
-            Destination file path.  Parent directories must already exist.
+            Destination file path **or** directory.  When a directory is given
+            (path ends with ``/`` or already exists as a directory) a filename
+            is generated automatically: ``plan_<start>_<end>_v<N>.json`` where
+            ``N`` is one higher than the highest existing integer-versioned plan
+            file for the same time window in that directory.
+            Parent directories are created automatically.
         indent:
             JSON indentation level (default 2).
 
@@ -165,7 +230,15 @@ class PlanSchema(BaseModel):
             The resolved path of the written file.
         """
         dest = Path(path)
-        payload = self.model_dump(mode="json")
+        if str(path).endswith("/") or dest.is_dir():
+            dest.mkdir(parents=True, exist_ok=True)
+            next_ver = self._next_version(dest)
+            schema = self.model_copy(update={"version": next_ver})
+            dest = dest / schema._default_filename()
+        else:
+            schema = self
+            dest.parent.mkdir(parents=True, exist_ok=True)
+        payload = schema.model_dump(mode="json")
         dest.write_text(json.dumps(payload, indent=indent), encoding="utf-8")
         return dest.resolve()
 

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -26,7 +26,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 
 from .._version import __version__
 from ..common.enums import ObsType
@@ -63,6 +70,18 @@ class PlanEntrySchema(BaseModel):
     isat: bool = False
     done: bool = False
     exposure: int = 0
+
+    @field_validator("begin", "end", mode="before")
+    @classmethod
+    def _coerce_time(cls, v: Any) -> float:
+        """Accept Unix timestamps (float/int) or ISO-8601 strings."""
+        if isinstance(v, str):
+            return datetime.fromisoformat(v).timestamp()
+        return float(v)
+
+    @field_serializer("begin", "end")
+    def _serialize_time(self, v: float) -> str:
+        return datetime.fromtimestamp(v, tz=timezone.utc).isoformat()
 
     @model_validator(mode="before")
     @classmethod
@@ -131,6 +150,21 @@ class PlanSchema(BaseModel):
     num_entries: int = 0
     entries: list[PlanEntrySchema] = Field(default_factory=list)
 
+    @field_validator("start", "end", mode="before")
+    @classmethod
+    def _coerce_time(cls, v: Any) -> float:
+        """Accept Unix timestamps (float/int) or ISO-8601 strings."""
+        if isinstance(v, str):
+            try:
+                return datetime.fromisoformat(v).timestamp()
+            except ValueError:
+                return float(v)
+        return float(v)
+
+    @field_serializer("start", "end")
+    def _serialize_time(self, v: float) -> str:
+        return datetime.fromtimestamp(v, tz=timezone.utc).isoformat()
+
     @field_validator("version", mode="before")
     @classmethod
     def _coerce_version(cls, v: Any) -> int:
@@ -158,6 +192,12 @@ class PlanSchema(BaseModel):
                 "entries": entries,
             }
         return data
+
+    @model_validator(mode="after")
+    def _sync_num_entries(self) -> PlanSchema:
+        """Keep num_entries consistent with the actual entries list."""
+        self.num_entries = len(self.entries)
+        return self
 
     # ── Convenience constructors ───────────────────────────────────────────────
 

--- a/conops/targets/pointing.py
+++ b/conops/targets/pointing.py
@@ -3,6 +3,7 @@ from typing import Literal
 import numpy as np
 
 from ..common import unixtime2date
+from ..common.enums import ObsType
 from ..config import MissionConfig
 from .plan_entry import PlanEntry
 
@@ -38,7 +39,7 @@ class Pointing(PlanEntry):
         PlanEntry.__init__(self, config=config, exptime=exptime)
         assert config.constraint is not None, "Constraint not properly set in Pointing"
         self.done = False
-        self.obstype = "AT"
+        self.obstype = ObsType.AT
         self.isat = False
         self.ra = ra
         self.dec = dec

--- a/docs/api/conops.targets.plan_schema.rst
+++ b/docs/api/conops.targets.plan_schema.rst
@@ -1,0 +1,7 @@
+conops.targets.plan\_schema
+===========================
+
+.. automodule:: conops.targets.plan_schema
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -45,6 +45,7 @@ Scheduling and Planning
    conops.targets.pointing
    conops.targets.plan
    conops.targets.plan_entry
+   conops.targets.plan_schema
    conops.targets.target_queue
 
 Spacecraft Components

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ optimize observation schedules, and validate operational constraints before laun
    data_management
    fault_management
    target_of_opportunity
+   plan_serialization
    api/modules
    contributing
    README
@@ -43,6 +44,7 @@ Features
 * **Attitude Control System**: Slew modeling, pointing accuracy, and settle time simulation
 * **South Atlantic Anomaly (SAA) Avoidance**: Radiation belt constraint handling
 * **DITL Generation**: Comprehensive day-in-the-life timeline simulation
+* **Plan Serialisation**: Save and reload observation plans as portable, version-stamped JSON files
 
 Quick Example
 -------------

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -1,0 +1,232 @@
+Plan Serialisation
+==================
+
+COASTSim can save an observation plan produced by a DITL run to a portable JSON file and
+reload it later.  The serialisation layer is built on `Pydantic v2`_ and lives in
+:mod:`conops.targets.plan_schema`.  Convenience methods are also available directly on
+:class:`~conops.targets.Plan` so you rarely need to import the schema classes explicitly.
+
+Overview
+--------
+
+Two Pydantic models handle the conversion:
+
+* :class:`~conops.targets.plan_schema.PlanEntrySchema` — represents a single observation
+  entry (a :class:`~conops.targets.PlanEntry` or :class:`~conops.targets.Pointing`).
+* :class:`~conops.targets.plan_schema.PlanSchema` — top-level container that bundles metadata
+  (version, timestamps, entry count) with the list of entries.
+
+Both models support ``model_validate(..., from_attributes=True)``, so they accept plain Python
+objects produced by the scheduler without any intermediate conversion step.
+
+Quick Start
+-----------
+
+**Save a plan after a DITL run**
+
+The simplest approach is to call :meth:`~conops.targets.Plan.save` directly on the plan:
+
+.. code-block:: python
+
+   # `ditl` is a QueueDITL (or similar) instance that has already been run
+   saved_path = ditl.plan.save("plan_20251201.json")
+   print(f"Saved to {saved_path}")
+
+You can also go via :class:`~conops.targets.plan_schema.PlanSchema` if you need access to the
+metadata fields before writing:
+
+.. code-block:: python
+
+   from conops.targets import PlanSchema
+
+   schema = PlanSchema.from_plan(ditl.plan)
+   print(f"Saving {schema.num_entries} entries (version {schema.version})")
+   schema.save("plan_20251201.json")
+
+**Load it back**
+
+:meth:`~conops.targets.Plan.load` is a class method on :class:`~conops.targets.Plan` that
+returns a :class:`~conops.targets.plan_schema.PlanSchema` (preserving all metadata):
+
+.. code-block:: python
+
+   schema = Plan.load("plan_20251201.json")
+   print(schema.version)          # e.g. "0.1.3"
+   print(schema.num_entries)      # number of plan entries
+   print(schema.entries[0].name)  # first target name
+
+Or equivalently via :class:`~conops.targets.plan_schema.PlanSchema` directly:
+
+.. code-block:: python
+
+   from conops.targets import PlanSchema
+
+   schema = PlanSchema.load("plan_20251201.json")
+
+**Round-trip via model_validate**
+
+.. code-block:: python
+
+   schema = PlanSchema.model_validate(ditl.plan, from_attributes=True)
+
+JSON File Format
+----------------
+
+The JSON file contains a metadata envelope followed by the entry list.
+
+.. code-block:: json
+
+   {
+     "version": "0.1.3",
+     "created_at": "2025-12-01T00:00:00+00:00",
+     "start": 1764547200.0,
+     "end": 1764633540.0,
+     "num_entries": 42,
+     "entries": [
+       {
+         "name": "TEST_001",
+         "ra": 83.82,
+         "dec": -5.39,
+         "roll": 0.0,
+         "begin": 1764547200.0,
+         "end": 1764548200.0,
+         "merit": 95.0,
+         "slewtime": 120,
+         "insaa": 0,
+         "obsid": 1001,
+         "obstype": "AT",
+         "slewdist": 10.3,
+         "ss_min": 300.0,
+         "ss_max": 1000000.0,
+         "exptime": 880,
+         "exporig": 1000,
+         "isat": false,
+         "done": true,
+         "exposure": 880
+       }
+     ]
+   }
+
+Metadata Fields
+~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Field
+     - Type
+     - Description
+   * - ``version``
+     - string
+     - COASTSim package version that produced the file.
+   * - ``created_at``
+     - string
+     - ISO-8601 UTC timestamp of when the file was written.
+   * - ``start``
+     - float
+     - Unix timestamp of the first entry's ``begin`` time (0 if the plan is empty).
+   * - ``end``
+     - float
+     - Unix timestamp of the last entry's ``end`` time (0 if the plan is empty).
+   * - ``num_entries``
+     - int
+     - Total number of entries in the file.
+
+Entry Fields
+~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Field
+     - Type
+     - Description
+   * - ``name``
+     - string
+     - Human-readable target name (e.g. ``"Crab Nebula"``).
+   * - ``ra``
+     - float
+     - Right ascension in degrees (J2000).
+   * - ``dec``
+     - float
+     - Declination in degrees (J2000).
+   * - ``roll``
+     - float
+     - Spacecraft roll angle in degrees (``-1`` = unset).
+   * - ``begin``
+     - float
+     - Start of the visibility window (Unix time).
+   * - ``end``
+     - float
+     - End of the visibility window (Unix time).
+   * - ``merit``
+     - float
+     - Scheduler merit/priority figure of merit.
+   * - ``slewtime``
+     - int
+     - Slew duration in seconds.
+   * - ``insaa``
+     - int
+     - Time spent in the South Atlantic Anomaly during the window (seconds).
+   * - ``obsid``
+     - int
+     - Numeric observation identifier.
+   * - ``obstype``
+     - string
+     - Observation type (e.g. ``"AT"`` for Astronomical Target, ``"PPT"`` for Preprogrammed Target).
+   * - ``slewdist``
+     - float
+     - Angular slew distance in degrees.
+   * - ``ss_min``
+     - float
+     - Minimum Sun-spacecraft separation angle encountered (degrees).
+   * - ``ss_max``
+     - float
+     - Maximum Sun-spacecraft separation angle encountered (degrees).
+   * - ``exptime``
+     - int
+     - Exposure time in seconds (may be shorter than original if interrupted).
+   * - ``exporig``
+     - int
+     - Originally requested exposure time in seconds.
+   * - ``isat``
+     - bool
+     - ``true`` if the detector was saturated during the exposure.
+   * - ``done``
+     - bool
+     - ``true`` if the observation completed successfully.
+   * - ``exposure``
+     - int
+     - Net science exposure time: ``end − begin − slewtime − insaa`` (seconds).
+
+Backward Compatibility
+----------------------
+
+:meth:`~conops.targets.plan_schema.PlanSchema.load` accepts files written by older versions of
+COASTSim that predate ``PlanSchema``.  Fields not present in the file (e.g. ``created_at``,
+``num_entries``) are filled with schema defaults.  Files that contain an ``exporig`` key (old
+spelling) are accepted without modification.
+
+The ``from_attributes=True`` model configuration means the schema can also validate against
+any object that exposes the expected attributes, not just plain dicts.
+
+API Reference
+-------------
+
+.. automethod:: conops.targets.plan.Plan.save
+
+.. automethod:: conops.targets.plan.Plan.load
+
+.. autoclass:: conops.targets.plan_schema.PlanEntrySchema
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: conops.targets.plan_schema.PlanSchema
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _Pydantic v2: https://docs.pydantic.dev/latest/

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -207,8 +207,9 @@ Backward Compatibility
 
 :meth:`~conops.targets.plan_schema.PlanSchema.load` accepts files written by older versions of
 COASTSim that predate ``PlanSchema``.  Fields not present in the file (e.g. ``created_at``,
-``num_entries``) are filled with schema defaults.  Files that contain an ``exporig`` key (old
-spelling) are accepted without modification.
+``num_entries``) are filled with schema defaults.  Legacy files must already use the field
+names documented above (including ``exporig``); there is currently no automatic renaming or
+aliasing of deprecated keys.
 
 The ``from_attributes=True`` model configuration means the schema can also validate against
 any object that exposes the expected attributes, not just plain dicts.

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -205,6 +205,9 @@ Entry Fields
 Backward Compatibility
 ----------------------
 
+:meth:`~conops.targets.plan_schema.PlanSchema.save` creates any missing parent directories
+automatically, so you can pass a nested path without creating it first.
+
 :meth:`~conops.targets.plan_schema.PlanSchema.load` accepts files written by older versions of
 COASTSim that predate ``PlanSchema``.  Fields not present in the file (e.g. ``created_at``,
 ``num_entries``) are filled with schema defaults.  Legacy files must already use the field

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -77,10 +77,11 @@ The JSON file contains a metadata envelope followed by the entry list.
 .. code-block:: json
 
    {
-     "version": "0.1.3",
+     "version": 3,
+     "coast_sim_version": "0.1.3",
      "created_at": "2025-12-01T00:00:00+00:00",
-     "start": 1764547200.0,
-     "end": 1764633540.0,
+     "start": "2025-12-01T00:00:00+00:00",
+     "end": "2025-12-01T23:59:00+00:00",
      "num_entries": 42,
      "entries": [
        {
@@ -88,8 +89,8 @@ The JSON file contains a metadata envelope followed by the entry list.
          "ra": 83.82,
          "dec": -5.39,
          "roll": 0.0,
-         "begin": 1764547200.0,
-         "end": 1764548200.0,
+         "begin": "2025-12-01T00:00:00+00:00",
+         "end": "2025-12-01T00:16:40+00:00",
          "merit": 95.0,
          "slewtime": 120,
          "insaa": 0,
@@ -118,18 +119,25 @@ Metadata Fields
      - Type
      - Description
    * - ``version``
+     - int
+     - Integer plan-file revision counter.  Starts at 0 and is incremented
+       automatically each time a new plan is saved to the same directory for
+       the same time window (see :ref:`auto-versioning` below).
+   * - ``coast_sim_version``
      - string
-     - COASTSim package version that produced the file.
+     - COASTSim package version that produced the file (e.g. ``"0.1.3"``).
    * - ``created_at``
      - string
      - ISO-8601 UTC timestamp of when the :class:`~conops.targets.plan_schema.PlanSchema`
        instance was created/validated (not updated by :meth:`~conops.targets.plan_schema.PlanSchema.save`).
    * - ``start``
-     - float
-     - Unix timestamp of the first entry's ``begin`` time (0 if the plan is empty).
+     - string
+     - ISO-8601 UTC timestamp of the first entry's ``begin`` time
+       (``"1970-01-01T00:00:00+00:00"`` if the plan is empty).
    * - ``end``
-     - float
-     - Unix timestamp of the last entry's ``end`` time (0 if the plan is empty).
+     - string
+     - ISO-8601 UTC timestamp of the last entry's ``end`` time
+       (``"1970-01-01T00:00:00+00:00"`` if the plan is empty).
    * - ``num_entries``
      - int
      - Total number of entries in the file.
@@ -157,11 +165,11 @@ Entry Fields
      - float
      - Spacecraft roll angle in degrees (``-1`` = unset).
    * - ``begin``
-     - float
-     - Start of the visibility window (Unix time).
+     - string
+     - Start of the observation window (ISO-8601 UTC).
    * - ``end``
-     - float
-     - End of the visibility window (Unix time).
+     - string
+     - End of the observation window (ISO-8601 UTC).
    * - ``merit``
      - float
      - Scheduler merit/priority figure of merit.
@@ -202,6 +210,17 @@ Entry Fields
      - int
      - Net science exposure time: ``end − begin − slewtime − insaa`` (seconds).
 
+.. _auto-versioning:
+
+Auto-versioning
+~~~~~~~~~~~~~~~
+
+When ``path`` is a directory (or ends with ``/``), :meth:`~conops.targets.Plan.save`
+scans the directory for existing files matching
+``plan_<start>_<end>_v<N>.json`` and sets ``version`` to ``max(N) + 1``
+(or ``0`` if no matching files exist).  Saving to an explicit file path
+leaves ``version`` unchanged.
+
 Backward Compatibility
 ----------------------
 
@@ -210,9 +229,13 @@ automatically, so you can pass a nested path without creating it first.
 
 :meth:`~conops.targets.plan_schema.PlanSchema.load` accepts files written by older versions of
 COASTSim that predate ``PlanSchema``.  Fields not present in the file (e.g. ``created_at``,
-``num_entries``) are filled with schema defaults.  Legacy files must already use the field
-names documented above (including ``exporig``); there is currently no automatic renaming or
-aliasing of deprecated keys.
+``num_entries``) are filled with schema defaults; ``num_entries`` is always recomputed from
+the actual entry list after loading.  Legacy files that store ``start``, ``end``, ``begin``,
+or ``end`` as numeric Unix timestamps (float/int) are accepted and converted to
+:class:`~datetime.datetime` objects internally — only the on-disk format changed to ISO-8601.
+Legacy files that stored ``version`` as a semantic-version string (e.g. ``"0.1.3"``) are
+coerced to ``0``.  Legacy files must already use the field names documented above (including
+``exporig``); there is currently no automatic renaming or aliasing of deprecated keys.
 
 The ``from_attributes=True`` model configuration means the schema can also validate against
 any object that exposes the expected attributes, not just plain dicts.

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -51,7 +51,7 @@ returns a :class:`~conops.targets.plan_schema.PlanSchema` (preserving all metada
 .. code-block:: python
 
    schema = Plan.load("plan_20251201.json")
-   print(schema.version)          # e.g. "0.1.3"
+   print(schema.version)          # schema format version (integer)
    print(schema.num_entries)      # number of plan entries
    print(schema.entries[0].name)  # first target name
 

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -122,7 +122,8 @@ Metadata Fields
      - COASTSim package version that produced the file.
    * - ``created_at``
      - string
-     - ISO-8601 UTC timestamp of when the file was written.
+     - ISO-8601 UTC timestamp of when the :class:`~conops.targets.plan_schema.PlanSchema`
+       instance was created/validated (not updated by :meth:`~conops.targets.plan_schema.PlanSchema.save`).
    * - ``start``
      - float
      - Unix timestamp of the first entry's ``begin`` time (0 if the plan is empty).

--- a/examples/Quick_DITL_Example.ipynb
+++ b/examples/Quick_DITL_Example.ipynb
@@ -339,6 +339,34 @@
    "id": "3d0b4773",
    "metadata": {},
    "outputs": [],
+   "source": [
+    "ditl.config.fault_management.events"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28fb83ac",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ed79005",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ditl.plan.save(\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f86f477",
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],

--- a/examples/Quick_DITL_Example.ipynb
+++ b/examples/Quick_DITL_Example.ipynb
@@ -282,13 +282,21 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fa15a09f-d06c-45cd-8837-293cd7403a07",
+   "cell_type": "markdown",
+   "id": "df675eaa",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "config.spacecraft_bus.star_trackers.model_dump()"
+    "Figure 3 shows the breakdown of time spent in each ACS mode (science, slewing, SAA passage, ground-station pass, charging) as a pie chart, and Figure 4 plots the data management telemetry (buffer fill level and downlink events) across the simulated day."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7299e0ba",
+   "metadata": {},
+   "source": [
+    "## Step 7: Inspect the Event Log\n",
+    "\n",
+    "The DITL log records every discrete event that occurred during the simulation — mode transitions, target acquisitions, SAA entries/exits, ground-station passes, and fault responses. Printing it gives a timestamped audit trail of spacecraft activity."
    ]
   },
   {
@@ -303,13 +311,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "67ccac95",
+   "metadata": {},
+   "source": [
+    "## Step 8: Fault Management Timeline\n",
+    "\n",
+    "Plot the fault management timeline to see when — and for how long — the spacecraft entered emergency charging or safe-mode, and how quickly autonomous recovery was triggered."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "9dbf6857-7c35-4530-a961-9f728b3d39d2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from conops import plot_fault_management_timeline_plotly\n",
     "from conops.visualization.fault_management import plot_fault_management_timeline\n",
     "\n",
     "plot_fault_management_timeline(\n",
@@ -320,36 +337,14 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "16bd5ff4",
+   "cell_type": "markdown",
+   "id": "20143ccf",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "plot_fault_management_timeline_plotly(\n",
-    "    ditl.config.fault_management,\n",
-    "    t0=ditl.begin.timestamp(),\n",
-    "    t_end=ditl.end.timestamp(),\n",
-    ")"
+    "## Step 9: Save the Plan to Disk\n",
+    "\n",
+    "Serialise the final observation plan to a JSON file.  Passing `\".\"` (the current directory) lets COASTSim auto-generate the filename — `plan_<start>_<end>_v<N>.json` — and auto-increment the version counter if a plan for the same time window already exists.  The returned `Path` shows exactly where the file was written."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3d0b4773",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ditl.config.fault_management.events"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "28fb83ac",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -358,16 +353,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ditl.plan.save(\"\")"
+    "ditl.plan.save(\".\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0f86f477",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tests/plan/test_plan.py
+++ b/tests/plan/test_plan.py
@@ -1,8 +1,53 @@
 """Tests for conops.plan module."""
 
+import json
+from pathlib import Path
 from unittest.mock import Mock
 
-from conops import PlanEntry
+import pytest
+
+from conops import Plan, PlanEntry
+from conops.common.enums import ObsType
+
+
+def _make_plan_entry(obsid: int, begin: float, end: float) -> PlanEntry:
+    """Return a bare PlanEntry instance (bypasses __init__) with the minimal
+    attributes that PlanEntrySchema._coerce_from_plan_entry reads."""
+    entry = object.__new__(PlanEntry)
+    entry.name = f"TARGET_{obsid}"
+    entry.ra = 10.0 + obsid
+    entry.dec = -20.0 + obsid
+    entry.roll = -1.0
+    entry.begin = begin
+    entry.end = end
+    entry.merit = 100.0
+    entry.slewtime = 60
+    entry.insaa = 0
+    entry.obsid = obsid
+    entry.obstype = ObsType.AT
+    entry.slewdist = 5.0
+    entry.ss_min = 300.0
+    entry.ss_max = 1_000_000.0
+    entry._exptime = 1000
+    entry._exporig = 1000
+    entry.isat = False
+    entry.done = False
+    entry.exposure = 1000
+    return entry
+
+
+def _make_plan(n: int = 2) -> Plan:
+    """Build a Plan with *n* real PlanEntry objects."""
+    plan = Plan()
+    for i in range(n):
+        plan.append(
+            _make_plan_entry(
+                obsid=i,
+                begin=float(1_000_000 + i * 2000),
+                end=float(1_001_000 + i * 2000),
+            )
+        )
+    return plan
 
 
 class TestTargetList:
@@ -139,3 +184,114 @@ class TestPlan:
         empty_plan.append(ppt1)
         empty_plan.append(ppt2)
         assert empty_plan[1] == ppt2
+
+
+class TestPlanSaveLoad:
+    """Tests for Plan.save() and Plan.load()."""
+
+    def test_save_to_explicit_path_returns_resolved_path(self, tmp_path):
+        """Plan.save(file) returns the resolved Path of the written file."""
+        plan = _make_plan(2)
+        dest = tmp_path / "plan.json"
+        result = plan.save(dest)
+        assert isinstance(result, Path)
+        assert result == dest.resolve()
+
+    def test_save_creates_json_file(self, tmp_path):
+        """Plan.save() writes a file that exists and is valid JSON."""
+        plan = _make_plan(2)
+        dest = tmp_path / "plan.json"
+        plan.save(dest)
+        assert dest.exists()
+        raw = json.loads(dest.read_text())
+        assert isinstance(raw, dict)
+
+    def test_save_json_contains_expected_metadata(self, tmp_path):
+        """Saved JSON contains version, start, end, num_entries, and entries keys."""
+        plan = _make_plan(2)
+        dest = tmp_path / "plan.json"
+        plan.save(dest)
+        raw = json.loads(dest.read_text())
+        assert "version" in raw
+        assert "coast_sim_version" in raw
+        assert "created_at" in raw
+        assert "start" in raw
+        assert "end" in raw
+        assert raw["num_entries"] == 2
+        assert len(raw["entries"]) == 2
+
+    def test_save_times_are_iso_strings(self, tmp_path):
+        """start, end, and entry begin/end are serialised as ISO-8601 strings."""
+        plan = _make_plan(1)
+        dest = tmp_path / "plan.json"
+        plan.save(dest)
+        raw = json.loads(dest.read_text())
+        assert isinstance(raw["start"], str) and "T" in raw["start"]
+        assert isinstance(raw["end"], str) and "T" in raw["end"]
+        entry = raw["entries"][0]
+        assert isinstance(entry["begin"], str) and "T" in entry["begin"]
+        assert isinstance(entry["end"], str) and "T" in entry["end"]
+
+    def test_save_to_directory_autogenerates_filename(self, tmp_path):
+        """Plan.save(directory) auto-generates a filename."""
+        plan = _make_plan(1)
+        result = plan.save(str(tmp_path) + "/")
+        assert result.parent == tmp_path.resolve()
+        assert result.suffix == ".json"
+        assert result.name.startswith("plan_")
+        assert result.exists()
+
+    def test_save_to_directory_increments_version(self, tmp_path):
+        """Saving to the same directory twice increments the version number."""
+        plan = _make_plan(1)
+        first = plan.save(tmp_path)
+        second = plan.save(tmp_path)
+        assert first != second
+        assert "_v0." in first.name
+        assert "_v1." in second.name
+
+    def test_load_returns_plan_schema(self, tmp_path):
+        """Plan.load() returns a PlanSchema, not a plain Plan."""
+        from conops.targets.plan_schema import PlanSchema
+
+        plan = _make_plan(2)
+        dest = tmp_path / "plan.json"
+        plan.save(dest)
+        loaded = Plan.load(dest)
+        assert isinstance(loaded, PlanSchema)
+
+    def test_load_entry_count_matches(self, tmp_path):
+        """Loaded PlanSchema has the same number of entries as saved."""
+        plan = _make_plan(3)
+        dest = tmp_path / "plan.json"
+        plan.save(dest)
+        loaded = Plan.load(dest)
+        assert loaded.num_entries == 3
+        assert len(loaded.entries) == 3
+
+    def test_load_entry_fields_roundtrip(self, tmp_path):
+        """Key scalar fields survive a save/load roundtrip."""
+
+        plan = _make_plan(1)
+        dest = tmp_path / "plan.json"
+        plan.save(dest)
+        loaded = Plan.load(dest)
+        original_entry = plan.entries[0]
+        loaded_entry = loaded.entries[0]
+        assert loaded_entry.obsid == original_entry.obsid
+        assert loaded_entry.ra == pytest.approx(original_entry.ra)
+        assert loaded_entry.dec == pytest.approx(original_entry.dec)
+        assert loaded_entry.begin == pytest.approx(original_entry.begin)
+        assert loaded_entry.end == pytest.approx(original_entry.end)
+        assert loaded_entry.obstype == original_entry.obstype
+
+    def test_load_metadata_roundtrip(self, tmp_path):
+        """start, end, and version survive a save/load roundtrip."""
+
+        plan = _make_plan(2)
+        dest = tmp_path / "plan.json"
+        plan.save(dest)
+        loaded = Plan.load(dest)
+        assert loaded.start == pytest.approx(plan.entries[0].begin)
+        assert loaded.end == pytest.approx(plan.entries[-1].end)
+        assert isinstance(loaded.version, int)

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -233,6 +233,60 @@ class TestPlanSchema:
         # num_entries and created_at will have schema defaults
         assert isinstance(schema.created_at, str)
 
+    def test_reconcile_num_entries_when_missing(self, tmp_path):
+        """num_entries is recomputed from entries when absent in JSON."""
+        raw = {
+            "version": 0,
+            "start": 1_000_000,
+            "end": 1_002_000,
+            "entries": [_ENTRY_DICT, _ENTRY_DICT],
+            # no num_entries key
+        }
+        dest = tmp_path / "plan.json"
+        dest.write_text(json.dumps(raw))
+        schema = PlanSchema.load(dest)
+        assert schema.num_entries == 2
+
+    def test_reconcile_num_entries_when_stale(self, tmp_path):
+        """num_entries is corrected when it disagrees with the actual entries list."""
+        raw = {
+            "version": 0,
+            "start": 1_000_000,
+            "end": 1_002_000,
+            "num_entries": 99,  # intentionally wrong
+            "entries": [_ENTRY_DICT],
+        }
+        dest = tmp_path / "plan.json"
+        dest.write_text(json.dumps(raw))
+        schema = PlanSchema.load(dest)
+        assert schema.num_entries == 1
+
+    def test_reconcile_start_when_missing(self, tmp_path):
+        """start is inferred from the first entry's begin time when absent."""
+        raw = {
+            "version": 0,
+            "end": 1_001_000,
+            "entries": [_ENTRY_DICT],
+            # no start key
+        }
+        dest = tmp_path / "plan.json"
+        dest.write_text(json.dumps(raw))
+        schema = PlanSchema.load(dest)
+        assert schema.start == pytest.approx(_ENTRY_DICT["begin"])
+
+    def test_reconcile_end_when_missing(self, tmp_path):
+        """end is inferred from the last entry's end time when absent."""
+        raw = {
+            "version": 0,
+            "start": 1_000_000,
+            "entries": [_ENTRY_DICT],
+            # no end key
+        }
+        dest = tmp_path / "plan.json"
+        dest.write_text(json.dumps(raw))
+        schema = PlanSchema.load(dest)
+        assert schema.end == pytest.approx(_ENTRY_DICT["end"])
+
     def test_from_plan_classmethod_empty_plan(self):
         """from_plan on an empty Plan should produce zero entries and start/end=0."""
         from conops.targets.plan import Plan

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -1,0 +1,212 @@
+"""Tests for conops.targets.plan_schema (PlanSchema / PlanEntrySchema)."""
+
+import json
+import pathlib
+
+import pytest
+
+from conops.targets import PlanEntrySchema, PlanSchema
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_ENTRY_DICT = {
+    "name": "TEST",
+    "ra": 123.45,
+    "dec": -45.0,
+    "roll": 0.0,
+    "begin": 1_000_000.0,
+    "end": 1_001_000.0,
+    "merit": 50.0,
+    "slewtime": 120,
+    "insaa": 0,
+    "obsid": 99,
+    "obstype": "AT",
+    "slewdist": 10.0,
+    "ss_min": 300.0,
+    "ss_max": 1_000_000.0,
+    "exptime": 880,
+    "exporig": 1000,
+    "isat": False,
+    "done": True,
+    "exposure": 880,
+}
+
+
+def _make_schema(n: int = 2) -> PlanSchema:
+    """Build a PlanSchema from raw dicts (no Plan object required)."""
+    entries = [
+        dict(
+            _ENTRY_DICT,
+            obsid=i,
+            begin=float(1_000_000 + i * 2000),
+            end=float(1_001_000 + i * 2000),
+        )
+        for i in range(n)
+    ]
+    return PlanSchema(
+        version="test-1.0",
+        created_at="2025-01-01T00:00:00+00:00",
+        start=entries[0]["begin"],
+        end=entries[-1]["end"],
+        num_entries=n,
+        entries=[PlanEntrySchema(**e) for e in entries],
+    )
+
+
+# ── PlanEntrySchema ────────────────────────────────────────────────────────────
+
+
+class TestPlanEntrySchema:
+    def test_from_dict_roundtrip(self):
+        entry = PlanEntrySchema(**_ENTRY_DICT)
+        assert entry.name == "TEST"
+        assert entry.ra == pytest.approx(123.45)
+        assert entry.dec == pytest.approx(-45.0)
+        assert entry.obsid == 99
+        assert entry.done is True
+        assert entry.isat is False
+        assert entry.exptime == 880
+        assert entry.exporig == 1000
+
+    def test_defaults_for_missing_optional_fields(self):
+        entry = PlanEntrySchema(
+            **{k: v for k, v in _ENTRY_DICT.items() if k not in ("isat", "done")}
+        )
+        assert entry.isat is False
+        assert entry.done is False
+
+    def test_model_dump_contains_all_keys(self):
+        entry = PlanEntrySchema(**_ENTRY_DICT)
+        dumped = entry.model_dump()
+        for key in (
+            "name",
+            "ra",
+            "dec",
+            "roll",
+            "begin",
+            "end",
+            "merit",
+            "slewtime",
+            "insaa",
+            "obsid",
+            "obstype",
+            "slewdist",
+            "ss_min",
+            "ss_max",
+            "exptime",
+            "exporig",
+            "isat",
+            "done",
+            "exposure",
+        ):
+            assert key in dumped, f"Missing key: {key}"
+
+
+# ── PlanSchema ─────────────────────────────────────────────────────────────────
+
+
+class TestPlanSchema:
+    def test_construction_and_basic_fields(self):
+        schema = _make_schema(3)
+        assert schema.num_entries == 3
+        assert len(schema.entries) == 3
+        assert schema.version == "test-1.0"
+        assert schema.start == pytest.approx(1_000_000.0)
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        original = _make_schema(2)
+        dest = tmp_path / "plan.json"
+        returned_path = original.save(dest)
+        assert returned_path == dest.resolve()
+
+        loaded = PlanSchema.load(dest)
+        assert loaded.version == original.version
+        assert loaded.created_at == original.created_at
+        assert loaded.num_entries == original.num_entries
+        assert len(loaded.entries) == len(original.entries)
+        assert loaded.entries[0].obsid == original.entries[0].obsid
+        assert loaded.entries[0].ra == pytest.approx(original.entries[0].ra)
+
+    def test_save_produces_valid_json(self, tmp_path):
+        schema = _make_schema(1)
+        dest = tmp_path / "plan.json"
+        schema.save(dest)
+        raw = json.loads(dest.read_text())
+        assert "version" in raw
+        assert "created_at" in raw
+        assert "start" in raw
+        assert "end" in raw
+        assert "num_entries" in raw
+        assert isinstance(raw["entries"], list)
+        assert len(raw["entries"]) == 1
+
+    def test_entry_fields_in_json(self, tmp_path):
+        schema = _make_schema(1)
+        dest = tmp_path / "plan.json"
+        schema.save(dest)
+        raw = json.loads(dest.read_text())
+        entry = raw["entries"][0]
+        for key in (
+            "name",
+            "ra",
+            "dec",
+            "roll",
+            "begin",
+            "end",
+            "merit",
+            "slewtime",
+            "insaa",
+            "obsid",
+            "obstype",
+            "slewdist",
+            "ss_min",
+            "ss_max",
+            "exptime",
+            "exporig",
+            "isat",
+            "done",
+            "exposure",
+        ):
+            assert key in entry, f"JSON entry missing key: {key}"
+
+    def test_load_existing_example_json(self):
+        """Load a plan JSON file produced by a previous version (backward compat)."""
+        example = (
+            pathlib.Path(__file__).parent.parent.parent
+            / "examples"
+            / "plan_20251201T000000Z_20251201T235900Z_v0.json"
+        )
+        if not example.exists():
+            pytest.skip("Example JSON file not found")
+        schema = PlanSchema.load(example)
+        assert schema.num_entries >= 0
+        assert isinstance(schema.entries, list)
+        # version string should be non-empty
+        assert schema.version
+
+    def test_load_legacy_json_without_metadata(self, tmp_path):
+        """Files produced before PlanSchema existed may lack created_at / num_entries."""
+        legacy = {
+            "version": "0.1.0",
+            "start": 1_000_000,
+            "end": 1_002_000,
+            "entries": [_ENTRY_DICT],
+        }
+        dest = tmp_path / "legacy.json"
+        dest.write_text(json.dumps(legacy))
+        schema = PlanSchema.load(dest)
+        assert schema.version == "0.1.0"
+        assert len(schema.entries) == 1
+        # num_entries and created_at will have schema defaults
+        assert isinstance(schema.created_at, str)
+
+    def test_from_plan_classmethod_empty_plan(self):
+        """from_plan on an empty Plan should produce zero entries and start/end=0."""
+        from conops.targets.plan import Plan
+
+        plan = Plan()
+        schema = PlanSchema.from_plan(plan)
+        assert schema.num_entries == 0
+        assert schema.entries == []
+        assert schema.start == 0.0
+        assert schema.end == 0.0

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -197,6 +197,7 @@ class TestPlanSchema:
         schema = PlanSchema.load(dest)
         assert schema.version == "0.1.0"
         assert len(schema.entries) == 1
+        assert schema.num_entries == len(schema.entries)
         # num_entries and created_at will have schema defaults
         assert isinstance(schema.created_at, str)
 

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -149,6 +149,10 @@ class TestPlanSchema:
         assert len(loaded.entries) == len(original.entries)
         assert loaded.entries[0].obsid == original.entries[0].obsid
         assert loaded.entries[0].ra == pytest.approx(original.entries[0].ra)
+        assert loaded.entries[0].begin == pytest.approx(original.entries[0].begin)
+        assert loaded.entries[0].end == pytest.approx(original.entries[0].end)
+        assert loaded.start == pytest.approx(original.start)
+        assert loaded.end == pytest.approx(original.end)
 
     def test_save_produces_valid_json(self, tmp_path):
         schema = _make_schema(1)
@@ -160,6 +164,9 @@ class TestPlanSchema:
         assert "start" in raw
         assert "end" in raw
         assert "num_entries" in raw
+        assert isinstance(raw["start"], str), "start should be an ISO-8601 string"
+        assert isinstance(raw["end"], str), "end should be an ISO-8601 string"
+        assert "T" in raw["start"]  # sanity-check ISO format
         assert isinstance(raw["entries"], list)
         assert len(raw["entries"]) == 1
 
@@ -191,6 +198,9 @@ class TestPlanSchema:
             "exposure",
         ):
             assert key in entry, f"JSON entry missing key: {key}"
+        assert isinstance(entry["begin"], str), "begin should be an ISO-8601 string"
+        assert isinstance(entry["end"], str), "end should be an ISO-8601 string"
+        assert "T" in entry["begin"]
 
     def test_load_existing_example_json(self):
         """Load a plan JSON file produced by a previous version (backward compat)."""

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -110,8 +110,31 @@ class TestPlanSchema:
         schema = _make_schema(3)
         assert schema.num_entries == 3
         assert len(schema.entries) == 3
-        assert schema.version == "test-1.0"
+        assert schema.version == 0  # coerced from "test-1.0"
         assert schema.start == pytest.approx(1_000_000.0)
+
+    def test_save_to_directory_autogenerates_filename(self, tmp_path):
+        schema = _make_schema(1)
+        returned_path = schema.save(str(tmp_path) + "/")
+        assert returned_path.parent == tmp_path.resolve()
+        assert returned_path.suffix == ".json"
+        assert returned_path.name.startswith("plan_")
+        assert returned_path.exists()
+
+    def test_save_to_existing_directory_autogenerates_filename(self, tmp_path):
+        schema = _make_schema(1)
+        returned_path = schema.save(tmp_path)  # tmp_path already exists as dir
+        assert returned_path.parent == tmp_path.resolve()
+        assert returned_path.name.startswith("plan_")
+
+    def test_default_filename_format(self):
+        schema = _make_schema(1)
+        name = schema._default_filename()
+        # e.g. plan_19700101T277H46M40Z_..._vtest-1.0.json
+        assert name.startswith("plan_")
+        assert name.endswith(".json")
+        parts = name[len("plan_") : name.rfind("_v")]
+        assert "T" in parts  # ISO date component present
 
     def test_save_and_load_roundtrip(self, tmp_path):
         original = _make_schema(2)
@@ -181,8 +204,7 @@ class TestPlanSchema:
         schema = PlanSchema.load(example)
         assert schema.num_entries >= 0
         assert isinstance(schema.entries, list)
-        # version string should be non-empty
-        assert schema.version
+        assert isinstance(schema.version, int)
 
     def test_load_legacy_json_without_metadata(self, tmp_path):
         """Files produced before PlanSchema existed may lack created_at / num_entries."""
@@ -195,7 +217,7 @@ class TestPlanSchema:
         dest = tmp_path / "legacy.json"
         dest.write_text(json.dumps(legacy))
         schema = PlanSchema.load(dest)
-        assert schema.version == "0.1.0"
+        assert schema.version == 0  # legacy semver coerced to 0
         assert len(schema.entries) == 1
         assert schema.num_entries == len(schema.entries)
         # num_entries and created_at will have schema defaults


### PR DESCRIPTION
This pull request introduces a new serialization layer for observation plans, enabling plans to be saved and loaded as portable, versioned JSON files. The core of this feature is implemented using Pydantic models, providing robust schema validation, metadata handling, and backward compatibility. The update includes new API methods for saving and loading plans, comprehensive documentation, and thorough test coverage.

**Plan Serialization and Schema Implementation:**

* Added `PlanEntrySchema` and `PlanSchema` Pydantic models in `conops/targets/plan_schema.py` to represent plan entries and entire plans, including metadata such as version, creation time, and entry count. These models support round-trip serialization to and from JSON, and can validate both dicts and `Plan` objects.
* Integrated the schema into the main API: `PlanEntrySchema` and `PlanSchema` are now imported in `conops/targets/__init__.py` for public use, and type-checking imports are added in `conops/targets/plan.py`. [[1]](diffhunk://#diff-ffe5c3d2e32736ed05d3f6029f902969168bdd85008718d3e0020d52331e3211R3-R10) [[2]](diffhunk://#diff-3abbd8e121cc81d10783bef7e5a4a58e01181511cb8a353b5778a8051ea894a1R4-R11)

**New API Methods for Plan Objects:**

* Added `Plan.save()` and `Plan.load()` methods to serialize and deserialize plans directly to/from JSON files, delegating to the schema models. These methods preserve metadata and ensure compatibility with previous file formats.

**Documentation Enhancements:**

* Added a new documentation page (`docs/plan_serialization.rst`) explaining plan serialization, usage examples, JSON file structure, and schema field definitions. Linked this page from the main index and module documentation. [[1]](diffhunk://#diff-d045297b345a931fa2005d48bf22b003fd664478df38b3aa027831522968c13bR1-R232) [[2]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R26) [[3]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R47) [[4]](diffhunk://#diff-3f2b7c61cde8211e25068fffcf9a48b019bd35dc069f83e5ef738efabd3c05cdR48) [[5]](diffhunk://#diff-ad156fda5437ffd1a3314a430f7e65e8a07e296134598d8500091ccbaf2a5856R1-R7)

**Testing:**

* Introduced a comprehensive test suite in `tests/plan/test_plan_schema.py` covering schema construction, serialization/deserialization, field validation, backward compatibility with legacy files, and integration with the main `Plan` API.