### PR TITLE
feat: update in_constraint_batch api to match rust_ephem 0.8.0

### DIFF
--- a/conops/config/constraint.py
+++ b/conops/config/constraint.py
@@ -482,7 +482,7 @@ class Constraint(ConfigModel):
         ras: list[float],
         decs: list[float],
         utime: float,
-        target_roll: float | None = None,
+        target_rolls: list[float] | None = None,
     ) -> np.ndarray:
         """Check constraints for multiple pointings at a single time.
 
@@ -493,12 +493,22 @@ class Constraint(ConfigModel):
             ras: List of right ascension values in degrees
             decs: List of declination values in degrees
             utime: Unix timestamp
+            target_rolls: Optional roll angles in degrees aligned element-wise with
+                ``ras`` and ``decs``
 
         Returns:
             Boolean array where True means constraint is violated
         """
         if not ras:
             return np.zeros(0, dtype=bool)
+
+        if len(ras) != len(decs):
+            raise ValueError("ras and decs must have the same length")
+
+        if target_rolls is not None and len(target_rolls) != len(ras):
+            raise ValueError(
+                "target_rolls must be None or have the same length as ras and decs"
+            )
 
         assert self.ephem is not None, (
             "Ephemeris must be set to use in_constraint_batch"
@@ -526,7 +536,7 @@ class Constraint(ConfigModel):
                 target_ras=ras,
                 target_decs=decs,
                 times=[dt],
-                target_roll=target_roll,
+                target_rolls=target_rolls,
             )
             # Result shape is (n_candidates, 1), flatten to (n_candidates,)
             result_flat = np.asarray(result).flatten()

--- a/conops/config/recorder.py
+++ b/conops/config/recorder.py
@@ -63,8 +63,8 @@ class OnboardRecorder(ConfigModel):
     @classmethod
     def validate_current_volume(cls, v: float, info: Any) -> float:
         """Ensure current volume doesn't exceed capacity."""
-        # Access capacity from ValidationInfo if available
-        capacity: float = info.data.get("capacity_gb", 32.0)
+        data = info.data or {}
+        capacity: float = data.get("capacity_gb", 32.0)
         if v > capacity:
             return capacity
         return v
@@ -73,7 +73,8 @@ class OnboardRecorder(ConfigModel):
     @classmethod
     def validate_thresholds(cls, v: float, info: Any) -> float:
         """Ensure red threshold is greater than or equal to yellow threshold."""
-        yellow = info.data.get("yellow_threshold", 0.7)
+        data = info.data or {}
+        yellow = data.get("yellow_threshold", 0.7)
         if v < yellow:
             raise ValueError("red_threshold must be >= yellow_threshold")
         return v

--- a/tests/constraint/test_constraint.py
+++ b/tests/constraint/test_constraint.py
@@ -1,6 +1,6 @@
 """Tests for conops.constraint module."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -371,16 +371,33 @@ class TestConstraintRollPassthrough:
 
         assert mock_in_constraint.call_args.kwargs["target_roll"] == 12.5
 
-    def test_in_constraint_batch_forwards_target_roll(
+    def test_in_constraint_batch_forwards_target_rolls(
         self, constraint_with_ephem
     ) -> None:
-        mock_constraint = Mock()
-        mock_constraint.in_constraint_batch.return_value = np.zeros((2, 1), dtype=bool)
+        class NewBatchConstraint:
+            def __init__(self) -> None:
+                self.target_rolls = None
+
+            def in_constraint_batch(
+                self,
+                ephemeris,
+                target_ras,
+                target_decs,
+                times,
+                indices=None,
+                target_rolls=None,
+                n_roll_samples=360,
+            ):
+                self.target_rolls = target_rolls
+                return np.zeros((len(target_ras), 1), dtype=bool)
+
+        mock_constraint = NewBatchConstraint()
         constraint_with_ephem.sun_constraint = mock_constraint
         constraint_with_ephem.earth_constraint = None
         constraint_with_ephem.panel_constraint = None
         constraint_with_ephem.moon_constraint = None
         constraint_with_ephem.anti_sun_constraint = None
+        constraint_with_ephem.orbit_constraint = None
         constraint_with_ephem.star_tracker_hard_constraint = None
         constraint_with_ephem.star_tracker_soft_constraint = None
 
@@ -388,12 +405,47 @@ class TestConstraintRollPassthrough:
             ras=[10.0, 20.0],
             decs=[-5.0, 15.0],
             utime=1700000000.0,
-            target_roll=22.0,
+            target_rolls=[22.0, 33.0],
         )
 
-        assert (
-            mock_constraint.in_constraint_batch.call_args.kwargs["target_roll"] == 22.0
-        )
+        assert mock_constraint.target_rolls == [22.0, 33.0]
+
+    def test_in_constraint_batch_rejects_mismatched_target_rolls(
+        self, constraint_with_ephem
+    ) -> None:
+        class NewBatchConstraint:
+            def in_constraint_batch(
+                self,
+                ephemeris,
+                target_ras,
+                target_decs,
+                times,
+                indices=None,
+                target_rolls=None,
+                n_roll_samples=360,
+            ):
+                return np.zeros((len(target_ras), 1), dtype=bool)
+
+        mock_constraint = NewBatchConstraint()
+        constraint_with_ephem.sun_constraint = mock_constraint
+        constraint_with_ephem.earth_constraint = None
+        constraint_with_ephem.panel_constraint = None
+        constraint_with_ephem.moon_constraint = None
+        constraint_with_ephem.anti_sun_constraint = None
+        constraint_with_ephem.orbit_constraint = None
+        constraint_with_ephem.star_tracker_hard_constraint = None
+        constraint_with_ephem.star_tracker_soft_constraint = None
+
+        with pytest.raises(
+            ValueError,
+            match="target_rolls must be None or have the same length",
+        ):
+            constraint_with_ephem.in_constraint_batch(
+                ras=[10.0, 20.0],
+                decs=[-5.0, 15.0],
+                utime=1700000000.0,
+                target_rolls=[22.0],
+            )
 
     @patch("rust_ephem.AndConstraint.in_constraint")
     def test_in_panel_with_float_returns_scalar(


### PR DESCRIPTION
Update fixes the use of `target_rolls` argument in `in_constraint_batch` to match rust-ephem 0.8.0. A single value for roll is no longer valid unless it's `None`. 

This pull request updates the batch constraint checking logic to support an element-wise list of roll angles (`target_rolls`) instead of a single roll angle, and adds validation and tests for this new behavior. The changes ensure that constraints are checked correctly when each pointing has its own roll angle, and that input lengths are validated to prevent errors.

**Constraint batch API improvements:**

* Changed the `in_constraint_batch` method in `conops/config/constraint.py` to accept a list of roll angles (`target_rolls`) aligned element-wise with `ras` and `decs`, instead of a single `target_roll`. Added validation to ensure `ras`, `decs`, and `target_rolls` (if provided) all have the same length, raising a `ValueError` otherwise. [[1]](diffhunk://#diff-eeb99acd4d46efb45375e29e7733780eaf82e0c8967d45e0d9dd45312b019ca7L485-R485) [[2]](diffhunk://#diff-eeb99acd4d46efb45375e29e7733780eaf82e0c8967d45e0d9dd45312b019ca7R496-R512)
* Updated the internal call to pass `target_rolls` to the constraint batch logic instead of `target_roll`.

**Testing enhancements:**

* Added and updated tests in `tests/constraint/test_constraint.py` to verify that `target_rolls` is forwarded correctly, and to check that mismatched input lengths for `target_rolls` raise a `ValueError`.
* Minor cleanup in imports in the test file.