### PR TITLE
feat(visualization): Add Spacecraft 3d model based on configuration parameters

### DIFF
--- a/conops/config/instrument.py
+++ b/conops/config/instrument.py
@@ -180,14 +180,14 @@ class Telescope(Instrument):
         ...     name="Primary Telescope",
         ...     boresight=(1.0, 0.0, 0.0),
         ...     optics=TelescopeConfig(
-        ...         aperture_m=0.6,
-        ...         focal_length_m=6.0,
+        ...         aperture_m=0.5,
+        ...         focal_length_m=3.5,              # f/7 telescope
         ...         telescope_type=TelescopeType.RITCHEY_CHRETIEN,
         ...         tube_length_m=1.2,
         ...     ),
         ... )
         >>> scope.optics.f_number
-        10.0
+        7.0
     """
 
     instrument_type: Literal["Telescope"] = Field(  # type: ignore[assignment]

--- a/conops/visualization/__init__.py
+++ b/conops/visualization/__init__.py
@@ -22,6 +22,7 @@ from .plotly.fault_management import plot_fault_management_timeline_plotly
 from .plotly.globe_pointing import plot_sky_pointing_globe
 from .plotly.radiator_telemetry import plot_radiator_telemetry_plotly
 from .plotly.sky_pointing import plot_sky_pointing_plotly
+from .plotly.spacecraft_3d import plot_spacecraft_3d
 
 __all__ = [
     "plot_ditl_timeline",
@@ -42,4 +43,5 @@ __all__ = [
     "plot_ditl_timeline_plotly",
     "plot_data_management_telemetry_plotly",
     "plot_acs_mode_distribution_plotly",
+    "plot_spacecraft_3d",
 ]

--- a/conops/visualization/plotly/__init__.py
+++ b/conops/visualization/plotly/__init__.py
@@ -15,6 +15,7 @@ from .radiator_telemetry import plot_radiator_telemetry_plotly
 from .sky_pointing import (
     plot_sky_pointing_plotly,
 )
+from .spacecraft_3d import plot_spacecraft_3d
 
 __all__ = [
     "plot_sky_pointing_globe",
@@ -26,4 +27,5 @@ __all__ = [
     "annotate_slew_distances",
     "plot_data_management_telemetry_plotly",
     "plot_acs_mode_distribution_plotly",
+    "plot_spacecraft_3d",
 ]

--- a/conops/visualization/plotly/spacecraft_3d.py
+++ b/conops/visualization/plotly/spacecraft_3d.py
@@ -417,6 +417,10 @@ def plot_spacecraft_3d(
     bus_hd: tuple[float, float, float] = bus_half_dims or (1.0, 0.55, 0.55)
     hx, hy, hz = bus_hd
 
+    # Telescope geometry captured during section 2; used for ST mounting in section 5.
+    # (tube_start, bore, outer_r, tube_len)
+    _scope_geom: tuple[np.ndarray, np.ndarray, float, float] | None = None
+
     # ------------------------------------------------------------------ #
     # 1. Spacecraft bus body                                               #
     # ------------------------------------------------------------------ #
@@ -455,6 +459,9 @@ def plot_spacecraft_3d(
 
         outer_r = aperture_r + 0.06  # baffle slightly wider than aperture
         scope_name = getattr(inst, "name", "Telescope")
+
+        # Save for star-tracker mounting below (last telescope wins if multiple).
+        _scope_geom = (tube_start, bore, outer_r, tube_len)
 
         # Outer baffle cylinder
         traces.append(
@@ -693,13 +700,27 @@ def plot_spacecraft_3d(
         b_vec = _unit(np.asarray(bore_raw, dtype=float))
         sc = st_colors[sidx % len(st_colors)]
 
-        # Place a small prism (box) on the bus face
-        c, u, v = _face_placement(b_vec, bus_hd, gap=0.0)
         body_size = 0.12
 
-        # Small square prism sticking out from bus face
-        prism_start = c
-        prism_end = c + b_vec * 0.08
+        if _scope_geom is not None:
+            # Mount on the telescope tube surface.
+            s_start, s_bore, s_outer_r, s_tube_len = _scope_geom
+            # Radial direction: component of boresight perpendicular to the tube axis.
+            b_perp = b_vec - float(np.dot(b_vec, s_bore)) * s_bore
+            radial = (
+                _unit(b_perp) if np.linalg.norm(b_perp) > 0.1 else _perp_pair(s_bore)[0]
+            )
+            # Position at 65 % along the tube, just outside the baffle surface.
+            c = s_start + s_bore * (s_tube_len * 0.65) + radial * (s_outer_r + 0.005)
+            u = s_bore  # span along tube
+            v = _unit(np.cross(s_bore, radial))  # span tangential to tube
+            prism_start = c
+            prism_end = c + radial * 0.08
+        else:
+            # No telescope — fall back to bus-face placement.
+            c, u, v = _face_placement(b_vec, bus_hd, gap=0.0)
+            prism_start = c
+            prism_end = c + b_vec * 0.08
         traces.append(
             _flat_rect_mesh(
                 (prism_start + prism_end) / 2,
@@ -716,10 +737,12 @@ def plot_spacecraft_3d(
         )
         st_legend_shown = True
 
-        # Front face of the star tracker (in tracker color = lens aperture)
+        # Front face of the star tracker (in tracker color = lens aperture).
+        # Offset slightly outward from the prism end in the mounting direction.
+        mount_dir = _unit(prism_end - prism_start)
         traces.append(
             _flat_rect_mesh(
-                prism_end + b_vec * 0.001,
+                prism_end + mount_dir * 0.001,
                 u,
                 v,
                 body_size * 0.6,

--- a/conops/visualization/plotly/spacecraft_3d.py
+++ b/conops/visualization/plotly/spacecraft_3d.py
@@ -82,7 +82,7 @@ def _box_mesh(
     center: tuple[float, float, float] = (0.0, 0.0, 0.0),
     color: str = _C_BUS,
     name: str = "Bus",
-    opacity: float = 0.88,
+    opacity: float = 1.0,
     show_legend: bool = True,
 ) -> go.Mesh3d:
     cx, cy, cz = center
@@ -128,7 +128,7 @@ def _flat_rect_mesh(
     height: float,
     color: str,
     name: str,
-    opacity: float = 0.88,
+    opacity: float = 1.0,
     show_legend: bool = True,
     legendgroup: str | None = None,
 ) -> go.Mesh3d:
@@ -143,8 +143,8 @@ def _flat_rect_mesh(
         y=pts[:, 1].tolist(),
         z=pts[:, 2].tolist(),
         i=[0, 0],
-        j=[1, 3],
-        k=[2, 2],
+        j=[1, 2],
+        k=[2, 3],
         color=color,
         opacity=opacity,
         name=name,
@@ -164,7 +164,7 @@ def _cylinder_mesh(
     color: str,
     name: str,
     n_theta: int = 32,
-    opacity: float = 0.90,
+    opacity: float = 1.0,
     show_legend: bool = True,
     legendgroup: str | None = None,
 ) -> go.Mesh3d:
@@ -212,7 +212,7 @@ def _disk_mesh(
     color: str,
     name: str,
     n_theta: int = 32,
-    opacity: float = 0.90,
+    opacity: float = 1.0,
     show_legend: bool = False,
     legendgroup: str | None = None,
 ) -> go.Mesh3d:
@@ -501,7 +501,6 @@ def plot_spacecraft_3d(
                 0.0,
                 color="rgb(8, 8, 15)",
                 name="Aperture opening",
-                opacity=0.95,
                 legendgroup="telescope",
             )
         )
@@ -610,7 +609,6 @@ def plot_spacecraft_3d(
                 ph + 0.04,
                 color=_C_SOLAR_FRAME,
                 name="Solar panel frame",
-                opacity=0.75,
                 show_legend=show_fr,
                 legendgroup="solar_frames",
             )
@@ -665,7 +663,6 @@ def plot_spacecraft_3d(
                 rh,
                 color=_C_RADIATOR,
                 name=rname,
-                opacity=0.85,
                 show_legend=show_r,
                 legendgroup="radiators",
             )
@@ -730,7 +727,6 @@ def plot_spacecraft_3d(
                 body_size,
                 color=_C_ST,
                 name=sname,
-                opacity=0.92,
                 show_legend=not st_legend_shown,
                 legendgroup="star_trackers",
             )
@@ -749,7 +745,6 @@ def plot_spacecraft_3d(
                 body_size * 0.6,
                 color=sc,
                 name=sname,
-                opacity=0.80,
                 show_legend=False,
                 legendgroup="star_trackers",
             )

--- a/conops/visualization/plotly/spacecraft_3d.py
+++ b/conops/visualization/plotly/spacecraft_3d.py
@@ -1,0 +1,837 @@
+"""Interactive 3-D spacecraft configuration visualizer.
+
+Renders the spacecraft body, solar panels, radiators, star trackers and
+telescope as a Plotly 3-D scene that is freely rotatable in the browser or
+Jupyter.
+
+Coordinate system (spacecraft body frame)
+------------------------------------------
+  +X  boresight / telescope pointing direction
+  +Y  spacecraft "up"
+  +Z  completes the right-handed system
+
+Component placement rules
+--------------------------
+  Telescope   – cylinder extending in the boresight direction from the +X bus face.
+  Solar panels – use ``PanelGeometry.center_m`` when present; otherwise placed
+                 on the bus face whose outward normal best matches the panel normal.
+  Radiators   – placed on the bus face whose outward normal best matches the
+                radiator normal; sized by ``width_m`` × ``height_m``.
+  Star trackers – small prism on the bus face matching the boresight direction.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import plotly.graph_objects as go
+
+if TYPE_CHECKING:
+    from ...config import MissionConfig
+
+# ---------------------------------------------------------------------------
+# Visual palette (dark-themed to match the rest of the codebase)
+# ---------------------------------------------------------------------------
+_BG = "rgb(12, 12, 28)"
+_C_BUS = "rgb(155, 160, 175)"
+_C_SCOPE = "rgb(45, 50, 62)"
+_C_SCOPE_RING = "rgb(200, 160, 50)"
+_C_SOLAR = "rgb(15, 55, 145)"
+_C_SOLAR_FRAME = "rgb(195, 200, 215)"
+_C_RADIATOR = "rgb(228, 232, 240)"
+_C_ST = "rgb(65, 70, 88)"
+_C_X = "red"
+_C_Y = "limegreen"
+_C_Z = "dodgerblue"
+_C_NORMAL = "rgba(255,255,180,0.9)"
+_C_BORESIGHT = "cyan"
+
+# Axis / arrow lengths
+_AXIS_LEN: float = 1.5
+_NORMAL_LEN: float = 0.45
+_CONE_SIZE: float = 0.07
+
+
+# ---------------------------------------------------------------------------
+# Low-level geometry helpers
+# ---------------------------------------------------------------------------
+
+
+def _unit(v: Any) -> np.ndarray:
+    a = np.asarray(v, dtype=float)
+    n = np.linalg.norm(a)
+    return a / n if n > 1e-12 else a
+
+
+def _perp_pair(v: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Two unit vectors perpendicular to *v*."""
+    v = _unit(v)
+    ref = np.array([0.0, 0.0, 1.0]) if abs(v[2]) < 0.9 else np.array([1.0, 0.0, 0.0])
+    u = np.cross(ref, v)
+    u = _unit(u)
+    w = _unit(np.cross(v, u))
+    return u, w
+
+
+def _box_mesh(
+    hx: float,
+    hy: float,
+    hz: float,
+    center: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    color: str = _C_BUS,
+    name: str = "Bus",
+    opacity: float = 0.88,
+    show_legend: bool = True,
+) -> go.Mesh3d:
+    cx, cy, cz = center
+    # 8 vertices (sx, sy, sz) ∈ {-1,+1}³
+    verts = np.array(
+        [
+            [-hx, -hy, -hz],  # 0
+            [+hx, -hy, -hz],  # 1
+            [+hx, +hy, -hz],  # 2
+            [-hx, +hy, -hz],  # 3
+            [-hx, -hy, +hz],  # 4
+            [+hx, -hy, +hz],  # 5
+            [+hx, +hy, +hz],  # 6
+            [-hx, +hy, +hz],  # 7
+        ]
+    ) + [cx, cy, cz]
+    # 12 triangles covering 6 faces
+    ii = [0, 0, 1, 1, 0, 0, 3, 3, 0, 0, 4, 4]
+    jj = [3, 2, 2, 6, 4, 5, 7, 6, 3, 7, 5, 6]
+    kk = [2, 1, 6, 5, 5, 6, 4, 2, 7, 4, 6, 7]
+    return go.Mesh3d(
+        x=verts[:, 0].tolist(),
+        y=verts[:, 1].tolist(),
+        z=verts[:, 2].tolist(),
+        i=ii,
+        j=jj,
+        k=kk,
+        color=color,
+        opacity=opacity,
+        name=name,
+        showlegend=show_legend,
+        flatshading=True,
+        lighting=dict(ambient=0.65, diffuse=0.75, specular=0.25, roughness=0.7),
+        hoverinfo="name",
+    )
+
+
+def _flat_rect_mesh(
+    center: np.ndarray,
+    u: np.ndarray,
+    v: np.ndarray,
+    width: float,
+    height: float,
+    color: str,
+    name: str,
+    opacity: float = 0.88,
+    show_legend: bool = True,
+    legendgroup: str | None = None,
+) -> go.Mesh3d:
+    """Flat rectangular panel as a two-triangle Mesh3d."""
+    c0 = center - u * width / 2 - v * height / 2
+    c1 = center + u * width / 2 - v * height / 2
+    c2 = center + u * width / 2 + v * height / 2
+    c3 = center - u * width / 2 + v * height / 2
+    pts = np.stack([c0, c1, c2, c3])
+    return go.Mesh3d(
+        x=pts[:, 0].tolist(),
+        y=pts[:, 1].tolist(),
+        z=pts[:, 2].tolist(),
+        i=[0, 0],
+        j=[1, 3],
+        k=[2, 2],
+        color=color,
+        opacity=opacity,
+        name=name,
+        showlegend=show_legend,
+        legendgroup=legendgroup,
+        flatshading=True,
+        lighting=dict(ambient=0.55, diffuse=0.80, specular=0.35, roughness=0.6),
+        hoverinfo="name",
+    )
+
+
+def _cylinder_mesh(
+    start: np.ndarray,
+    axis: np.ndarray,
+    radius: float,
+    length: float,
+    color: str,
+    name: str,
+    n_theta: int = 32,
+    opacity: float = 0.90,
+    show_legend: bool = True,
+    legendgroup: str | None = None,
+) -> go.Mesh3d:
+    """Side surface of a cylinder as a Mesh3d."""
+    u, v = _perp_pair(axis)
+    theta = np.linspace(0, 2 * math.pi, n_theta, endpoint=False)
+    cos_t = np.cos(theta)
+    sin_t = np.sin(theta)
+    ring0 = start[:, None] + radius * (np.outer(u, cos_t) + np.outer(v, sin_t))
+    ring1 = (start + axis * length)[:, None] + radius * (
+        np.outer(u, cos_t) + np.outer(v, sin_t)
+    )
+    xs = np.concatenate([ring0[0], ring1[0]]).tolist()
+    ys = np.concatenate([ring0[1], ring1[1]]).tolist()
+    zs = np.concatenate([ring0[2], ring1[2]]).tolist()
+    ii, jj, kk = [], [], []
+    for idx in range(n_theta):
+        nxt = (idx + 1) % n_theta
+        ii.extend([idx, nxt])
+        jj.extend([nxt, nxt + n_theta])
+        kk.extend([idx + n_theta, idx + n_theta])
+    return go.Mesh3d(
+        x=xs,
+        y=ys,
+        z=zs,
+        i=ii,
+        j=jj,
+        k=kk,
+        color=color,
+        opacity=opacity,
+        name=name,
+        showlegend=show_legend,
+        legendgroup=legendgroup,
+        flatshading=True,
+        lighting=dict(ambient=0.55, diffuse=0.80, specular=0.45, roughness=0.5),
+        hoverinfo="name",
+    )
+
+
+def _disk_mesh(
+    center: np.ndarray,
+    normal: np.ndarray,
+    outer_r: float,
+    inner_r: float,
+    color: str,
+    name: str,
+    n_theta: int = 32,
+    opacity: float = 0.90,
+    show_legend: bool = False,
+    legendgroup: str | None = None,
+) -> go.Mesh3d:
+    """Annulus (ring) or filled disk (inner_r=0) as a Mesh3d."""
+    u, v = _perp_pair(normal)
+    theta = np.linspace(0, 2 * math.pi, n_theta, endpoint=False)
+    outer = center[:, None] + outer_r * (
+        np.outer(u, np.cos(theta)) + np.outer(v, np.sin(theta))
+    )
+    if inner_r > 0:
+        inner = center[:, None] + inner_r * (
+            np.outer(u, np.cos(theta)) + np.outer(v, np.sin(theta))
+        )
+        xs = np.concatenate([outer[0], inner[0]]).tolist()
+        ys = np.concatenate([outer[1], inner[1]]).tolist()
+        zs = np.concatenate([outer[2], inner[2]]).tolist()
+        ii, jj, kk = [], [], []
+        for idx in range(n_theta):
+            nxt = (idx + 1) % n_theta
+            ii.extend([idx, nxt])
+            jj.extend([nxt, nxt + n_theta])
+            kk.extend([idx + n_theta, idx + n_theta])
+    else:
+        xs = [center[0]] + outer[0].tolist()
+        ys = [center[1]] + outer[1].tolist()
+        zs = [center[2]] + outer[2].tolist()
+        ii, jj, kk = [], [], []
+        for idx in range(n_theta):
+            nxt = (idx % n_theta) + 1
+            nxt2 = ((idx + 1) % n_theta) + 1
+            ii.append(0)
+            jj.append(nxt)
+            kk.append(nxt2)
+    return go.Mesh3d(
+        x=xs,
+        y=ys,
+        z=zs,
+        i=ii,
+        j=jj,
+        k=kk,
+        color=color,
+        opacity=opacity,
+        name=name,
+        showlegend=show_legend,
+        legendgroup=legendgroup,
+        flatshading=True,
+        hoverinfo="name",
+    )
+
+
+def _arrow_traces(
+    origin: np.ndarray,
+    direction: np.ndarray,
+    length: float,
+    color: str,
+    name: str,
+    cone_sz: float = _CONE_SIZE,
+    show_legend: bool = True,
+    legendgroup: str | None = None,
+    line_width: int = 4,
+) -> list[Any]:
+    """[Scatter3d shaft, Cone arrowhead] for a labelled vector arrow."""
+    d = _unit(direction)
+    if np.linalg.norm(d) < 0.5:
+        return []
+    tip = origin + d * length
+    shaft_end = origin + d * (length - cone_sz * 1.2)
+    line = go.Scatter3d(
+        x=[float(origin[0]), float(shaft_end[0])],
+        y=[float(origin[1]), float(shaft_end[1])],
+        z=[float(origin[2]), float(shaft_end[2])],
+        mode="lines",
+        line=dict(color=color, width=line_width),
+        name=name,
+        showlegend=show_legend,
+        legendgroup=legendgroup,
+        hoverinfo="name",
+    )
+    cone = go.Cone(
+        x=[float(tip[0])],
+        y=[float(tip[1])],
+        z=[float(tip[2])],
+        u=[float(d[0]) * cone_sz],
+        v=[float(d[1]) * cone_sz],
+        w=[float(d[2]) * cone_sz],
+        colorscale=[[0, color], [1, color]],
+        showscale=False,
+        name=name,
+        showlegend=False,
+        legendgroup=legendgroup,
+        sizemode="absolute",
+        sizeref=cone_sz,
+        anchor="tail",
+        hoverinfo="name",
+    )
+    return [line, cone]
+
+
+def _axis_label(pos: np.ndarray, text: str, color: str) -> go.Scatter3d:
+    return go.Scatter3d(
+        x=[float(pos[0])],
+        y=[float(pos[1])],
+        z=[float(pos[2])],
+        mode="text",
+        text=[text],
+        textfont=dict(color=color, size=14),
+        showlegend=False,
+        hoverinfo="skip",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bus-face placement helper
+# ---------------------------------------------------------------------------
+
+
+def _face_placement(
+    normal: np.ndarray,
+    bus_hd: tuple[float, float, float],
+    gap: float = 0.03,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Given a component normal/boresight, return (center, span_u, span_v)
+    placing the component on the bus face whose outward normal best matches.
+    """
+    hx, hy, hz = bus_hd
+    face_n = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, -1.0],
+        ]
+    )
+    face_c = np.array(
+        [
+            [hx, 0.0, 0.0],
+            [-hx, 0.0, 0.0],
+            [0.0, hy, 0.0],
+            [0.0, -hy, 0.0],
+            [0.0, 0.0, hz],
+            [0.0, 0.0, -hz],
+        ]
+    )
+    best = int(np.argmax(face_n @ normal))
+    fn = face_n[best]
+    center = face_c[best] + fn * gap
+    u, v = _perp_pair(fn)
+    return center, u, v
+
+
+# ---------------------------------------------------------------------------
+# Main public function
+# ---------------------------------------------------------------------------
+
+
+def plot_spacecraft_3d(
+    config: MissionConfig,
+    show_normals: bool = True,
+    show_axes: bool = True,
+    bus_half_dims: tuple[float, float, float] | None = None,
+    title: str | None = None,
+) -> go.Figure:
+    """Build an interactive rotatable 3-D model of the spacecraft.
+
+    The figure uses Plotly's 3-D scene so the user can rotate, zoom and pan
+    freely.  All geometric parameters are read directly from *config*.
+
+    Parameters
+    ----------
+    config:
+        A fully-constructed ``MissionConfig``.  Defaults are used for any
+        subsystem that is not explicitly configured.
+    show_normals:
+        Draw outward-normal / boresight arrows for panels, radiators and
+        star trackers (default ``True``).
+    show_axes:
+        Draw +X / +Y / +Z spacecraft-body-frame axes from the origin
+        (default ``True``).
+    bus_half_dims:
+        ``(half_x, half_y, half_z)`` extents of the spacecraft bus box in
+        metres.  Defaults to ``(1.0, 0.55, 0.55)``.
+    title:
+        Figure title.  Falls back to the spacecraft bus name from config.
+
+    Returns
+    -------
+    go.Figure
+        Interactive Plotly figure.  Call ``fig.show()`` or evaluate in
+        Jupyter to render.
+
+    Examples
+    --------
+    >>> config = MissionConfig.from_json_file("config.json")
+    >>> fig = plot_spacecraft_3d(config)
+    >>> fig.show()
+    """
+    traces: list[Any] = []
+
+    bus_hd: tuple[float, float, float] = bus_half_dims or (1.0, 0.55, 0.55)
+    hx, hy, hz = bus_hd
+
+    # ------------------------------------------------------------------ #
+    # 1. Spacecraft bus body                                               #
+    # ------------------------------------------------------------------ #
+    bus_name = getattr(
+        getattr(config, "spacecraft_bus", None), "name", "Spacecraft Bus"
+    )
+    traces.append(_box_mesh(hx, hy, hz, name=bus_name, color=_C_BUS))
+
+    # ------------------------------------------------------------------ #
+    # 2. Telescope / payload instruments                                   #
+    # ------------------------------------------------------------------ #
+    payload = getattr(config, "payload", None)
+    instruments = list(getattr(payload, "instruments", []) or [])
+
+    scope_legend_shown = False
+    for inst in instruments:
+        inst_type = getattr(inst, "instrument_type", None)
+        if inst_type != "Telescope":
+            continue
+
+        bore = np.asarray(getattr(inst, "boresight", (1.0, 0.0, 0.0)), dtype=float)
+        bore = _unit(bore)
+        optics = getattr(inst, "optics", None)
+        aperture_r: float = (getattr(optics, "aperture_m", None) or 0.5) / 2.0
+        tube_len: float = getattr(optics, "tube_length_m", None) or max(
+            aperture_r * 5.0, 1.2
+        )
+
+        # Outer baffle tube starts at the +X face of the bus
+        # (projected along boresight to the face)
+        # Approximate: place the tube starting at the bus face in the boresight direction
+        face_offset: float = max(
+            hx * abs(bore[0]), hy * abs(bore[1]), hz * abs(bore[2])
+        )
+        tube_start = bore * face_offset
+
+        outer_r = aperture_r + 0.06  # baffle slightly wider than aperture
+        scope_name = getattr(inst, "name", "Telescope")
+
+        # Outer baffle cylinder
+        traces.append(
+            _cylinder_mesh(
+                tube_start,
+                bore,
+                outer_r,
+                tube_len,
+                color=_C_SCOPE,
+                name=scope_name,
+                show_legend=not scope_legend_shown,
+                legendgroup="telescope",
+            )
+        )
+        scope_legend_shown = True
+
+        # Aperture end ring (gold)
+        aper_center = tube_start + bore * tube_len
+        traces.append(
+            _disk_mesh(
+                aper_center,
+                bore,
+                outer_r,
+                aperture_r,
+                color=_C_SCOPE_RING,
+                name="Aperture ring",
+                legendgroup="telescope",
+            )
+        )
+
+        # Aperture cover disk (dark, shows the opening)
+        traces.append(
+            _disk_mesh(
+                aper_center,
+                bore,
+                aperture_r,
+                0.0,
+                color="rgb(8, 8, 15)",
+                name="Aperture opening",
+                opacity=0.95,
+                legendgroup="telescope",
+            )
+        )
+
+        # Mid-tube baffle ring for the "space telescope" look
+        mid_center = tube_start + bore * (tube_len * 0.45)
+        traces.append(
+            _disk_mesh(
+                mid_center,
+                bore,
+                outer_r,
+                outer_r * 0.75,
+                color=_C_SCOPE_RING,
+                name="Baffle ring",
+                legendgroup="telescope",
+            )
+        )
+
+        # Secondary mirror housing (small cylinder near aperture)
+        sec_r = aperture_r * 0.25
+        sec_start = aper_center - bore * (tube_len * 0.15)
+        traces.append(
+            _cylinder_mesh(
+                sec_start,
+                bore,
+                sec_r,
+                tube_len * 0.12,
+                color="rgb(80, 85, 100)",
+                name="Secondary",
+                show_legend=False,
+                legendgroup="telescope",
+            )
+        )
+
+        # Boresight arrow
+        if show_normals:
+            bsight_origin = aper_center + bore * 0.05
+            traces.extend(
+                _arrow_traces(
+                    bsight_origin,
+                    bore,
+                    _NORMAL_LEN,
+                    color=_C_BORESIGHT,
+                    name=f"{scope_name} boresight",
+                    legendgroup="tel_normals",
+                    show_legend=True,
+                )
+            )
+
+    # ------------------------------------------------------------------ #
+    # 3. Solar panels                                                      #
+    # ------------------------------------------------------------------ #
+    solar_set = getattr(config, "solar_panel", None)
+    panels = list(getattr(solar_set, "panels", []) or [])
+    panel_legend_shown = False
+    frame_legend_shown = False
+
+    for pidx, panel in enumerate(panels):
+        pname = getattr(panel, "name", f"Panel {pidx + 1}")
+        normal_raw = getattr(panel, "normal", (0.0, 1.0, 0.0))
+        n_vec = _unit(np.asarray(normal_raw, dtype=float))
+        geom = getattr(panel, "geometry", None)
+
+        if geom is not None:
+            # Use explicit PanelGeometry
+            c = np.asarray(geom.center_m, dtype=float)
+            u = _unit(np.asarray(geom.u, dtype=float))
+            v = _unit(np.asarray(geom.v, dtype=float))
+            pw = float(geom.width_m)
+            ph = float(geom.height_m)
+        else:
+            # Place panel on the matching bus face
+            # Panel size estimated from max_power (assume ~150 W/m²)
+            max_pwr = float(getattr(panel, "max_power", 800.0))
+            eff = float(getattr(solar_set, "conversion_efficiency", 0.95))
+            area_est = max_pwr / max(150.0 * eff, 1.0)
+            pw = max(math.sqrt(area_est * 1.6), 0.8)
+            ph = max(math.sqrt(area_est / 1.6), 0.5)
+            c, u, v = _face_placement(n_vec, bus_hd, gap=0.02)
+
+        show_sol = not panel_legend_shown
+        traces.append(
+            _flat_rect_mesh(
+                c,
+                u,
+                v,
+                pw,
+                ph,
+                color=_C_SOLAR,
+                name=pname,
+                show_legend=show_sol,
+                legendgroup="solar_panels",
+            )
+        )
+        panel_legend_shown = True
+
+        # Thin frame border (slightly larger, behind the cell)
+        frame_offset = n_vec * 0.003
+        show_fr = not frame_legend_shown
+        traces.append(
+            _flat_rect_mesh(
+                c - frame_offset,
+                u,
+                v,
+                pw + 0.04,
+                ph + 0.04,
+                color=_C_SOLAR_FRAME,
+                name="Solar panel frame",
+                opacity=0.75,
+                show_legend=show_fr,
+                legendgroup="solar_frames",
+            )
+        )
+        frame_legend_shown = True
+
+        if show_normals:
+            traces.extend(
+                _arrow_traces(
+                    c + n_vec * 0.05,
+                    n_vec,
+                    _NORMAL_LEN,
+                    color=_C_NORMAL,
+                    name=f"{pname} normal",
+                    show_legend=(pidx == 0),
+                    legendgroup="panel_normals",
+                )
+            )
+
+    # ------------------------------------------------------------------ #
+    # 4. Radiators                                                         #
+    # ------------------------------------------------------------------ #
+    rad_cfg = getattr(getattr(config, "spacecraft_bus", None), "radiators", None)
+    radiators = list(getattr(rad_cfg, "radiators", []) or [])
+    rad_legend_shown = False
+
+    for ridx, rad in enumerate(radiators):
+        rname = getattr(rad, "name", f"Radiator {ridx + 1}")
+        orient = getattr(rad, "orientation", None)
+        normal_raw = getattr(orient, "normal", (0.0, 1.0, 0.0))
+        n_vec = _unit(np.asarray(normal_raw, dtype=float))
+        rw = float(getattr(rad, "width_m", 1.0))
+        rh = float(getattr(rad, "height_m", 1.0))
+
+        geom = getattr(rad, "geometry", None)
+        if geom is not None:
+            c = np.asarray(geom.center_m, dtype=float)
+            u = _unit(np.asarray(geom.u, dtype=float))
+            v = _unit(np.asarray(geom.v, dtype=float))
+            rw = float(geom.width_m)
+            rh = float(geom.height_m)
+        else:
+            c, u, v = _face_placement(n_vec, bus_hd, gap=0.005)
+
+        show_r = not rad_legend_shown
+        traces.append(
+            _flat_rect_mesh(
+                c,
+                u,
+                v,
+                rw,
+                rh,
+                color=_C_RADIATOR,
+                name=rname,
+                opacity=0.85,
+                show_legend=show_r,
+                legendgroup="radiators",
+            )
+        )
+        rad_legend_shown = True
+
+        if show_normals:
+            traces.extend(
+                _arrow_traces(
+                    c + n_vec * 0.02,
+                    n_vec,
+                    _NORMAL_LEN * 0.8,
+                    color=_C_NORMAL,
+                    name=f"{rname} normal",
+                    show_legend=(ridx == 0),
+                    legendgroup="rad_normals",
+                )
+            )
+
+    # ------------------------------------------------------------------ #
+    # 5. Star trackers                                                     #
+    # ------------------------------------------------------------------ #
+    st_cfg = getattr(getattr(config, "spacecraft_bus", None), "star_trackers", None)
+    trackers = list(getattr(st_cfg, "star_trackers", []) or [])
+    st_colors = ["orange", "hotpink", "cyan", "limegreen", "gold", "violet"]
+    st_legend_shown = False
+
+    for sidx, st in enumerate(trackers):
+        sname = getattr(st, "name", f"StarTracker {sidx + 1}")
+        orient = getattr(st, "orientation", None)
+        bore_raw = getattr(orient, "boresight", (1.0, 0.0, 0.0))
+        b_vec = _unit(np.asarray(bore_raw, dtype=float))
+        sc = st_colors[sidx % len(st_colors)]
+
+        # Place a small prism (box) on the bus face
+        c, u, v = _face_placement(b_vec, bus_hd, gap=0.0)
+        body_size = 0.12
+
+        # Small square prism sticking out from bus face
+        prism_start = c
+        prism_end = c + b_vec * 0.08
+        traces.append(
+            _flat_rect_mesh(
+                (prism_start + prism_end) / 2,
+                u,
+                v,
+                body_size,
+                body_size,
+                color=_C_ST,
+                name=sname,
+                opacity=0.92,
+                show_legend=not st_legend_shown,
+                legendgroup="star_trackers",
+            )
+        )
+        st_legend_shown = True
+
+        # Front face of the star tracker (in tracker color = lens aperture)
+        traces.append(
+            _flat_rect_mesh(
+                prism_end + b_vec * 0.001,
+                u,
+                v,
+                body_size * 0.6,
+                body_size * 0.6,
+                color=sc,
+                name=sname,
+                opacity=0.80,
+                show_legend=False,
+                legendgroup="star_trackers",
+            )
+        )
+
+        if show_normals:
+            bore_origin = prism_end + b_vec * 0.05
+            traces.extend(
+                _arrow_traces(
+                    bore_origin,
+                    b_vec,
+                    _NORMAL_LEN * 0.9,
+                    color=sc,
+                    name=f"{sname} boresight",
+                    show_legend=(sidx == 0),
+                    legendgroup="st_normals",
+                    line_width=3,
+                )
+            )
+
+    # ------------------------------------------------------------------ #
+    # 6. Spacecraft body-frame coordinate axes                             #
+    # ------------------------------------------------------------------ #
+    if show_axes:
+        origin = np.zeros(3)
+        for direction, color, label in [
+            (np.array([1.0, 0.0, 0.0]), _C_X, "+X (boresight)"),
+            (np.array([0.0, 1.0, 0.0]), _C_Y, "+Y (up)"),
+            (np.array([0.0, 0.0, 1.0]), _C_Z, "+Z"),
+        ]:
+            traces.extend(
+                _arrow_traces(
+                    origin,
+                    direction,
+                    _AXIS_LEN,
+                    color=color,
+                    name=label,
+                    cone_sz=0.09,
+                    legendgroup="axes",
+                    line_width=5,
+                )
+            )
+            label_pos = direction * (_AXIS_LEN + 0.12)
+            traces.append(_axis_label(label_pos, label.split()[0], color))
+
+    # ------------------------------------------------------------------ #
+    # 7. Figure layout                                                     #
+    # ------------------------------------------------------------------ #
+    fig_title = title or f"{bus_name} — 3-D Configuration"
+    fig = go.Figure(data=traces)
+
+    # Compute a sensible axis range
+    scope_reach = hx + 2.5  # telescope extends in +X
+    panel_reach = max(hy + 2.5, hz + 1.5)
+    rng = max(scope_reach, panel_reach, _AXIS_LEN + 0.5)
+
+    fig.update_layout(
+        title=dict(
+            text=fig_title,
+            font=dict(color="white", size=15),
+        ),
+        paper_bgcolor=_BG,
+        plot_bgcolor=_BG,
+        font=dict(color="white"),
+        scene=dict(
+            xaxis=dict(
+                title="X (boresight)",
+                range=[-rng, rng],
+                backgroundcolor=_BG,
+                gridcolor="rgba(80,80,120,0.4)",
+                zerolinecolor="rgba(120,120,160,0.6)",
+                color="rgba(200,200,220,0.8)",
+            ),
+            yaxis=dict(
+                title="Y (up)",
+                range=[-rng, rng],
+                backgroundcolor=_BG,
+                gridcolor="rgba(80,80,120,0.4)",
+                zerolinecolor="rgba(120,120,160,0.6)",
+                color="rgba(200,200,220,0.8)",
+            ),
+            zaxis=dict(
+                title="Z",
+                range=[-rng, rng],
+                backgroundcolor=_BG,
+                gridcolor="rgba(80,80,120,0.4)",
+                zerolinecolor="rgba(120,120,160,0.6)",
+                color="rgba(200,200,220,0.8)",
+            ),
+            bgcolor=_BG,
+            aspectmode="cube",
+            camera=dict(
+                eye=dict(x=1.6, y=0.9, z=0.7),
+                up=dict(x=0, y=1, z=0),
+            ),
+        ),
+        legend=dict(
+            bgcolor="rgba(20,20,40,0.85)",
+            bordercolor="rgba(120,120,170,0.5)",
+            borderwidth=1,
+            font=dict(color="white", size=11),
+            itemsizing="constant",
+        ),
+        margin=dict(l=0, r=0, t=50, b=0),
+        height=700,
+    )
+
+    return fig

--- a/conops/visualization/plotly/spacecraft_3d.py
+++ b/conops/visualization/plotly/spacecraft_3d.py
@@ -11,8 +11,9 @@ Coordinate system (spacecraft body frame)
   +Z  completes the right-handed system
 
 Component placement rules
+Component placement rules
 --------------------------
-  Telescope   – cylinder extending in the boresight direction from the +X bus face.
+  Telescope   – cylinder extending in the boresight direction from the bus surface.
   Solar panels – use ``PanelGeometry.center_m`` when present; otherwise placed
                  on the bus face whose outward normal best matches the panel normal.
   Radiators   – placed on the bus face whose outward normal best matches the
@@ -305,7 +306,7 @@ def _arrow_traces(
         legendgroup=legendgroup,
         sizemode="absolute",
         sizeref=cone_sz,
-        anchor="tail",
+        anchor="tip",
         hoverinfo="name",
     )
     return [line, cone]
@@ -452,11 +453,14 @@ def plot_spacecraft_3d(
         # Outer baffle tube starts at the +X face of the bus
         # (projected along boresight to the face)
         # Approximate: place the tube starting at the bus face in the boresight direction
-        face_offset: float = max(
-            hx * abs(bore[0]), hy * abs(bore[1]), hz * abs(bore[2])
-        )
+        eps = 1e-12
+        t_candidates = [
+            hx / abs(bore[0]) if abs(bore[0]) > eps else math.inf,
+            hy / abs(bore[1]) if abs(bore[1]) > eps else math.inf,
+            hz / abs(bore[2]) if abs(bore[2]) > eps else math.inf,
+        ]
+        face_offset: float = min(t_candidates)
         tube_start = bore * face_offset
-
         outer_r = aperture_r + 0.06  # baffle slightly wider than aperture
         scope_name = getattr(inst, "name", "Telescope")
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -662,8 +662,8 @@ A ``Telescope`` can be placed directly in ``Payload.instruments`` alongside any 
        power_draw=PowerDraw(nominal_power=80.0, peak_power=120.0),
        data_generation=DataGeneration(rate_gbps=0.5),
        optics=TelescopeConfig(
-           aperture_m=0.6,
-           focal_length_m=6.0,             # f_number → 10.0 (auto-derived)
+           aperture_m=0.5,
+           focal_length_m=3.5,             # f_number → 7.0 (auto-derived)
            telescope_type=TelescopeType.RITCHEY_CHRETIEN,
            tube_length_m=1.2,
        ),
@@ -705,9 +705,9 @@ to the ``TelescopeConfig`` fields:
            "power_draw": { "nominal_power": 80.0, "peak_power": 120.0, "power_mode": {} },
            "data_generation": { "rate_gbps": 0.5, "per_observation_gb": 0.0 },
            "optics": {
-             "aperture_m": 0.6,
-             "focal_length_m": 6.0,
-             "f_number": 10.0,
+             "aperture_m": 0.5,
+             "focal_length_m": 3.5,
+             "f_number": 7.0,
              "telescope_type": "Ritchey-Chrétien",
              "tube_length_m": 1.2
            }

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -843,8 +843,8 @@ A ``Telescope`` can be placed directly in ``Payload.instruments`` alongside any 
        power_draw=PowerDraw(nominal_power=80.0, peak_power=120.0),
        data_generation=DataGeneration(rate_gbps=0.5),
        optics=TelescopeConfig(
-           aperture_m=0.6,
-           focal_length_m=6.0,             # f_number → 10.0 (auto-derived)
+           aperture_m=0.5,
+           focal_length_m=3.5,             # f_number → 7.0 (auto-derived)
            telescope_type=TelescopeType.RITCHEY_CHRETIEN,
            tube_length_m=1.2,
        ),
@@ -886,9 +886,9 @@ to the ``TelescopeConfig`` fields:
            "power_draw": { "nominal_power": 80.0, "peak_power": 120.0, "power_mode": {} },
            "data_generation": { "rate_gbps": 0.5, "per_observation_gb": 0.0 },
            "optics": {
-             "aperture_m": 0.6,
-             "focal_length_m": 6.0,
-             "f_number": 10.0,
+             "aperture_m": 0.5,
+             "focal_length_m": 3.5,
+             "f_number": 7.0,
              "telescope_type": "Ritchey-Chrétien",
              "tube_length_m": 1.2
            }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ optimize observation schedules, and validate operational constraints before laun
    examples
    visualization
    sky_pointing_visualization
+   spacecraft_3d_visualization
    communications
    data_management
    fault_management
@@ -49,6 +50,7 @@ Features
 * **DITL Generation**: Comprehensive day-in-the-life timeline simulation
 * **Instantaneous Field of Regard**: Optional computation of accessible sky solid angle at each simulation timestep
 * **Plan Serialisation**: Save and reload observation plans as portable, version-stamped JSON files
+* **3-D Spacecraft Visualizer**: Interactive rotatable 3-D model of the spacecraft from its MissionConfig — bus, telescope, solar panels, radiators, and star trackers with body-frame axes and normal vectors
 
 Quick Example
 -------------

--- a/docs/spacecraft_3d_visualization.rst
+++ b/docs/spacecraft_3d_visualization.rst
@@ -1,0 +1,227 @@
+3-D Spacecraft Configuration Visualizer
+========================================
+
+``plot_spacecraft_3d`` renders an interactive, rotatable 3-D model of a
+spacecraft directly from its :class:`~conops.config.MissionConfig`.  The
+figure is produced with Plotly and can be rotated, zoomed, and panned in
+any browser or Jupyter notebook without running a full DITL simulation.
+
+Features
+--------
+
+* **Spacecraft bus** — lit, solid-shaded box with configurable dimensions.
+* **Telescope assembly** — cylindrical baffle tube with aperture ring, mid-tube
+  baffle rings, and secondary mirror housing.  Sized automatically from
+  ``optics.aperture_m`` and ``optics.tube_length_m``.
+* **Solar panels** — deep-blue solar cell faces on a silver frame.  Uses
+  :class:`~conops.config.geometry.PanelGeometry` when configured, otherwise
+  places panels on the bus face whose outward normal best matches the panel
+  normal vector.  Panel area is estimated from ``max_power``.
+* **Radiators** — white/MLI panels placed on the bus face matching
+  ``orientation.normal``, sized by ``width_m`` × ``height_m``.
+* **Star trackers** — small prism bodies with a coloured aperture face, one
+  per configured tracker.  Each gets a distinct boresight-arrow colour.
+* **Body-frame axes** — +X / +Y / +Z triad with labelled arrows (red, green,
+  blue).
+* **Normal / boresight arrows** — outward-normal arrows for solar panels and
+  radiators; boresight arrows for the telescope and each star tracker.
+
+Coordinate system
+-----------------
+
+All geometry is expressed in the spacecraft body frame:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
+
+   * - Axis
+     - Meaning
+   * - +X
+     - Boresight / telescope pointing direction
+   * - +Y
+     - Spacecraft "up"
+   * - +Z
+     - Completes the right-handed system
+
+Quick start
+-----------
+
+.. code-block:: python
+
+   from conops.config import MissionConfig
+   from conops.visualization import plot_spacecraft_3d
+
+   config = MissionConfig.from_json_file("examples/example_config.json")
+   fig = plot_spacecraft_3d(config)
+   fig.show()
+
+No simulation run is needed — the visualizer reads geometry directly from
+the configuration.
+
+Usage examples
+--------------
+
+Minimal default spacecraft
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   from conops.config import MissionConfig
+   from conops.visualization import plot_spacecraft_3d
+
+   # Default config gives a bus, one solar panel, one radiator, and one star tracker
+   fig = plot_spacecraft_3d(MissionConfig())
+   fig.show()
+
+Custom Ritchey-Chrétien telescope
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   from conops.config import MissionConfig
+   from conops.config.instrument import Telescope, TelescopeConfig, TelescopeType, Payload
+   from conops.config.solar_panel import SolarPanel, SolarPanelSet, create_solar_panel_vector
+   from conops.visualization import plot_spacecraft_3d
+
+   config = MissionConfig(
+       payload=Payload(instruments=[
+           Telescope(
+               name="Primary",
+               boresight=(1.0, 0.0, 0.0),
+               optics=TelescopeConfig(
+                   aperture_m=0.6,
+                   tube_length_m=1.6,
+                   telescope_type=TelescopeType.RITCHEY_CHRETIEN,
+               ),
+           )
+       ]),
+       solar_panel=SolarPanelSet(panels=[
+           SolarPanel(name="Panel +Y", normal=create_solar_panel_vector("sidemount"),         max_power=1200.0),
+           SolarPanel(name="Panel -Y", normal=create_solar_panel_vector("sidemount", cant_z=180.0), max_power=1200.0),
+       ]),
+   )
+
+   fig = plot_spacecraft_3d(config, title="RC Telescope — Dual Wing Config")
+   fig.show()
+
+Overriding the bus box size
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   # bus_half_dims = (half_X, half_Y, half_Z) in metres
+   fig = plot_spacecraft_3d(config, bus_half_dims=(1.2, 0.65, 0.65))
+   fig.show()
+
+Hiding normal vectors or axes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   # Clean view without arrows
+   fig = plot_spacecraft_3d(config, show_normals=False, show_axes=False)
+   fig.show()
+
+Embedding in a Jupyter notebook
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   # The figure is a standard go.Figure — display inline with:
+   fig = plot_spacecraft_3d(config)
+   fig  # Jupyter evaluates this cell and renders the Plotly widget
+
+Saving to HTML
+^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   fig = plot_spacecraft_3d(config)
+   fig.write_html("spacecraft_model.html")
+
+Visual elements reference
+--------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 55
+
+   * - Element
+     - Colour
+     - Source in config
+   * - Spacecraft bus
+     - Silver-gray
+     - ``bus_half_dims`` parameter (default 1.0 × 0.55 × 0.55 m)
+   * - Telescope tube
+     - Dark gunmetal
+     - ``payload.instruments`` (``instrument_type = "Telescope"``)
+   * - Aperture / baffle rings
+     - Gold
+     - ``optics.aperture_m``, ``optics.tube_length_m``
+   * - Solar cell faces
+     - Deep blue
+     - ``solar_panel.panels[*].normal``, ``PanelGeometry``
+   * - Solar panel frames
+     - Silver
+     - Derived from panel geometry
+   * - Radiators
+     - White / MLI
+     - ``spacecraft_bus.radiators.radiators[*]``
+   * - Star tracker body
+     - Dark gray
+     - ``spacecraft_bus.star_trackers.star_trackers[*]``
+   * - Star tracker aperture
+     - Per-tracker colour
+     - One of orange / hotpink / cyan / limegreen / gold / violet
+   * - +X axis
+     - Red
+     - Hard-coded body frame
+   * - +Y axis
+     - Limegreen
+     - Hard-coded body frame
+   * - +Z axis
+     - Dodgerblue
+     - Hard-coded body frame
+   * - Panel / radiator normals
+     - Yellow
+     - ``normal`` / ``orientation.normal``
+   * - Telescope boresight
+     - Cyan
+     - ``boresight``
+   * - Star tracker boresights
+     - Per-tracker colour
+     - ``orientation.boresight``
+
+Panel placement rules
+---------------------
+
+When a :class:`~conops.config.geometry.PanelGeometry` is attached to a solar
+panel or radiator, its ``center_m``, ``u``, ``v``, ``width_m``, and
+``height_m`` fields are used directly.
+
+When no ``PanelGeometry`` is set the visualizer falls back to automatic face
+placement:
+
+1. Dot-product the component normal against the six bus face normals.
+2. Select the face with the largest dot product.
+3. Place the component centre just outside that face (3 mm gap) and orient the
+   panel spanning directions perpendicular to the face normal.
+
+Solar panel size is estimated from ``max_power`` assuming 150 W/m² (solar
+constant × typical conversion efficiency).  Radiator size comes directly from
+``width_m`` and ``height_m``.
+
+API reference
+-------------
+
+.. autofunction:: conops.visualization.plot_spacecraft_3d
+
+See also
+--------
+
+* :doc:`configuration` — all geometric configuration fields in detail.
+* :doc:`visualization` — overview of all COASTSim visualization utilities.
+* :doc:`sky_pointing_visualization` — interactive sky-pointing globe.
+* :py:func:`conops.visualization.plot_sky_pointing_globe` — celestial-sphere
+  globe driven by a completed DITL simulation.

--- a/docs/spacecraft_3d_visualization.rst
+++ b/docs/spacecraft_3d_visualization.rst
@@ -206,7 +206,7 @@ placement:
 
 1. Dot-product the component normal against the six bus face normals.
 2. Select the face with the largest dot product.
-3. Place the component centre just outside that face (3 mm gap) and orient the
+3. Place the component centre just outside that face (gap is component-specific; e.g. 20 mm for solar panels and 5 mm for radiators) and orient the
    panel spanning directions perpendicular to the face normal.
 
 Solar panel size is estimated from ``max_power`` assuming 150 W/m² (solar

--- a/docs/spacecraft_3d_visualization.rst
+++ b/docs/spacecraft_3d_visualization.rst
@@ -90,7 +90,8 @@ Custom Ritchey-Chrétien telescope
                name="Primary",
                boresight=(1.0, 0.0, 0.0),
                optics=TelescopeConfig(
-                   aperture_m=0.6,
+                   aperture_m=0.5,
+                   focal_length_m=3.5,
                    tube_length_m=1.6,
                    telescope_type=TelescopeType.RITCHEY_CHRETIEN,
                ),

--- a/docs/visualization.rst
+++ b/docs/visualization.rst
@@ -35,6 +35,8 @@ The following plotting functions are available under `conops.visualization`:
 - `plot_ditl_timeline()` — timeline with orbit numbers, observations, slews, SAA, and eclipses.
 - `plot_sky_pointing()` — an interactive Mollweide sky projection with current pointing and constraints.
 - `save_sky_pointing_movie()` — export the entire DITL sky pointing visualization as a movie (MP4, AVI, or GIF).
+- `plot_spacecraft_3d()` — rotatable 3-D spacecraft model built directly from a ``MissionConfig`` (no simulation required).
+  See :doc:`spacecraft_3d_visualization` for full details.
 
 Examples and advanced usage
 ---------------------------

--- a/examples/Quick_DITL_Example.ipynb
+++ b/examples/Quick_DITL_Example.ipynb
@@ -35,7 +35,7 @@
     "import numpy as np\n",
     "from rust_ephem import TLEEphemeris\n",
     "\n",
-    "from conops.config.config import MissionConfig\n",
+    "from conops.config import MissionConfig, Telescope, TelescopeConfig, TelescopeType\n",
     "from conops.ditl.queue_ditl import QueueDITL\n",
     "from conops.visualization import plot_ditl_timeline, plot_sky_pointing"
    ]
@@ -58,6 +58,37 @@
    "outputs": [],
    "source": [
     "config = MissionConfig()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0452ee83",
+   "metadata": {},
+   "source": [
+    "## Step 2b: Add a Telescope Instrument\n",
+    "\n",
+    "We add a small f/7, 0.5 m aperture telescope to the payload. The optics block\n",
+    "uses ``aperture_m`` and ``focal_length_m`` to auto-derive the ``f_number``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37f4aa7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config.payload.instruments.append(\n",
+    "    Telescope(\n",
+    "        name=\"Telescope f/7 0.5m\",\n",
+    "        optics=TelescopeConfig(\n",
+    "            aperture_m=0.5,\n",
+    "            focal_length_m=3.5,\n",
+    "            telescope_type=TelescopeType.RITCHEY_CHRETIEN,\n",
+    "            tube_length_m=1.0,\n",
+    "        ),\n",
+    "    )\n",
+    ")"
    ]
   },
   {
@@ -121,9 +152,9 @@
     "from conops.common.enums import ACSMode\n",
     "from conops.config import (\n",
     "    Constraint,\n",
-    "    Radiator,\n",
-    "    RadiatorConfiguration,\n",
-    "    RadiatorOrientation,\n",
+    "    #    Radiator,\n",
+    "    #    RadiatorConfiguration,\n",
+    "    #    RadiatorOrientation,\n",
     "    StarTracker,\n",
     "    StarTrackerConfiguration,\n",
     "    StarTrackerOrientation,\n",
@@ -158,14 +189,6 @@
     "                sun_constraint=SunConstraint(min_angle=20),\n",
     "            ),\n",
     "        ),\n",
-    "        #        StarTracker(\n",
-    "        #            name=\"ST-Port\",\n",
-    "        #            orientation=StarTrackerOrientation(boresight=(0.0, 1.0, 0.0)),\n",
-    "        #            hard_constraint=Constraint(\n",
-    "        #                earth_constraint=EarthLimbConstraint(min_angle=10),\n",
-    "        #                sun_constraint=SunConstraint(min_angle=20),\n",
-    "        #            ),\n",
-    "        #        ),\n",
     "    ],\n",
     "    min_functional_trackers=2,\n",
     "    modes_require_lock=[ACSMode.SCIENCE],\n",
@@ -192,6 +215,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from conops.config.radiator import Radiator, RadiatorConfiguration, RadiatorOrientation\n",
+    "\n",
     "config.spacecraft_bus.radiators = RadiatorConfiguration(\n",
     "    radiators=[\n",
     "        Radiator(\n",
@@ -206,6 +231,18 @@
     "    ]\n",
     ")\n",
     "config.spacecraft_bus.radiators.set_ephem(ephemeris)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "032d8a96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from conops.visualization.plotly.spacecraft_3d import plot_spacecraft_3d\n",
+    "\n",
+    "plot_spacecraft_3d(config)"
    ]
   },
   {
@@ -419,9 +456,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from conops.visualization.mpl.radiator_telemetry import plot_radiator_telemetry\n",
+    "from conops.visualization.plotly.radiator_telemetry import (\n",
+    "    plot_radiator_telemetry_plotly,\n",
+    ")\n",
     "\n",
-    "plot_radiator_telemetry(ditl, figsize=(10, 5))"
+    "plot_radiator_telemetry_plotly(ditl)"
    ]
   },
   {

--- a/examples/Quick_DITL_Example.ipynb
+++ b/examples/Quick_DITL_Example.ipynb
@@ -242,7 +242,7 @@
    "source": [
     "from conops.visualization.plotly.spacecraft_3d import plot_spacecraft_3d\n",
     "\n",
-    "plot_spacecraft_3d(config)"
+    "plot_spacecraft_3d(config, bus_half_dims=(0.1, 0.4, 0.4))"
    ]
   },
   {

--- a/examples/Quick_DITL_Example.ipynb
+++ b/examples/Quick_DITL_Example.ipynb
@@ -35,7 +35,7 @@
     "import numpy as np\n",
     "from rust_ephem import TLEEphemeris\n",
     "\n",
-    "from conops.config.config import MissionConfig\n",
+    "from conops.config import MissionConfig, Telescope, TelescopeConfig, TelescopeType\n",
     "from conops.ditl.queue_ditl import QueueDITL\n",
     "from conops.visualization import plot_ditl_timeline, plot_sky_pointing"
    ]
@@ -58,6 +58,37 @@
    "outputs": [],
    "source": [
     "config = MissionConfig()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0452ee83",
+   "metadata": {},
+   "source": [
+    "## Step 2b: Add a Telescope Instrument\n",
+    "\n",
+    "We add a small f/7, 0.5 m aperture telescope to the payload. The optics block\n",
+    "uses ``aperture_m`` and ``focal_length_m`` to auto-derive the ``f_number``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37f4aa7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config.payload.instruments.append(\n",
+    "    Telescope(\n",
+    "        name=\"Telescope f/7 0.5m\",\n",
+    "        optics=TelescopeConfig(\n",
+    "            aperture_m=0.5,\n",
+    "            focal_length_m=3.5,\n",
+    "            telescope_type=TelescopeType.RITCHEY_CHRETIEN,\n",
+    "            tube_length_m=1.0,\n",
+    "        ),\n",
+    "    )\n",
+    ")"
    ]
   },
   {
@@ -121,9 +152,9 @@
     "from conops.common.enums import ACSMode\n",
     "from conops.config import (\n",
     "    Constraint,\n",
-    "    Radiator,\n",
-    "    RadiatorConfiguration,\n",
-    "    RadiatorOrientation,\n",
+    "    #    Radiator,\n",
+    "    #    RadiatorConfiguration,\n",
+    "    #    RadiatorOrientation,\n",
     "    StarTracker,\n",
     "    StarTrackerConfiguration,\n",
     "    StarTrackerOrientation,\n",
@@ -184,6 +215,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from conops.config.radiator import Radiator, RadiatorConfiguration, RadiatorOrientation\n",
+    "\n",
     "config.spacecraft_bus.radiators = RadiatorConfiguration(\n",
     "    radiators=[\n",
     "        Radiator(\n",
@@ -198,6 +231,18 @@
     "    ]\n",
     ")\n",
     "config.spacecraft_bus.radiators.set_ephem(ephemeris)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "032d8a96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from conops.visualization.plotly.spacecraft_3d import plot_spacecraft_3d\n",
+    "\n",
+    "plot_spacecraft_3d(config)"
    ]
   },
   {
@@ -411,9 +456,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from conops.visualization.mpl.radiator_telemetry import plot_radiator_telemetry\n",
+    "from conops.visualization.plotly.radiator_telemetry import (\n",
+    "    plot_radiator_telemetry_plotly,\n",
+    ")\n",
     "\n",
-    "plot_radiator_telemetry(ditl, figsize=(10, 5))"
+    "plot_radiator_telemetry_plotly(ditl)"
    ]
   },
   {

--- a/examples/Quick_DITL_Example.ipynb
+++ b/examples/Quick_DITL_Example.ipynb
@@ -152,9 +152,6 @@
     "from conops.common.enums import ACSMode\n",
     "from conops.config import (\n",
     "    Constraint,\n",
-    "    #    Radiator,\n",
-    "    #    RadiatorConfiguration,\n",
-    "    #    RadiatorOrientation,\n",
     "    StarTracker,\n",
     "    StarTrackerConfiguration,\n",
     "    StarTrackerOrientation,\n",
@@ -240,7 +237,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from conops.visualization.plotly.spacecraft_3d import plot_spacecraft_3d\n",
+    "from conops.visualization import plot_spacecraft_3d\n",
     "\n",
     "plot_spacecraft_3d(config, bus_half_dims=(0.1, 0.4, 0.4))"
    ]

--- a/tests/instrument/test_telescope_config.py
+++ b/tests/instrument/test_telescope_config.py
@@ -49,6 +49,10 @@ class TestTelescopeConfigFnumber:
         tc = TelescopeConfig(aperture_m=0.5, focal_length_m=5.0)
         assert tc.f_number == pytest.approx(10.0)
 
+    def test_f_number_derived_for_f7_0p5m_aperture(self) -> None:
+        tc = TelescopeConfig(aperture_m=0.5, focal_length_m=3.5)
+        assert tc.f_number == pytest.approx(7.0)
+
     def test_explicit_consistent_f_number_accepted(self) -> None:
         tc = TelescopeConfig(aperture_m=0.5, focal_length_m=5.0, f_number=10.0)
         assert tc.f_number == pytest.approx(10.0)

--- a/tests/instrument/test_telescope_config.py
+++ b/tests/instrument/test_telescope_config.py
@@ -40,6 +40,10 @@ class TestTelescopeConfigFnumber:
         tc = TelescopeConfig(aperture_m=0.5, focal_length_m=5.0)
         assert tc.f_number == pytest.approx(10.0)
 
+    def test_f_number_derived_for_f7_0p5m_aperture(self) -> None:
+        tc = TelescopeConfig(aperture_m=0.5, focal_length_m=3.5)
+        assert tc.f_number == pytest.approx(7.0)
+
     def test_explicit_consistent_f_number_accepted(self) -> None:
         tc = TelescopeConfig(aperture_m=0.5, focal_length_m=5.0, f_number=10.0)
         assert tc.f_number == pytest.approx(10.0)

--- a/tests/visualization/test_spacecraft_3d.py
+++ b/tests/visualization/test_spacecraft_3d.py
@@ -482,6 +482,75 @@ class TestMultiplePanels:
 # ---------------------------------------------------------------------------
 # TestMultipleRadiators
 # ---------------------------------------------------------------------------
+# TestStarTrackerMounting
+# ---------------------------------------------------------------------------
+
+
+class TestStarTrackerMounting:
+    """Star trackers mount on the telescope tube when one is present; otherwise on the bus."""
+
+    @pytest.fixture
+    def config_with_telescope(self) -> MissionConfig:
+        return MissionConfig(
+            payload=Payload(
+                instruments=[
+                    Telescope(
+                        name="OTA",
+                        boresight=(1.0, 0.0, 0.0),
+                        optics=TelescopeConfig(aperture_m=0.5, tube_length_m=1.4),
+                    )
+                ]
+            )
+        )
+
+    def _st_body_mesh(self, fig: go.Figure) -> go.Mesh3d:
+        """Return the first star-tracker body Mesh3d."""
+        meshes = [
+            t for t in fig.data if isinstance(t, go.Mesh3d) and t.name == "StarTracker"
+        ]
+        assert meshes, "no StarTracker body mesh found"
+        return meshes[0]
+
+    def _center(self, mesh: go.Mesh3d) -> tuple[float, float, float]:
+        x = sum(mesh.x) / len(mesh.x)
+        y = sum(mesh.y) / len(mesh.y)
+        z = sum(mesh.z) / len(mesh.z)
+        return x, y, z
+
+    def test_no_telescope_star_tracker_near_bus_face(self) -> None:
+        fig = plot_spacecraft_3d(MissionConfig())
+        cx, cy, cz = self._center(self._st_body_mesh(fig))
+        # Default ST boresight is +X → lands on the +X bus face (half-dim = 1.0)
+        assert 0.9 < cx < 1.2, f"expected ST near +X bus face, got x={cx:.3f}"
+
+    def test_with_telescope_star_tracker_on_tube(
+        self, config_with_telescope: MissionConfig
+    ) -> None:
+        fig = plot_spacecraft_3d(config_with_telescope)
+        cx, cy, cz = self._center(self._st_body_mesh(fig))
+        # Tube starts at x=1.0, length=1.4, 65% along = x≈1.91
+        # ST must be clearly beyond the bus front face (x > 1.3)
+        assert cx > 1.3, f"expected ST on telescope tube (x > 1.3), got x={cx:.3f}"
+
+    def test_with_telescope_star_tracker_outside_baffle(
+        self, config_with_telescope: MissionConfig
+    ) -> None:
+        fig = plot_spacecraft_3d(config_with_telescope)
+        cx, cy, cz = self._center(self._st_body_mesh(fig))
+        # With aperture=0.5 → outer_r = 0.25+0.06 = 0.31; ST must be outside that
+        r_perp = math.sqrt(cy**2 + cz**2)
+        assert r_perp > 0.28, f"expected ST outside baffle radius, got r={r_perp:.3f}"
+
+    def test_with_telescope_trace_count_unchanged(
+        self, config_with_telescope: MissionConfig
+    ) -> None:
+        # Mounting location should not affect trace count
+        n_scope = len(plot_spacecraft_3d(config_with_telescope).data)
+        # default (21) + 7 telescope traces = 28
+        assert n_scope == 28
+
+
+# ---------------------------------------------------------------------------
 
 
 class TestMultipleRadiators:

--- a/tests/visualization/test_spacecraft_3d.py
+++ b/tests/visualization/test_spacecraft_3d.py
@@ -1,0 +1,611 @@
+"""Unit tests for conops.visualization.plotly.spacecraft_3d.
+
+Organised by concern:
+  TestGeometryHelpers       — _unit, _perp_pair, _face_placement
+  TestPlotSpacecraft3dBasic — return type, layout, title, dark theme
+  TestTraceComposition      — Mesh3d / Scatter3d / Cone composition by component
+  TestFlagParameters        — show_normals, show_axes, bus_half_dims, title
+  TestTelescope             — Telescope instrument rendering
+  TestMultiplePanels        — trace count scales with panel count
+  TestMultipleRadiators     — trace count scales with radiator count
+  TestMultipleStarTrackers  — trace count scales with star-tracker count
+  TestRealConfig            — smoke test against examples/example_config.json
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import plotly.graph_objects as go
+import pytest
+
+from conops.config import MissionConfig
+from conops.config.instrument import Payload, Telescope, TelescopeConfig, TelescopeType
+from conops.config.radiator import (
+    Radiator,
+    RadiatorConfiguration,
+    RadiatorOrientation,
+)
+from conops.config.solar_panel import (
+    SolarPanel,
+    SolarPanelSet,
+    create_solar_panel_vector,
+)
+from conops.config.spacecraft_bus import SpacecraftBus
+from conops.config.star_tracker import (
+    StarTracker,
+    StarTrackerConfiguration,
+    StarTrackerOrientation,
+)
+from conops.visualization import plot_spacecraft_3d
+from conops.visualization.plotly.spacecraft_3d import (
+    _face_placement,
+    _perp_pair,
+    _unit,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ZERO = np.zeros(3)
+_BUS_HD = (1.0, 0.55, 0.55)
+
+
+def _trace_types(fig: go.Figure) -> list[str]:
+    return [type(t).__name__ for t in fig.data]
+
+
+def _trace_names(fig: go.Figure) -> list[str]:
+    return [t.name or "" for t in fig.data]
+
+
+def _count_type(fig: go.Figure, cls: type) -> int:
+    return sum(1 for t in fig.data if isinstance(t, cls))
+
+
+def _default_fig() -> go.Figure:
+    return plot_spacecraft_3d(MissionConfig())
+
+
+# ---------------------------------------------------------------------------
+# TestGeometryHelpers
+# ---------------------------------------------------------------------------
+
+
+class TestGeometryHelpers:
+    def test_unit_unit_vector_unchanged(self) -> None:
+        v = np.array([1.0, 0.0, 0.0])
+        result = _unit(v)
+        np.testing.assert_allclose(result, v)
+
+    def test_unit_normalizes_arbitrary_vector(self) -> None:
+        v = np.array([3.0, 4.0, 0.0])
+        result = _unit(v)
+        assert math.isclose(np.linalg.norm(result), 1.0, abs_tol=1e-10)
+
+    def test_unit_zero_vector_returns_zero(self) -> None:
+        result = _unit(np.zeros(3))
+        assert np.linalg.norm(result) == 0.0
+
+    def test_unit_accepts_tuple(self) -> None:
+        result = _unit((0.0, 1.0, 0.0))
+        np.testing.assert_allclose(result, [0.0, 1.0, 0.0])
+
+    def test_perp_pair_both_perpendicular_to_input(self) -> None:
+        for v in [[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 0], [1, 1, 1]]:
+            axis = np.array(v, dtype=float)
+            u, w = _perp_pair(axis)
+            assert abs(float(np.dot(_unit(axis), u))) < 1e-9
+            assert abs(float(np.dot(_unit(axis), w))) < 1e-9
+
+    def test_perp_pair_are_unit_vectors(self) -> None:
+        u, w = _perp_pair(np.array([0.5, 0.5, 0.707]))
+        assert math.isclose(np.linalg.norm(u), 1.0, abs_tol=1e-9)
+        assert math.isclose(np.linalg.norm(w), 1.0, abs_tol=1e-9)
+
+    def test_perp_pair_mutually_perpendicular(self) -> None:
+        u, w = _perp_pair(np.array([0.0, 0.0, 1.0]))
+        assert abs(float(np.dot(u, w))) < 1e-9
+
+    @pytest.mark.parametrize(
+        "normal,expected_axis,expected_sign",
+        [
+            ([1.0, 0.0, 0.0], 0, +1),  # +X face
+            ([-1.0, 0.0, 0.0], 0, -1),  # -X face
+            ([0.0, 1.0, 0.0], 1, +1),  # +Y face
+            ([0.0, -1.0, 0.0], 1, -1),  # -Y face
+            ([0.0, 0.0, 1.0], 2, +1),  # +Z face
+            ([0.0, 0.0, -1.0], 2, -1),  # -Z face
+        ],
+    )
+    def test_face_placement_selects_correct_face(
+        self, normal: list[float], expected_axis: int, expected_sign: int
+    ) -> None:
+        n = np.array(normal, dtype=float)
+        center, u, v = _face_placement(n, _BUS_HD)
+        # The centre should be on the correct side
+        assert np.sign(center[expected_axis]) == expected_sign
+        # The two span vectors should be perpendicular to the normal
+        assert abs(float(np.dot(n, u))) < 1e-9
+        assert abs(float(np.dot(n, v))) < 1e-9
+
+    def test_face_placement_center_outside_bus(self) -> None:
+        """Panel center must lie outside (or on) the bus face."""
+        n = np.array([0.0, 1.0, 0.0])
+        center, _, _ = _face_placement(n, _BUS_HD, gap=0.03)
+        # Y component should be at least hy (0.55) away from origin
+        assert center[1] >= _BUS_HD[1]
+
+    def test_face_placement_off_axis_normal_picks_best_face(self) -> None:
+        """A slightly-tilted +Y normal should still land on the +Y face."""
+        n = np.array([0.1, 0.9, 0.1])
+        center, _, _ = _face_placement(_unit(n), _BUS_HD)
+        assert center[1] > 0  # lands on +Y side
+
+
+# ---------------------------------------------------------------------------
+# TestPlotSpacecraft3dBasic
+# ---------------------------------------------------------------------------
+
+
+class TestPlotSpacecraft3dBasic:
+    def test_returns_go_figure(self) -> None:
+        assert isinstance(_default_fig(), go.Figure)
+
+    def test_has_traces(self) -> None:
+        assert len(_default_fig().data) > 0
+
+    def test_contains_mesh3d_traces(self) -> None:
+        assert _count_type(_default_fig(), go.Mesh3d) > 0
+
+    def test_contains_scatter3d_traces(self) -> None:
+        assert _count_type(_default_fig(), go.Scatter3d) > 0
+
+    def test_contains_cone_traces(self) -> None:
+        assert _count_type(_default_fig(), go.Cone) > 0
+
+    def test_default_title_contains_bus_name(self) -> None:
+        config = MissionConfig()
+        fig = plot_spacecraft_3d(config)
+        assert config.spacecraft_bus.name in fig.layout.title.text
+
+    def test_custom_title_is_used(self) -> None:
+        fig = plot_spacecraft_3d(MissionConfig(), title="My Spacecraft")
+        assert fig.layout.title.text == "My Spacecraft"
+
+    def test_dark_paper_background(self) -> None:
+        fig = _default_fig()
+        assert fig.layout.paper_bgcolor.startswith("rgb(")
+        # All three channels should be very dark (< 50)
+        channels = [int(c) for c in fig.layout.paper_bgcolor[4:-1].split(",")]
+        assert all(c < 50 for c in channels)
+
+    def test_scene_aspect_is_cube(self) -> None:
+        assert _default_fig().layout.scene.aspectmode == "cube"
+
+    def test_scene_has_labelled_axes(self) -> None:
+        scene = _default_fig().layout.scene
+        # Plotly wraps title in a Title object; coerce to str for portability
+        assert "X" in str(scene.xaxis.title)
+        assert "Y" in str(scene.yaxis.title)
+        assert "Z" in str(scene.zaxis.title)
+
+    def test_figure_height_set(self) -> None:
+        assert _default_fig().layout.height > 0
+
+    def test_legend_is_configured(self) -> None:
+        legend = _default_fig().layout.legend
+        assert legend is not None
+
+
+# ---------------------------------------------------------------------------
+# TestTraceComposition  — what the default config produces
+# ---------------------------------------------------------------------------
+
+
+class TestTraceComposition:
+    """Default MissionConfig gives: 1 bus + 1 panel + 1 frame + 2 panel arrows
+    + 1 radiator + 2 radiator arrows + 1 ST + 1 ST aperture + 2 ST arrows
+    + 3 axes × 3 = 21 traces total."""
+
+    _EXPECTED_DEFAULT = 21
+
+    def test_default_config_trace_count(self) -> None:
+        assert len(_default_fig().data) == self._EXPECTED_DEFAULT
+
+    def test_bus_mesh_present(self) -> None:
+        names = _trace_names(_default_fig())
+        # The bus name comes from spacecraft_bus.name
+        assert any(MissionConfig().spacecraft_bus.name in n for n in names)
+
+    def test_bus_is_mesh3d(self) -> None:
+        fig = _default_fig()
+        bus_name = MissionConfig().spacecraft_bus.name
+        bus_traces = [t for t in fig.data if t.name == bus_name]
+        assert len(bus_traces) == 1
+        assert isinstance(bus_traces[0], go.Mesh3d)
+
+    def test_solar_panel_mesh_present(self) -> None:
+        panel_name = MissionConfig().solar_panel.panels[0].name
+        names = _trace_names(_default_fig())
+        assert any(panel_name in n for n in names)
+
+    def test_solar_frame_mesh_present(self) -> None:
+        names = _trace_names(_default_fig())
+        assert any("Solar panel frame" in n for n in names)
+
+    def test_axes_scatter3d_lines_present(self) -> None:
+        # Three axis shafts: +X, +Y, +Z
+        axis_lines = [
+            t
+            for t in _default_fig().data
+            if isinstance(t, go.Scatter3d)
+            and t.name in ("+X (boresight)", "+Y (up)", "+Z")
+        ]
+        assert len(axis_lines) == 3
+
+    def test_axes_cone_traces_present(self) -> None:
+        axis_cones = [
+            t
+            for t in _default_fig().data
+            if isinstance(t, go.Cone) and t.name in ("+X (boresight)", "+Y (up)", "+Z")
+        ]
+        assert len(axis_cones) == 3
+
+    def test_normal_arrows_present_by_default(self) -> None:
+        # At least panel normal + radiator normal + ST boresight
+        arrow_traces = [
+            t
+            for t in _default_fig().data
+            if isinstance(t, (go.Scatter3d, go.Cone)) and "normal" in (t.name or "")
+        ]
+        assert len(arrow_traces) >= 2
+
+
+# ---------------------------------------------------------------------------
+# TestFlagParameters
+# ---------------------------------------------------------------------------
+
+
+class TestFlagParameters:
+    def test_show_normals_false_removes_normal_arrows(self) -> None:
+        fig = plot_spacecraft_3d(MissionConfig(), show_normals=False)
+        names = _trace_names(fig)
+        assert not any("normal" in n.lower() for n in names)
+        # Component boresight arrows (e.g. "ST-1 boresight") should be gone.
+        # The axis label "+X (boresight)" is still present when show_axes=True,
+        # so we check the trace legendgroup instead of the name.
+        component_boresight = [
+            t
+            for t in fig.data
+            if "boresight" in (t.name or "").lower()
+            and getattr(t, "legendgroup", None) not in ("axes", None)
+        ]
+        assert len(component_boresight) == 0
+
+    def test_show_normals_false_fewer_traces(self) -> None:
+        n_with = len(_default_fig().data)
+        n_without = len(plot_spacecraft_3d(MissionConfig(), show_normals=False).data)
+        assert n_without < n_with
+
+    def test_show_axes_false_removes_axis_traces(self) -> None:
+        fig = plot_spacecraft_3d(MissionConfig(), show_axes=False)
+        names = _trace_names(fig)
+        assert not any(n in names for n in ("+X (boresight)", "+Y (up)", "+Z"))
+
+    def test_show_axes_false_removes_nine_traces(self) -> None:
+        # Default has 9 axis traces (3 line + 3 cone + 3 text labels)
+        n_with = len(_default_fig().data)
+        n_without = len(plot_spacecraft_3d(MissionConfig(), show_axes=False).data)
+        assert n_with - n_without == 9
+
+    def test_both_flags_false_minimum_traces(self) -> None:
+        fig = plot_spacecraft_3d(MissionConfig(), show_normals=False, show_axes=False)
+        # Bus + solar panel + frame + radiator + 2 ST meshes = 6
+        assert len(fig.data) == 6
+
+    def test_custom_bus_half_dims_affects_axis_range(self) -> None:
+        fig_small = plot_spacecraft_3d(MissionConfig(), bus_half_dims=(0.5, 0.3, 0.3))
+        fig_large = plot_spacecraft_3d(MissionConfig(), bus_half_dims=(2.0, 1.0, 1.0))
+        x_range_small = fig_small.layout.scene.xaxis.range
+        x_range_large = fig_large.layout.scene.xaxis.range
+        assert x_range_large[1] > x_range_small[1]
+
+    def test_custom_bus_half_dims_does_not_break_render(self) -> None:
+        for dims in [(0.3, 0.2, 0.2), (1.0, 0.55, 0.55), (3.0, 1.5, 1.5)]:
+            fig = plot_spacecraft_3d(MissionConfig(), bus_half_dims=dims)
+            assert len(fig.data) > 0
+
+
+# ---------------------------------------------------------------------------
+# TestTelescope
+# ---------------------------------------------------------------------------
+
+
+class TestTelescope:
+    @pytest.fixture
+    def telescope_config(self) -> MissionConfig:
+        return MissionConfig(
+            payload=Payload(
+                instruments=[
+                    Telescope(
+                        name="PrimTel",
+                        boresight=(1.0, 0.0, 0.0),
+                        optics=TelescopeConfig(
+                            aperture_m=0.5,
+                            tube_length_m=1.4,
+                            telescope_type=TelescopeType.RITCHEY_CHRETIEN,
+                        ),
+                    )
+                ]
+            )
+        )
+
+    def test_telescope_tube_present(self, telescope_config: MissionConfig) -> None:
+        fig = plot_spacecraft_3d(telescope_config)
+        names = _trace_names(fig)
+        assert "PrimTel" in names
+
+    def test_telescope_adds_aperture_ring(
+        self, telescope_config: MissionConfig
+    ) -> None:
+        names = _trace_names(plot_spacecraft_3d(telescope_config))
+        assert "Aperture ring" in names
+
+    def test_telescope_adds_aperture_opening(
+        self, telescope_config: MissionConfig
+    ) -> None:
+        names = _trace_names(plot_spacecraft_3d(telescope_config))
+        assert "Aperture opening" in names
+
+    def test_telescope_adds_baffle_ring(self, telescope_config: MissionConfig) -> None:
+        names = _trace_names(plot_spacecraft_3d(telescope_config))
+        assert "Baffle ring" in names
+
+    def test_telescope_adds_secondary(self, telescope_config: MissionConfig) -> None:
+        names = _trace_names(plot_spacecraft_3d(telescope_config))
+        assert "Secondary" in names
+
+    def test_telescope_boresight_arrow_present(
+        self, telescope_config: MissionConfig
+    ) -> None:
+        names = _trace_names(plot_spacecraft_3d(telescope_config))
+        assert any("boresight" in n.lower() for n in names)
+
+    def test_telescope_adds_seven_traces(self, telescope_config: MissionConfig) -> None:
+        # tube + aperture ring + aperture opening + baffle ring + secondary
+        # + boresight Scatter3d + boresight Cone = 7 traces
+        default_count = len(_default_fig().data)
+        scope_count = len(plot_spacecraft_3d(telescope_config).data)
+        assert scope_count - default_count == 7
+
+    def test_non_boresight_telescope_still_renders(self) -> None:
+        config = MissionConfig(
+            payload=Payload(
+                instruments=[
+                    Telescope(
+                        name="SideScope",
+                        boresight=(0.0, 1.0, 0.0),
+                        optics=TelescopeConfig(aperture_m=0.3),
+                    )
+                ]
+            )
+        )
+        fig = plot_spacecraft_3d(config)
+        assert any("SideScope" in (t.name or "") for t in fig.data)
+
+    def test_telescope_tube_is_mesh3d(self, telescope_config: MissionConfig) -> None:
+        fig = plot_spacecraft_3d(telescope_config)
+        tube_traces = [t for t in fig.data if t.name == "PrimTel"]
+        assert len(tube_traces) == 1
+        assert isinstance(tube_traces[0], go.Mesh3d)
+
+    def test_show_normals_false_removes_telescope_boresight(
+        self, telescope_config: MissionConfig
+    ) -> None:
+        fig = plot_spacecraft_3d(telescope_config, show_normals=False)
+        component_boresight = [
+            t
+            for t in fig.data
+            if "boresight" in (t.name or "").lower()
+            and getattr(t, "legendgroup", None) not in ("axes", None)
+        ]
+        assert len(component_boresight) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestMultiplePanels
+# ---------------------------------------------------------------------------
+
+
+class TestMultiplePanels:
+    def _config_with_n_panels(self, n: int) -> MissionConfig:
+        panels = [
+            SolarPanel(
+                name=f"Panel-{i}",
+                normal=create_solar_panel_vector("sidemount", cant_z=i * (360.0 / n)),
+                max_power=800.0,
+            )
+            for i in range(n)
+        ]
+        return MissionConfig(solar_panel=SolarPanelSet(panels=panels))
+
+    def test_one_panel_base_count(self) -> None:
+        fig = plot_spacecraft_3d(self._config_with_n_panels(1))
+        # Only the cell Mesh3d uses the exact panel name; arrows are "Panel-0 normal"
+        panel_meshes = [
+            t for t in fig.data if isinstance(t, go.Mesh3d) and t.name == "Panel-0"
+        ]
+        assert len(panel_meshes) == 1
+
+    def test_two_panels_adds_four_more_traces(self) -> None:
+        n1 = len(plot_spacecraft_3d(self._config_with_n_panels(1)).data)
+        n2 = len(plot_spacecraft_3d(self._config_with_n_panels(2)).data)
+        # Each additional panel: 1 cell + 1 frame + 2 arrows = 4 traces
+        assert n2 - n1 == 4
+
+    def test_four_panels_trace_count(self) -> None:
+        n1 = len(plot_spacecraft_3d(self._config_with_n_panels(1)).data)
+        n4 = len(plot_spacecraft_3d(self._config_with_n_panels(4)).data)
+        assert n4 - n1 == 3 * 4  # three extra panels × 4 traces each
+
+    def test_panel_with_geometry_uses_geometry_center(self) -> None:
+        from conops.config.geometry import PanelGeometry
+
+        panel_with_geom = SolarPanel(
+            name="GeomPanel",
+            normal=(0.0, 1.0, 0.0),
+            max_power=500.0,
+            geometry=PanelGeometry(
+                center_m=(0.5, 1.0, 0.0),
+                u=(1.0, 0.0, 0.0),
+                v=(0.0, 0.0, 1.0),
+                width_m=1.5,
+                height_m=0.8,
+            ),
+        )
+        config = MissionConfig(solar_panel=SolarPanelSet(panels=[panel_with_geom]))
+        fig = plot_spacecraft_3d(config)
+        # Panel mesh should be roughly centred at (0.5, 1.0, 0.0)
+        cell_traces = [
+            t for t in fig.data if t.name == "GeomPanel" and isinstance(t, go.Mesh3d)
+        ]
+        assert len(cell_traces) == 1
+        x_vals = list(cell_traces[0].x)
+        y_vals = list(cell_traces[0].y)
+        assert math.isclose(sum(x_vals) / len(x_vals), 0.5, abs_tol=0.01)
+        assert math.isclose(sum(y_vals) / len(y_vals), 1.0, abs_tol=0.01)
+
+
+# ---------------------------------------------------------------------------
+# TestMultipleRadiators
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleRadiators:
+    def _config_with_n_radiators(self, n: int) -> MissionConfig:
+        normals = [
+            (0.0, 1.0, 0.0),
+            (0.0, -1.0, 0.0),
+            (0.0, 0.0, 1.0),
+            (0.0, 0.0, -1.0),
+        ]
+        rads = [
+            Radiator(
+                name=f"Rad-{i}",
+                width_m=0.8,
+                height_m=0.6,
+                orientation=RadiatorOrientation(normal=normals[i % len(normals)]),
+            )
+            for i in range(n)
+        ]
+        bus = SpacecraftBus(radiators=RadiatorConfiguration(radiators=rads))
+        return MissionConfig(spacecraft_bus=bus)
+
+    def test_one_radiator_base(self) -> None:
+        fig = plot_spacecraft_3d(self._config_with_n_radiators(1))
+        # The Mesh3d uses the exact radiator name; arrows are "Rad-0 normal"
+        rad_meshes = [
+            t for t in fig.data if isinstance(t, go.Mesh3d) and t.name == "Rad-0"
+        ]
+        assert len(rad_meshes) == 1
+
+    def test_two_radiators_adds_three_traces(self) -> None:
+        # Each radiator: 1 mesh + 2 arrows = 3 traces
+        n1 = len(plot_spacecraft_3d(self._config_with_n_radiators(1)).data)
+        n2 = len(plot_spacecraft_3d(self._config_with_n_radiators(2)).data)
+        assert n2 - n1 == 3
+
+    def test_no_radiators_still_renders(self) -> None:
+        bus = SpacecraftBus(radiators=RadiatorConfiguration(radiators=[]))
+        config = MissionConfig(spacecraft_bus=bus)
+        fig = plot_spacecraft_3d(config)
+        assert isinstance(fig, go.Figure)
+
+
+# ---------------------------------------------------------------------------
+# TestMultipleStarTrackers
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleStarTrackers:
+    def _config_with_n_trackers(self, n: int) -> MissionConfig:
+        boresights = [
+            (0.0, 1.0, 0.0),
+            (0.0, -1.0, 0.0),
+            (0.0, 0.0, 1.0),
+            (0.0, 0.0, -1.0),
+        ]
+        trackers = [
+            StarTracker(
+                name=f"ST-{i}",
+                orientation=StarTrackerOrientation(
+                    boresight=boresights[i % len(boresights)]
+                ),
+            )
+            for i in range(n)
+        ]
+        bus = SpacecraftBus(
+            star_trackers=StarTrackerConfiguration(star_trackers=trackers)
+        )
+        return MissionConfig(spacecraft_bus=bus)
+
+    def test_one_tracker_base(self) -> None:
+        fig = plot_spacecraft_3d(self._config_with_n_trackers(1))
+        st_traces = [t for t in fig.data if "ST-0" in (t.name or "")]
+        assert len(st_traces) >= 1
+
+    def test_two_trackers_adds_four_traces(self) -> None:
+        # Each tracker: 2 meshes + 2 arrows = 4 traces
+        n1 = len(plot_spacecraft_3d(self._config_with_n_trackers(1)).data)
+        n2 = len(plot_spacecraft_3d(self._config_with_n_trackers(2)).data)
+        assert n2 - n1 == 4
+
+    def test_each_tracker_gets_distinct_boresight_color(self) -> None:
+        fig = plot_spacecraft_3d(self._config_with_n_trackers(2))
+        # Exclude the "+X (boresight)" axis cone (legendgroup="axes")
+        bore_cones = [
+            t
+            for t in fig.data
+            if isinstance(t, go.Cone)
+            and "boresight" in (t.name or "").lower()
+            and getattr(t, "legendgroup", None) != "axes"
+        ]
+        assert len(bore_cones) == 2
+        colors = [t.colorscale[0][1] for t in bore_cones]
+        assert colors[0] != colors[1]
+
+    def test_no_star_trackers_still_renders(self) -> None:
+        bus = SpacecraftBus(star_trackers=StarTrackerConfiguration(star_trackers=[]))
+        config = MissionConfig(spacecraft_bus=bus)
+        fig = plot_spacecraft_3d(config)
+        assert isinstance(fig, go.Figure)
+
+
+# ---------------------------------------------------------------------------
+# TestRealConfig — integration smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestRealConfig:
+    def test_example_json_config(self) -> None:
+        config = MissionConfig.from_json_file("examples/example_config.json")
+        fig = plot_spacecraft_3d(config)
+        assert isinstance(fig, go.Figure)
+        assert len(fig.data) > 0
+
+    def test_example_json_title_uses_bus_name(self) -> None:
+        config = MissionConfig.from_json_file("examples/example_config.json")
+        fig = plot_spacecraft_3d(config)
+        assert config.spacecraft_bus.name in fig.layout.title.text
+
+    def test_example_json_expected_trace_count(self) -> None:
+        config = MissionConfig.from_json_file("examples/example_config.json")
+        fig = plot_spacecraft_3d(config)
+        # 1 bus + 1 panel + 1 frame + 2 panel arrows
+        # + 1 radiator + 2 rad arrows
+        # + 2 ST × (2 mesh + 2 arrows)
+        # + 9 axes = 25
+        assert len(fig.data) == 25

--- a/tests/visualization/test_spacecraft_3d.py
+++ b/tests/visualization/test_spacecraft_3d.py
@@ -414,6 +414,32 @@ class TestTelescope:
         ]
         assert len(component_boresight) == 0
 
+    def test_telescope_no_optics_uses_default_aperture(self) -> None:
+        config = MissionConfig(
+            payload=Payload(
+                instruments=[Telescope(name="BareScope", boresight=(1.0, 0.0, 0.0))]
+            )
+        )
+        fig = plot_spacecraft_3d(config)
+        assert any("BareScope" in (t.name or "") for t in fig.data)
+
+    def test_telescope_optics_no_aperture_uses_default_aperture(self) -> None:
+        from conops.config.instrument import TelescopeConfig
+
+        config = MissionConfig(
+            payload=Payload(
+                instruments=[
+                    Telescope(
+                        name="NoAperScope",
+                        boresight=(1.0, 0.0, 0.0),
+                        optics=TelescopeConfig(focal_length_m=3.5),
+                    )
+                ]
+            )
+        )
+        fig = plot_spacecraft_3d(config)
+        assert any("NoAperScope" in (t.name or "") for t in fig.data)
+
 
 # ---------------------------------------------------------------------------
 # TestMultiplePanels


### PR DESCRIPTION
This pull request introduces a new 3-D spacecraft visualization feature and updates documentation, examples, and tests to support and demonstrate this capability. It also updates telescope configuration examples to use a 0.5 m aperture, f/7 Ritchey-Chrétien telescope, ensuring consistency across code, documentation, and tests.

**3-D Spacecraft Visualization Feature:**

* Added `plot_spacecraft_3d` function to the `conops.visualization` and `conops.visualization.plotly` modules, enabling interactive 3-D visualization of spacecraft configurations directly from `MissionConfig`. This feature is documented in a new `spacecraft_3d_visualization.rst` file and referenced throughout the documentation. [[1]](diffhunk://#diff-8717b552158dc40f03122f5e0e8b0914ba5eadb0bcc896ab675bf61457e934d3R25) [[2]](diffhunk://#diff-8717b552158dc40f03122f5e0e8b0914ba5eadb0bcc896ab675bf61457e934d3R46) [[3]](diffhunk://#diff-7aa71c3a5fe6f6799bb93758f386adeca0200b0b23b0d570e2ace6f6b95335fdR18) [[4]](diffhunk://#diff-7aa71c3a5fe6f6799bb93758f386adeca0200b0b23b0d570e2ace6f6b95335fdR30) [[5]](diffhunk://#diff-7df901fd54053c147fac1be3bee53d0d301b7f87655a7f098d2be1855ed4a4f9R1-R227) [[6]](diffhunk://#diff-c70ab5d5c341587441f8f4fa5547082bce2998728b91e644785214ab64add5d7R38-R39) [[7]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R22) [[8]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R53)

* Added usage examples for the new 3-D visualizer in the documentation and the `Quick_DITL_Example.ipynb` notebook, including how to add a telescope instrument and visualize the spacecraft. [[1]](diffhunk://#diff-9e85a3738ba4d2316c448615f79ca01a9ac148e6372ddc7aa777f1eccdaa05f8R63-R93) [[2]](diffhunk://#diff-9e85a3738ba4d2316c448615f79ca01a9ac148e6372ddc7aa777f1eccdaa05f8R236-R247)

**Telescope Configuration Updates:**

* Updated telescope configuration examples and documentation to use a 0.5 m aperture, 3.5 m focal length (f/7) Ritchey-Chrétien telescope, replacing the previous 0.6 m, f/10 example. This change is reflected in code comments, docstrings, and configuration documentation. [[1]](diffhunk://#diff-c176d62b267540e370ed8d5e9aff78f945a3cedbb1eaa5fbf12f3ea87a21f0c4L183-R190) [[2]](diffhunk://#diff-68a31565c7f34fbe6ac80bbc0b4287ee3711fa615ce5b973c1f83f285d0d28faL665-R666) [[3]](diffhunk://#diff-68a31565c7f34fbe6ac80bbc0b4287ee3711fa615ce5b973c1f83f285d0d28faL708-R710) [[4]](diffhunk://#diff-9e85a3738ba4d2316c448615f79ca01a9ac148e6372ddc7aa777f1eccdaa05f8R63-R93)

**Documentation Improvements:**

* Added a dedicated documentation page for the 3-D visualizer, updated the index and visualization overview to highlight the new feature, and provided detailed usage instructions and API reference. [[1]](diffhunk://#diff-7df901fd54053c147fac1be3bee53d0d301b7f87655a7f098d2be1855ed4a4f9R1-R227) [[2]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R22) [[3]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R53) [[4]](diffhunk://#diff-c70ab5d5c341587441f8f4fa5547082bce2998728b91e644785214ab64add5d7R38-R39)

**Example and Test Enhancements:**

* Improved the `Quick_DITL_Example.ipynb` notebook to demonstrate adding a telescope, configuring radiators, and using the new 3-D visualization. Updated imports and plotting functions to use the new and updated features. [[1]](diffhunk://#diff-9e85a3738ba4d2316c448615f79ca01a9ac148e6372ddc7aa777f1eccdaa05f8L38-R38) [[2]](diffhunk://#diff-9e85a3738ba4d2316c448615f79ca01a9ac148e6372ddc7aa777f1eccdaa05f8L124-R157) [[3]](diffhunk://#diff-9e85a3738ba4d2316c448615f79ca01a9ac148e6372ddc7aa777f1eccdaa05f8L161-L168) [[4]](diffhunk://#diff-9e85a3738ba4d2316c448615f79ca01a9ac148e6372ddc7aa777f1eccdaa05f8R218-R219) [[5]](diffhunk://#diff-9e85a3738ba4d2316c448615f79ca01a9ac148e6372ddc7aa777f1eccdaa05f8L422-R463)

* Added a new test to verify that `TelescopeConfig` correctly derives the f-number for a 0.5 m aperture, 3.5 m focal length telescope.