### PR TITLE
fix(roll): fix bug where roll angle was changing during observation

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -958,7 +958,10 @@ class QueueDITL(DITLMixin, DITLStats):
             self.ppt.done = True
 
         self.ppt = None
-        self.acs.last_slew = None
+        # Do NOT clear last_slew here. The spacecraft is physically still pointing
+        # at the science target; clearing last_slew would cause pointing() to call
+        # optimum_roll() and jump the roll on the next tick. Roll stays locked to
+        # last_slew.endroll until the next executed slew replaces last_slew.
 
     def _get_constraint_name(
         self,
@@ -1129,6 +1132,40 @@ class QueueDITL(DITLMixin, DITLStats):
             )
             self.ppt.roll = slew.endroll
             slew.calc_slewtime()
+
+            # Validate that the locked roll satisfies constraints for at least
+            # ss_min seconds after slew completion.  The ACS holds roll constant
+            # during observations, so a roll that is immediately constrained
+            # would cause the observation to be terminated before any science
+            # is collected.  Skip the target now rather than wasting a slew.
+            obs_start_time = execution_time + slew.slewtime
+            obs_val_end = obs_start_time + self.ppt.ss_min
+            ephem = self.acs.ephem
+            begin_idx = ephem.index(dtutcfromtimestamp(obs_start_time))
+            end_idx = ephem.index(dtutcfromtimestamp(obs_val_end)) + 1
+            for t in ephem.timestamp[begin_idx:end_idx]:
+                t_unix = t.timestamp() if hasattr(t, "timestamp") else float(t)
+                if self.constraint.in_constraint(
+                    self.ppt.ra,
+                    self.ppt.dec,
+                    t_unix,
+                    target_roll=slew.endroll,
+                    acs_mode=ACSMode.SCIENCE,
+                ):
+                    self.log.log_event(
+                        utime=utime,
+                        event_type="QUEUE",
+                        description=(
+                            f"Target {self.ppt.obsid} skipped — locked roll "
+                            f"{slew.endroll:.1f}° violates constraint "
+                            f"within minimum observation window (at t+{t_unix - obs_start_time:.0f}s)"
+                        ),
+                        obsid=self.ppt.obsid,
+                        acs_mode=self.acs.acsmode,
+                    )
+                    self.ppt = None
+                    self._ppt_unavailable = True
+                    return
 
             # Verify slew won't overlap with a pass - check both start and end
             slew_end = execution_time + slew.slewtime

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1139,10 +1139,17 @@ class QueueDITL(DITLMixin, DITLStats):
             # would cause the observation to be terminated before any science
             # is collected.  Skip the target now rather than wasting a slew.
             obs_start_time = execution_time + slew.slewtime
-            obs_val_end = obs_start_time + self.ppt.ss_min
             ephem = self.acs.ephem
-            begin_idx = ephem.index(dtutcfromtimestamp(obs_start_time))
-            end_idx = ephem.index(dtutcfromtimestamp(obs_val_end)) + 1
+            ephem_end = (
+                ephem.timestamp[-1].timestamp()
+                if hasattr(ephem.timestamp[-1], "timestamp")
+                else float(ephem.timestamp[-1])
+            )
+            obs_val_end = min(obs_start_time + self.ppt.ss_min, ephem_end)
+            begin_idx = max(0, ephem.index(dtutcfromtimestamp(obs_start_time)))
+            end_idx = min(
+                len(ephem.timestamp), ephem.index(dtutcfromtimestamp(obs_val_end)) + 1
+            )
             for t in ephem.timestamp[begin_idx:end_idx]:
                 t_unix = t.timestamp() if hasattr(t, "timestamp") else float(t)
                 if self.constraint.in_constraint(

--- a/conops/schedulers/scheduler.py
+++ b/conops/schedulers/scheduler.py
@@ -5,6 +5,7 @@ import rust_ephem
 
 from ..common import dtutcfromtimestamp
 from ..config import MissionConfig
+from ..simulation.roll import optimum_roll
 from ..simulation.saa import SAA
 from ..targets import Plan, PlanEntry, TargetList
 
@@ -94,11 +95,27 @@ class DumbScheduler:
                 obs_start = current_time
                 obs_end = current_time + task.exptime + slewtime
 
+                # Compute the roll that will be locked for this observation.
+                # The ACS computes optimum_roll at the slew execution time and
+                # then holds it constant throughout the observation; replicate
+                # that here so the scheduler validates the same fixed roll.
+                solar_panel = (
+                    self.config.solar_panel if self.config is not None else None
+                )
+                obs_roll = optimum_roll(
+                    task.ra,
+                    task.dec,
+                    obs_start,
+                    self.ephem,
+                    solar_panel,
+                    self.constraint,
+                )
+
                 # Get ephemeris time indices for observation window
                 begin_idx = self.ephem.index(dtutcfromtimestamp(obs_start))
                 end_idx = self.ephem.index(dtutcfromtimestamp(obs_end)) + 1
 
-                # Evaluate constraints at each timestep in the observation window
+                # Evaluate constraints at each timestep using the fixed roll.
                 time_window = self.ephem.timestamp[begin_idx:end_idx]
 
                 in_occult = [
@@ -106,7 +123,7 @@ class DumbScheduler:
                         ra=task.ra,
                         dec=task.dec,
                         utime=t.timestamp(),
-                        target_roll=getattr(task, "roll", None),
+                        target_roll=obs_roll,
                     )
                     for t in time_window
                 ]

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -506,49 +506,8 @@ class ACS:
         # Calculate current RA/Dec pointing
         self._calculate_pointing(utime)
 
-        # Calculate roll angle.
-        # NOTE: Must run after _calculate_pointing so self.ra/dec are current.
-        #
-        # Roll is locked to the value computed at scheduling time (slew.endroll)
-        # once the spacecraft has settled at a science pointing.  Tracking the
-        # solar-optimal roll during an observation is physically unrealistic and
-        # would violate constraints that were validated at scheduling time.
-        #
-        # Exceptions:
-        #   - Actively slewing: interpolate roll along the pre-computed SLERP path.
-        #   - Emergency charging / safe mode: continuously track the solar-optimal
-        #     roll so that power generation is maximised as the Sun moves.
-        #   - No executed slew yet (slewstart == 0, initial boundary condition):
-        #     compute optimal roll as a reasonable starting condition.
-        if self._is_actively_slewing(utime) and self.current_slew is not None:
-            self.roll = self.current_slew.slew_roll(utime)
-        elif self._is_in_charging_mode(utime) or self.in_safe_mode:
-            self.roll = optimum_roll(
-                self.ra,
-                self.dec,
-                utime,
-                self.ephem,
-                self.solar_panel,
-                self.constraint,
-            )
-        elif (
-            self.last_slew is not None
-            and isinstance(self.last_slew, Slew)
-            and getattr(self.last_slew, "slewstart", 0) > 0
-            and hasattr(self.last_slew, "endroll")
-        ):
-            # Settled at a pointing after a real slew: lock roll to endroll.
-            self.roll = self.last_slew.endroll
-        else:
-            # Initial state before any slew has executed: use optimal roll.
-            self.roll = optimum_roll(
-                self.ra,
-                self.dec,
-                utime,
-                self.ephem,
-                self.solar_panel,
-                self.constraint,
-            )
+        # Calculate roll angle (must run after _calculate_pointing so ra/dec are current).
+        self.roll = self._compute_roll(utime)
 
         # Check current constraints (must run after roll is updated)
         self._check_constraints(utime)
@@ -603,6 +562,32 @@ class ACS:
     def _is_actively_slewing(self, utime: float) -> bool:
         """Check if spacecraft is currently executing a slew."""
         return self.current_slew is not None and self.current_slew.is_slewing(utime)
+
+    def _compute_roll(self, utime: float) -> float:
+        """Return the roll angle for the current timestep.
+
+        - During a slew: interpolate along the SLERP path.
+        - Charging / safe mode: track solar-optimal roll continuously.
+        - Settled at a science pointing: lock to the roll computed at scheduling
+          time (slew.endroll) so constraints validated by the scheduler hold.
+        - Initial boundary condition (no real slew yet): use optimal roll.
+        """
+        if self._is_actively_slewing(utime) and self.current_slew is not None:
+            return self.current_slew.slew_roll(utime)
+        if self._is_in_charging_mode(utime) or self.in_safe_mode:
+            return optimum_roll(
+                self.ra, self.dec, utime, self.ephem, self.solar_panel, self.constraint
+            )
+        if (
+            self.last_slew is not None
+            and isinstance(self.last_slew, Slew)
+            and getattr(self.last_slew, "slewstart", 0) > 0
+            and hasattr(self.last_slew, "endroll")
+        ):
+            return self.last_slew.endroll
+        return optimum_roll(
+            self.ra, self.dec, utime, self.ephem, self.solar_panel, self.constraint
+        )
 
     def _is_in_charging_mode(self, utime: float) -> bool:
         """Check if spacecraft is in charging mode (dwelling at charge pointing).

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -506,16 +506,49 @@ class ACS:
         # Calculate current RA/Dec pointing
         self._calculate_pointing(utime)
 
-        # Calculate roll angle to optimize solar panel illumination
+        # Calculate roll angle.
         # NOTE: Must run after _calculate_pointing so self.ra/dec are current.
-        self.roll = optimum_roll(
-            self.ra,
-            self.dec,
-            utime,
-            self.ephem,
-            self.solar_panel,
-            self.constraint,
-        )
+        #
+        # Roll is locked to the value computed at scheduling time (slew.endroll)
+        # once the spacecraft has settled at a science pointing.  Tracking the
+        # solar-optimal roll during an observation is physically unrealistic and
+        # would violate constraints that were validated at scheduling time.
+        #
+        # Exceptions:
+        #   - Actively slewing: interpolate roll along the pre-computed SLERP path.
+        #   - Emergency charging / safe mode: continuously track the solar-optimal
+        #     roll so that power generation is maximised as the Sun moves.
+        #   - No executed slew yet (slewstart == 0, initial boundary condition):
+        #     compute optimal roll as a reasonable starting condition.
+        if self._is_actively_slewing(utime) and self.current_slew is not None:
+            self.roll = self.current_slew.slew_roll(utime)
+        elif self._is_in_charging_mode(utime) or self.in_safe_mode:
+            self.roll = optimum_roll(
+                self.ra,
+                self.dec,
+                utime,
+                self.ephem,
+                self.solar_panel,
+                self.constraint,
+            )
+        elif (
+            self.last_slew is not None
+            and isinstance(self.last_slew, Slew)
+            and getattr(self.last_slew, "slewstart", 0) > 0
+            and hasattr(self.last_slew, "endroll")
+        ):
+            # Settled at a pointing after a real slew: lock roll to endroll.
+            self.roll = self.last_slew.endroll
+        else:
+            # Initial state before any slew has executed: use optimal roll.
+            self.roll = optimum_roll(
+                self.ra,
+                self.dec,
+                utime,
+                self.ephem,
+                self.solar_panel,
+                self.constraint,
+            )
 
         # Check current constraints (must run after roll is updated)
         self._check_constraints(utime)
@@ -621,8 +654,7 @@ class ACS:
         ):
             assert self.last_slew.at is not None
 
-            # Update the roll on the target to reflect the current optimum roll
-            # (the stored roll was computed at schedule time and may be stale)
+            # Keep the target's stored roll in sync with the ACS locked roll.
             self.last_slew.at.roll = self.roll
 
             # Collect only the true constraints

--- a/tests/acs/test_acs_comprehensive.py
+++ b/tests/acs/test_acs_comprehensive.py
@@ -330,6 +330,7 @@ class TestPointing:
         mock_slew.obstype = "PPT"
         mock_slew.obsid = 100
         mock_slew.ra_dec = Mock(return_value=(45.0, 30.0))
+        mock_slew.slew_roll = Mock(return_value=45.0)
         mock_slew.at = None
 
         acs.last_slew = mock_slew
@@ -351,6 +352,7 @@ class TestPointing:
         mock_pass.obstype = "GSP"
         mock_pass.obsid = 200
         mock_pass.ra_dec = Mock(return_value=(45.0, 30.0))
+        mock_pass.slew_roll = Mock(return_value=45.0)
 
         acs.last_slew = mock_pass
         acs.current_slew = mock_pass

--- a/tests/scheduler/conftest.py
+++ b/tests/scheduler/conftest.py
@@ -94,6 +94,16 @@ def mock_ephemeris():
     ephem.ephtime = mock_ephtime
     ephem.step_size = 60  # seconds
 
+    # Add position arrays needed by optimum_roll (shape: [n_steps, 3])
+    n_steps = len(ephem.utime)
+    sun_pos = np.zeros((n_steps, 3))
+    sun_pos[:, 0] = 1.496e8  # Sun ~1 AU in +X direction (km)
+    gcrs_pos = np.zeros((n_steps, 3))
+    ephem.sun_pv = Mock()
+    ephem.sun_pv.position = sun_pos
+    ephem.gcrs_pv = Mock()
+    ephem.gcrs_pv.position = gcrs_pos
+
     return ephem
 
 

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -507,6 +507,7 @@ class TestFetchNewPPT:
         mock_ppt.obsid = 1001
         mock_ppt.next_vis = Mock(return_value=1000.0)
         mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 300.0
         cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
         assert queue_ditl.ppt is mock_ppt
@@ -525,6 +526,7 @@ class TestFetchNewPPT:
         mock_ppt.obsid = 1001
         mock_ppt.next_vis = Mock(return_value=1000.0)
         mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 300.0
         cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
         cast(Mock, queue_ditl.acs.enqueue_command).assert_called_once()
@@ -544,6 +546,7 @@ class TestFetchNewPPT:
         mock_ppt.obsid = 1001
         mock_ppt.next_vis = Mock(return_value=1000.0)
         mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 300.0
         cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
         # Check the log instead of print output
@@ -971,6 +974,7 @@ class TestCalcMethod:
         mock_ppt.done = False
         mock_ppt.next_vis = Mock(return_value=1543276800.0)
         mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 300.0
         mock_ppt.copy = Mock(return_value=Mock())
         mock_ppt.copy.return_value.begin = 1543622400
         mock_ppt.copy.return_value.end = 1543629600
@@ -1069,6 +1073,7 @@ class TestCalcMethod:
         mock_ppt.done = False
         mock_ppt.next_vis = Mock(return_value=1543276800.0)
         mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 300.0
         mock_ppt.copy = Mock(return_value=Mock())
         mock_ppt.copy.return_value.begin = 1543622400
         mock_ppt.copy.return_value.end = 1543708800
@@ -1292,6 +1297,7 @@ class TestCalcMethod:
         mock_ppt.obsid = 1001
         mock_ppt.next_vis = Mock(return_value=1000.0)
         mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 300.0
         queue_ditl.queue.get = Mock(return_value=mock_ppt)
 
         # Create a mock current slew that's still slewing
@@ -1323,6 +1329,7 @@ class TestCalcMethod:
         # Set next_vis to a time after the current time (1000.0)
         mock_ppt.next_vis = Mock(return_value=1200.0)
         mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 300.0
         queue_ditl.queue.get = Mock(return_value=mock_ppt)
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
 

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -717,6 +717,71 @@ class TestFetchNewPPT:
         # Command should be enqueued
         cast(Mock, queue_ditl.acs.enqueue_command).assert_called_once()
 
+    def test_fetch_ppt_rejects_when_locked_roll_violates_constraint_in_window(
+        self, queue_ditl
+    ) -> None:
+        """Locked roll that violates a constraint inside the ss_min window skips target.
+
+        Expected outcome:
+        - No slew command enqueued
+        - ppt cleared (None)
+        - _ppt_unavailable set to True
+        - log event describing the locked-roll violation emitted
+        """
+        mock_ppt = Mock()
+        mock_ppt.ra = 45.0
+        mock_ppt.dec = 30.0
+        mock_ppt.obsid = 1001
+        mock_ppt.next_vis = Mock(return_value=1000.0)
+        mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 300.0
+        cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
+
+        # No blocking pass
+        cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
+        cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(return_value=None)
+
+        # Constraint reports a violation for every timestamp in the window
+        queue_ditl.constraint.in_constraint = Mock(return_value=True)
+
+        queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        # No slew should be enqueued
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
+        # PPT should be cleared
+        assert queue_ditl.ppt is None
+        # Unavailable flag should be set so the caller does not retry immediately
+        assert queue_ditl._ppt_unavailable is True
+        # A log event describing the locked-roll rejection should have been emitted
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "locked roll" in log_text
+        assert str(mock_ppt.obsid) in log_text
+
+    def test_fetch_ppt_accepts_when_locked_roll_satisfies_constraint_in_window(
+        self, queue_ditl
+    ) -> None:
+        """Target is accepted when locked roll clears all constraints across ss_min window."""
+        mock_ppt = Mock()
+        mock_ppt.ra = 45.0
+        mock_ppt.dec = 30.0
+        mock_ppt.obsid = 1002
+        mock_ppt.next_vis = Mock(return_value=1000.0)
+        mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 300.0
+        cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
+
+        # No blocking pass
+        cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
+        cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(return_value=None)
+
+        # Constraint reports no violation (default for the fixture, but explicit here)
+        queue_ditl.constraint.in_constraint = Mock(return_value=False)
+
+        queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        assert queue_ditl.ppt is mock_ppt
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_called_once()
+
 
 class TestRecordSpacecraftState:
     """Test _record_spacecraft_state helper method."""


### PR DESCRIPTION
This pull request introduces significant improvements to how roll angles are handled and validated during spacecraft scheduling and simulation, ensuring the roll is consistently locked during science observations and properly validated against constraints. It also updates related tests to reflect the new logic and adds necessary test data. The most important changes are grouped below.

**Roll Locking and Validation Improvements:**

* The roll angle is now locked to the value computed at slew execution and held constant throughout science observations, both in the scheduler (`scheduler.py`) and in the ACS simulation (`acs.py`). This ensures that constraint checks during scheduling match those during execution. [[1]](diffhunk://#diff-e1a0758cb4361cb8e0f7a3a2146d8451dae5e96d01e7505016fdda70f418e829R98-R126) [[2]](diffhunk://#diff-ca395e9d108129451f9c289e11ae05ac321ac659fa6b87401619b8ed1f625738L509-R510) [[3]](diffhunk://#diff-ca395e9d108129451f9c289e11ae05ac321ac659fa6b87401619b8ed1f625738R566-R591)
* When fetching a new science target, the code now validates that the locked roll satisfies all constraints for at least the minimum observation duration (`ss_min`). If the roll would violate constraints during this window, the target is skipped before slewing, preventing wasted maneuvers.
* The `last_slew` roll is no longer cleared upon terminating a PPT, preserving the locked roll until a new slew is executed.

**Test and Mock Data Updates:**

* Tests for fetching PPTs and scheduling now set the `ss_min` attribute and provide necessary mock data for roll validation. [[1]](diffhunk://#diff-eb255c58112da1923f2804163831fb9f7e1db9451be9932c688c013ff7d22528R510) [[2]](diffhunk://#diff-eb255c58112da1923f2804163831fb9f7e1db9451be9932c688c013ff7d22528R529) [[3]](diffhunk://#diff-eb255c58112da1923f2804163831fb9f7e1db9451be9932c688c013ff7d22528R549) [[4]](diffhunk://#diff-eb255c58112da1923f2804163831fb9f7e1db9451be9932c688c013ff7d22528R977) [[5]](diffhunk://#diff-eb255c58112da1923f2804163831fb9f7e1db9451be9932c688c013ff7d22528R1076) [[6]](diffhunk://#diff-eb255c58112da1923f2804163831fb9f7e1db9451be9932c688c013ff7d22528R1300) [[7]](diffhunk://#diff-eb255c58112da1923f2804163831fb9f7e1db9451be9932c688c013ff7d22528R1332)
* The mock ephemeris used in scheduler tests now includes position arrays for the Sun and spacecraft, supporting the new roll computation logic.
* Tests for ACS slewing now mock the `slew_roll` method to ensure correct roll interpolation during slews. [[1]](diffhunk://#diff-2ecf669f19096e484f58890525d77aa8e586f24fd48a1695ba088714eee2d3ecR333) [[2]](diffhunk://#diff-2ecf669f19096e484f58890525d77aa8e586f24fd48a1695ba088714eee2d3ecR355)

**Code Consistency and Synchronization:**

* The ACS now synchronizes the stored roll value on the target with the locked roll used by the controller, ensuring consistency between scheduling, simulation, and analysis.

These changes collectively improve the physical realism and reliability of roll handling in both scheduling and simulation, and ensure that tests accurately reflect the new behaviors.