### PR TITLE
fix: under-collected science plan entries

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -19,6 +19,7 @@ from ..common.vector import attitude_to_quat
 from ..config import MissionConfig
 from ..simulation.acs_command import ACSCommand
 from ..simulation.emergency_charging import EmergencyCharging
+from ..simulation.passes import pass_slew_trigger_buffer
 from ..simulation.roll import optimum_roll
 from ..simulation.slew import Slew
 from ..targets import Plan, Pointing, Queue
@@ -447,7 +448,7 @@ class QueueDITL(DITLMixin, DITLStats):
 
         # Make sure the last PPT of the day ends (if any)
         if self.plan:
-            self.plan[-1].end = utime
+            self._close_last_plan_entry(utime)
 
         return True
 
@@ -517,6 +518,73 @@ class QueueDITL(DITLMixin, DITLStats):
                     reason=reason,
                 )
                 self.acs.enqueue_command(command)
+
+    @staticmethod
+    def _is_science_entry(entry: Any) -> bool:
+        if getattr(entry, "obstype", None) not in (ObsType.AT, "AT"):
+            return False
+        return True
+
+    @classmethod
+    def _science_collection_time(
+        cls, entry: Any, end_time: float | None = None
+    ) -> float | None:
+        if not cls._is_science_entry(entry):
+            return None
+        begin = cls._float_or_none(getattr(entry, "begin", None))
+        raw_end = getattr(entry, "end", None) if end_time is None else end_time
+        end = cls._float_or_none(raw_end)
+        slewtime = cls._float_or_none(getattr(entry, "slewtime", None))
+        insaa = cls._float_or_none(getattr(entry, "insaa", 0.0))
+        if begin is None or end is None or slewtime is None:
+            return None
+        if insaa is None:
+            insaa = 0.0
+        return end - begin - max(0.0, slewtime) - max(0.0, insaa)
+
+    @classmethod
+    def _is_short_science_entry(cls, entry: Any) -> bool:
+        collection_time = cls._science_collection_time(entry)
+        if collection_time is None:
+            return False
+
+        ss_min = cls._float_or_none(getattr(entry, "ss_min", None))
+        if ss_min is None:
+            return collection_time <= 0.0
+        return collection_time < max(0.0, ss_min)
+
+    def _pop_last_plan_entry(self) -> None:
+        entries = getattr(self.plan, "entries", None)
+        if entries is not None:
+            entries.pop()
+            return
+        pop = getattr(self.plan, "pop")
+        pop()
+
+    def _close_last_plan_entry(self, end_time: float) -> None:
+        if len(self.plan) == 0:
+            return
+        self.plan[-1].end = end_time
+        if self._is_short_science_entry(self.plan[-1]):
+            entry = self.plan[-1]
+            collection_time = self._science_collection_time(entry)
+            collected = max(0.0, collection_time or 0.0)
+            ss_min = self._float_or_none(getattr(entry, "ss_min", None))
+            required_text = f" of required {ss_min:.0f}s" if ss_min is not None else ""
+            raw_obsid = getattr(entry, "obsid", None)
+            obsid = raw_obsid if isinstance(raw_obsid, int) else None
+            obsid_text = obsid if obsid is not None else "unknown"
+            self.log.log_event(
+                utime=end_time,
+                event_type="QUEUE",
+                description=(
+                    f"Dropping under-collected science entry {obsid_text} - "
+                    f"collected {collected:.0f}s{required_text}"
+                ),
+                obsid=obsid,
+                acs_mode=getattr(self.acs, "acsmode", None),
+            )
+            self._pop_last_plan_entry()
 
     def _create_housekeeping_record(
         self, utime: float, ra: float, dec: float, roll: float, mode: ACSMode
@@ -619,7 +687,7 @@ class QueueDITL(DITLMixin, DITLStats):
                 # Charging PPTs use exactly 86400, science obs use larger values
                 if last_entry.end >= last_entry.begin + 86400:
                     # Set end to the begin time of new PPT (no gap between entries)
-                    self.plan[-1].end = self.ppt.begin
+                    self._close_last_plan_entry(self.ppt.begin)
 
             self.plan.append(self.ppt.copy())
 
@@ -634,7 +702,7 @@ class QueueDITL(DITLMixin, DITLStats):
             # Check if end time looks like a placeholder (>= 86400 seconds from begin)
             # Charging PPTs use exactly 86400, science obs use larger values
             if last_entry.end >= last_entry.begin + 86400:
-                self.plan[-1].end = utime
+                self._close_last_plan_entry(utime)
 
     def _handle_mode_operations(
         self, mode: ACSMode, utime: float, ra: float, dec: float
@@ -679,12 +747,18 @@ class QueueDITL(DITLMixin, DITLStats):
 
     def _initiate_charging(self, utime: float, ra: float, dec: float) -> None:
         """Initiate emergency charging by creating charging PPT and sending command to ACS."""
+        interrupted_ppt = self.ppt
         self.charging_ppt = self.emergency_charging.initiate_emergency_charging(
             utime, self.ephem, ra, dec, self.ppt
         )
 
         # If charging PPT created successfully, send command to ACS and replace current PPT
         if self.charging_ppt is not None:
+            if interrupted_ppt is not None and self._is_short_science_entry(
+                interrupted_ppt
+            ):
+                interrupted_ppt.done = False
+
             command = ACSCommand(
                 command_type=ACSCommandType.START_BATTERY_CHARGE,
                 execution_time=utime,
@@ -885,6 +959,9 @@ class QueueDITL(DITLMixin, DITLStats):
                 self._terminate_emergency_charging("constraint", utime)
             return
 
+        if mode == ACSMode.SLEWING:
+            return
+
         # Decrement exposure time when actively observing
         if mode == ACSMode.SCIENCE:
             self._decrement_exposure_time()
@@ -952,7 +1029,7 @@ class QueueDITL(DITLMixin, DITLStats):
 
         # Update plan timeline with actual end time
         if len(self.plan) > 0:
-            self.plan[-1].end = utime
+            self._close_last_plan_entry(utime)
 
         if mark_done:
             self.ppt.done = True
@@ -998,6 +1075,156 @@ class QueueDITL(DITLMixin, DITLStats):
         ):
             return "ST Soft"
         return "Unknown"
+
+    @staticmethod
+    def _float_or_none(value: Any) -> float | None:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _simulation_end_deadline(self) -> float | None:
+        if getattr(self, "uend", 0.0):
+            return float(self.uend)
+        try:
+            return float(self.end.timestamp())
+        except Exception:
+            return None
+
+    def _current_ppt_visibility_deadline(self, slew_end: float) -> float | None:
+        assert self.ppt is not None
+        windows = getattr(self.ppt, "windows", None)
+        if isinstance(windows, (tuple, list)) and windows:
+            for window in windows:
+                if not isinstance(window, (tuple, list)) or len(window) < 2:
+                    continue
+                start = self._float_or_none(window[0])
+                end = self._float_or_none(window[1])
+                if start is None or end is None:
+                    continue
+                if start <= slew_end <= end:
+                    return end
+            return slew_end
+
+        visible = getattr(self.ppt, "visible", None)
+        if not callable(visible):
+            return None
+        try:
+            vis_window = visible(slew_end, slew_end)
+        except Exception:
+            return None
+        if vis_window is False:
+            return slew_end
+        if isinstance(vis_window, (tuple, list)) and len(vis_window) >= 2:
+            return self._float_or_none(vis_window[1])
+        return None
+
+    def _next_pass_science_deadline(self, slew_end: float) -> float | None:
+        assert self.ppt is not None
+        next_pass = self.acs.passrequests.next_pass(slew_end)
+        if next_pass is None:
+            return None
+
+        pass_begin = self._float_or_none(getattr(next_pass, "begin", None))
+        if pass_begin is None:
+            return None
+
+        try:
+            pass_slew_dist = angular_separation(
+                self.ppt.ra,
+                self.ppt.dec,
+                next_pass.gsstartra,
+                next_pass.gsstartdec,
+            )
+            acs_cfg = self.config.spacecraft_bus.attitude_control
+            pass_slew_time = float(acs_cfg.slew_time(pass_slew_dist))
+        except Exception:
+            pass_slew_time = 0.0
+
+        return pass_begin - pass_slew_time - self._pass_slew_trigger_buffer()
+
+    def _pass_slew_trigger_buffer(self) -> float:
+        step_size = self._float_or_none(getattr(self.ephem, "step_size", None))
+        if step_size is None:
+            return 0.0
+        return pass_slew_trigger_buffer(step_size)
+
+    def _next_science_deadline(
+        self, slew_end: float
+    ) -> tuple[float | None, str | None]:
+        deadlines: list[tuple[float, str]] = []
+
+        sim_end = self._simulation_end_deadline()
+        if sim_end is not None:
+            deadlines.append((sim_end, "simulation end"))
+
+        visibility_end = self._current_ppt_visibility_deadline(slew_end)
+        if visibility_end is not None:
+            deadlines.append((visibility_end, "visibility window"))
+
+        pass_deadline = self._next_pass_science_deadline(slew_end)
+        if pass_deadline is not None:
+            deadlines.append((pass_deadline, "pass"))
+
+        if not deadlines:
+            return None, None
+        return min(deadlines, key=lambda item: item[0])
+
+    def _can_retry_without_current_ppt(self) -> bool:
+        targets = getattr(self.queue, "targets", None)
+        return isinstance(targets, list) and len(targets) > 1
+
+    def _retry_fetch_without_current_ppt(
+        self, utime: float, ra: float, dec: float
+    ) -> None:
+        rejected_ppt = self.ppt
+        if rejected_ppt is None or not self._can_retry_without_current_ppt():
+            self.ppt = None
+            self._ppt_unavailable = True
+            return
+
+        try:
+            was_done = bool(rejected_ppt.done)
+        except Exception:
+            was_done = False
+
+        rejected_ppt.done = True
+        self.ppt = None
+        try:
+            self._fetch_new_ppt(utime, ra, dec)
+        finally:
+            rejected_ppt.done = was_done
+
+    def _reject_current_ppt_if_insufficient_collect_time(
+        self, slew_end: float, utime: float, ra: float, dec: float
+    ) -> bool:
+        assert self.ppt is not None
+        ss_min = self._float_or_none(getattr(self.ppt, "ss_min", None))
+        if ss_min is None or ss_min <= 0:
+            return False
+
+        deadline, reason = self._next_science_deadline(slew_end)
+        if deadline is None:
+            return False
+
+        available_collect_time = deadline - slew_end
+        if available_collect_time >= ss_min:
+            return False
+
+        reason_label = reason or "hard boundary"
+        self.log.log_event(
+            utime=utime,
+            event_type="QUEUE",
+            description=(
+                f"Target {self.ppt.obsid} rejected - only "
+                f"{available_collect_time:.0f}s available before {reason_label} "
+                f"(need {ss_min:.0f}s)"
+            ),
+            obsid=self.ppt.obsid,
+            acs_mode=self.acs.acsmode,
+        )
+        self._retry_fetch_without_current_ppt(utime, ra, dec)
+        return True
 
     def _fetch_new_ppt(self, utime: float, ra: float, dec: float) -> None:
         """Fetch a new pointing target from the queue and enqueue slew command."""
@@ -1199,35 +1426,12 @@ class QueueDITL(DITLMixin, DITLStats):
                 self._ppt_unavailable = True
                 return
 
+            if self._reject_current_ppt_if_insufficient_collect_time(
+                slew_end, utime, ra, dec
+            ):
+                return
+
             self.acs.slew_dists.append(slew.slewdist)
-
-            # Check if there's enough observation time before the next pass
-            slew_end_time = slew.slewstart + slew.slewtime
-            next_pass = self.acs.passrequests.next_pass(slew_end_time)
-            if next_pass is not None:
-                # Calculate when we need to start slewing to the pass
-                time_to_pass_slew = next_pass.begin - slew_end_time
-                # Estimate slew time to pass start position using existing utilities
-                pass_slew_dist = angular_separation(
-                    self.ppt.ra, self.ppt.dec, next_pass.gsstartra, next_pass.gsstartdec
-                )
-                acs_cfg = self.config.spacecraft_bus.attitude_control
-                pass_slew_time = acs_cfg.slew_time(pass_slew_dist)
-
-                # Available observation time = time until pass - slew time to pass
-                available_obs_time = time_to_pass_slew - pass_slew_time
-                if available_obs_time < self.ppt.ss_min:
-                    self.log.log_event(
-                        utime=utime,
-                        event_type="QUEUE",
-                        description=f"Target {self.ppt.obsid} rejected - only {available_obs_time:.0f}s "
-                        f"available before pass (need {self.ppt.ss_min}s)",
-                        obsid=self.ppt.obsid,
-                        acs_mode=self.acs.acsmode,
-                    )
-                    self.ppt = None
-                    self._ppt_unavailable = True
-                    return
 
             # Update PPT timing based on slew
             self.ppt.begin = int(execution_time)
@@ -1385,7 +1589,7 @@ class QueueDITL(DITLMixin, DITLStats):
         if self.ppt is not None and self.ppt != self.charging_ppt:
             # Update plan timeline with actual end time
             if len(self.plan) > 0:
-                self.plan[-1].end = utime
+                self._close_last_plan_entry(utime)
             self.ppt.end = utime
             self.ppt.done = True
             self.ppt = None
@@ -1395,7 +1599,7 @@ class QueueDITL(DITLMixin, DITLStats):
         if self.charging_ppt is not None:
             # Update plan timeline with actual end time
             if len(self.plan) > 0:
-                self.plan[-1].end = utime
+                self._close_last_plan_entry(utime)
             self.charging_ppt.end = utime
             self.charging_ppt.done = True
             self.charging_ppt = None

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -22,7 +22,7 @@ from ..simulation.emergency_charging import EmergencyCharging
 from ..simulation.passes import pass_slew_trigger_buffer
 from ..simulation.roll import optimum_roll
 from ..simulation.slew import Slew
-from ..targets import Plan, Pointing, Queue
+from ..targets import Plan, PlanEntry, Pointing, Queue
 from .ditl_log import DITLLog
 from .ditl_mixin import DITLMixin
 from .ditl_stats import DITLStats
@@ -520,46 +520,29 @@ class QueueDITL(DITLMixin, DITLStats):
                 self.acs.enqueue_command(command)
 
     @staticmethod
-    def _is_science_entry(entry: Any) -> bool:
-        if getattr(entry, "obstype", None) not in (ObsType.AT, "AT"):
-            return False
-        return True
+    def _is_science_entry(entry: PlanEntry) -> bool:
+        return entry.obstype == ObsType.AT
 
-    @classmethod
+    @staticmethod
     def _science_collection_time(
-        cls, entry: Any, end_time: float | None = None
+        entry: PlanEntry, end_time: float | None = None
     ) -> float | None:
-        if not cls._is_science_entry(entry):
+        if entry.obstype != ObsType.AT:
             return None
-        begin = cls._float_or_none(getattr(entry, "begin", None))
-        raw_end = getattr(entry, "end", None) if end_time is None else end_time
-        end = cls._float_or_none(raw_end)
-        slewtime = cls._float_or_none(getattr(entry, "slewtime", None))
-        insaa = cls._float_or_none(getattr(entry, "insaa", 0.0))
-        if begin is None or end is None or slewtime is None:
-            return None
-        if insaa is None:
-            insaa = 0.0
-        return end - begin - max(0.0, slewtime) - max(0.0, insaa)
+        end = end_time if end_time is not None else float(entry.end)
+        return (
+            end
+            - entry.begin
+            - max(0.0, float(entry.slewtime))
+            - max(0.0, float(entry.insaa))
+        )
 
-    @classmethod
-    def _is_short_science_entry(cls, entry: Any) -> bool:
-        collection_time = cls._science_collection_time(entry)
+    @staticmethod
+    def _is_short_science_entry(entry: PlanEntry) -> bool:
+        collection_time = QueueDITL._science_collection_time(entry)
         if collection_time is None:
             return False
-
-        ss_min = cls._float_or_none(getattr(entry, "ss_min", None))
-        if ss_min is None:
-            return collection_time <= 0.0
-        return collection_time < max(0.0, ss_min)
-
-    def _pop_last_plan_entry(self) -> None:
-        entries = getattr(self.plan, "entries", None)
-        if entries is not None:
-            entries.pop()
-            return
-        pop = getattr(self.plan, "pop")
-        pop()
+        return collection_time < max(0.0, float(entry.ss_min))
 
     def _close_last_plan_entry(self, end_time: float) -> None:
         if len(self.plan) == 0:
@@ -569,22 +552,17 @@ class QueueDITL(DITLMixin, DITLStats):
             entry = self.plan[-1]
             collection_time = self._science_collection_time(entry)
             collected = max(0.0, collection_time or 0.0)
-            ss_min = self._float_or_none(getattr(entry, "ss_min", None))
-            required_text = f" of required {ss_min:.0f}s" if ss_min is not None else ""
-            raw_obsid = getattr(entry, "obsid", None)
-            obsid = raw_obsid if isinstance(raw_obsid, int) else None
-            obsid_text = obsid if obsid is not None else "unknown"
             self.log.log_event(
                 utime=end_time,
                 event_type="QUEUE",
                 description=(
-                    f"Dropping under-collected science entry {obsid_text} - "
-                    f"collected {collected:.0f}s{required_text}"
+                    f"Dropping under-collected science entry {entry.obsid} - "
+                    f"collected {collected:.0f}s of required {float(entry.ss_min):.0f}s"
                 ),
-                obsid=obsid,
-                acs_mode=getattr(self.acs, "acsmode", None),
+                obsid=entry.obsid,
+                acs_mode=self.acs.acsmode,
             )
-            self._pop_last_plan_entry()
+            self.plan.pop()
 
     def _create_housekeeping_record(
         self, utime: float, ra: float, dec: float, roll: float, mode: ACSMode
@@ -1076,87 +1054,45 @@ class QueueDITL(DITLMixin, DITLStats):
             return "ST Soft"
         return "Unknown"
 
-    @staticmethod
-    def _float_or_none(value: Any) -> float | None:
-        try:
-            return float(value)
-        except (TypeError, ValueError):
-            return None
-
-    def _simulation_end_deadline(self) -> float | None:
-        if getattr(self, "uend", 0.0):
-            return float(self.uend)
-        try:
-            return float(self.end.timestamp())
-        except Exception:
-            return None
+    def _simulation_end_deadline(self) -> float:
+        return self.uend if self.uend > 0.0 else self.end.timestamp()
 
     def _current_ppt_visibility_deadline(self, slew_end: float) -> float | None:
+        """Calculate the end of the current PPT visibility window, if any, after the slew ends."""
         assert self.ppt is not None
-        windows = getattr(self.ppt, "windows", None)
-        if isinstance(windows, (tuple, list)) and windows:
-            for window in windows:
-                if not isinstance(window, (tuple, list)) or len(window) < 2:
-                    continue
-                start = self._float_or_none(window[0])
-                end = self._float_or_none(window[1])
-                if start is None or end is None:
-                    continue
-                if start <= slew_end <= end:
-                    return end
-            return slew_end
-
-        visible = getattr(self.ppt, "visible", None)
-        if not callable(visible):
+        if not self.ppt.windows:
             return None
-        try:
-            vis_window = visible(slew_end, slew_end)
-        except Exception:
-            return None
-        if vis_window is False:
-            return slew_end
-        if isinstance(vis_window, (tuple, list)) and len(vis_window) >= 2:
-            return self._float_or_none(vis_window[1])
-        return None
+        for window in self.ppt.windows:
+            if window[0] <= slew_end <= window[1]:
+                return window[1]
+        return slew_end
 
     def _next_pass_science_deadline(self, slew_end: float) -> float | None:
+        """Calculate the next pass deadline after the slew ends, accounting for
+        slew time to the pass start."""
         assert self.ppt is not None
         next_pass = self.acs.passrequests.next_pass(slew_end)
         if next_pass is None:
             return None
 
-        pass_begin = self._float_or_none(getattr(next_pass, "begin", None))
-        if pass_begin is None:
-            return None
+        pass_slew_dist = angular_separation(
+            self.ppt.ra, self.ppt.dec, next_pass.gsstartra, next_pass.gsstartdec
+        )
+        acs_cfg = self.config.spacecraft_bus.attitude_control
+        pass_slew_time = float(acs_cfg.slew_time(pass_slew_dist))
 
-        try:
-            pass_slew_dist = angular_separation(
-                self.ppt.ra,
-                self.ppt.dec,
-                next_pass.gsstartra,
-                next_pass.gsstartdec,
-            )
-            acs_cfg = self.config.spacecraft_bus.attitude_control
-            pass_slew_time = float(acs_cfg.slew_time(pass_slew_dist))
-        except Exception:
-            pass_slew_time = 0.0
-
-        return pass_begin - pass_slew_time - self._pass_slew_trigger_buffer()
+        return next_pass.begin - pass_slew_time - self._pass_slew_trigger_buffer()
 
     def _pass_slew_trigger_buffer(self) -> float:
-        step_size = self._float_or_none(getattr(self.ephem, "step_size", None))
-        if step_size is None:
-            return 0.0
-        return pass_slew_trigger_buffer(step_size)
+        return pass_slew_trigger_buffer(self.ephem.step_size)
 
-    def _next_science_deadline(
-        self, slew_end: float
-    ) -> tuple[float | None, str | None]:
-        deadlines: list[tuple[float, str]] = []
-
-        sim_end = self._simulation_end_deadline()
-        if sim_end is not None:
-            deadlines.append((sim_end, "simulation end"))
+    def _next_science_deadline(self, slew_end: float) -> tuple[float, str]:
+        """Determine the next science deadline after the slew ends, which could
+        be the end of the current visibility window, the next pass, or the end
+        of the simulation."""
+        deadlines: list[tuple[float, str]] = [
+            (self._simulation_end_deadline(), "simulation end")
+        ]
 
         visibility_end = self._current_ppt_visibility_deadline(slew_end)
         if visibility_end is not None:
@@ -1166,28 +1102,27 @@ class QueueDITL(DITLMixin, DITLStats):
         if pass_deadline is not None:
             deadlines.append((pass_deadline, "pass"))
 
-        if not deadlines:
-            return None, None
         return min(deadlines, key=lambda item: item[0])
 
     def _can_retry_without_current_ppt(self) -> bool:
-        targets = getattr(self.queue, "targets", None)
-        return isinstance(targets, list) and len(targets) > 1
+        """Sanity check to see if we can retry fetching a new PPT without just
+        returning the same one"""
+        return len(self.queue.targets) > 1
 
     def _retry_fetch_without_current_ppt(
         self, utime: float, ra: float, dec: float
     ) -> None:
+        """
+        Retry fetching a new PPT without the current one, if possible. If
+        the current PPT is the only one in the queue, mark PPT as unavailable.
+        """
         rejected_ppt = self.ppt
         if rejected_ppt is None or not self._can_retry_without_current_ppt():
             self.ppt = None
             self._ppt_unavailable = True
             return
 
-        try:
-            was_done = bool(rejected_ppt.done)
-        except Exception:
-            was_done = False
-
+        was_done = rejected_ppt.done
         rejected_ppt.done = True
         self.ppt = None
         try:
@@ -1198,29 +1133,32 @@ class QueueDITL(DITLMixin, DITLStats):
     def _reject_current_ppt_if_insufficient_collect_time(
         self, slew_end: float, utime: float, ra: float, dec: float
     ) -> bool:
+        """Check if the current PPT has enough time to collect before the next
+        science deadline."""
         assert self.ppt is not None
-        ss_min = self._float_or_none(getattr(self.ppt, "ss_min", None))
-        if ss_min is None or ss_min <= 0:
+        if self.ppt.ss_min <= 0:
             return False
 
+        # Check if there's enough time to collect before the next science
+        # deadline (visibility window end, next pass, or simulation end)
         deadline, reason = self._next_science_deadline(slew_end)
-        if deadline is None:
-            return False
-
         available_collect_time = deadline - slew_end
-        if available_collect_time >= ss_min:
+        if available_collect_time >= self.ppt.ss_min:
             return False
 
-        reason_label = reason or "hard boundary"
+        # If not enough time to collect, reject this target and try fetching
+        # another one
+        ss_min = self.ppt.ss_min
+        obsid = self.ppt.obsid
         self.log.log_event(
             utime=utime,
             event_type="QUEUE",
             description=(
-                f"Target {self.ppt.obsid} rejected - only "
-                f"{available_collect_time:.0f}s available before {reason_label} "
+                f"Target {obsid} rejected - only "
+                f"{available_collect_time:.0f}s available before {reason} "
                 f"(need {ss_min:.0f}s)"
             ),
-            obsid=self.ppt.obsid,
+            obsid=obsid,
             acs_mode=self.acs.acsmode,
         )
         self._retry_fetch_without_current_ppt(utime, ra, dec)

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -522,6 +522,8 @@ class QueueDITL(DITLMixin, DITLStats):
     def _science_collection_time(
         self, entry: PlanEntry, end_time: float | None = None
     ) -> float | None:
+        """Calculate the effective science collection time for a given plan
+        entry."""
         if entry.obstype != ObsType.AT:
             return None
         end = end_time if end_time is not None else float(entry.end)
@@ -533,12 +535,17 @@ class QueueDITL(DITLMixin, DITLStats):
         )
 
     def _is_short_science_entry(self, entry: PlanEntry) -> bool:
+        """Determine if a science observation entry failed to meet the minimum
+        snapshot requirement."""
         collection_time = self._science_collection_time(entry)
         if collection_time is None:
             return False
         return collection_time < max(0.0, float(entry.ss_min))
 
     def _close_last_plan_entry(self, end_time: float) -> None:
+        """Close the last plan entry in the timeline by setting its end time.
+        If it's a science observation that didn't meet the minimum snapshot
+        requirement, log it and remove it from the plan."""
         if len(self.plan) == 0:
             return
         self.plan[-1].end = end_time

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -519,13 +519,8 @@ class QueueDITL(DITLMixin, DITLStats):
                 )
                 self.acs.enqueue_command(command)
 
-    @staticmethod
-    def _is_science_entry(entry: PlanEntry) -> bool:
-        return entry.obstype == ObsType.AT
-
-    @staticmethod
     def _science_collection_time(
-        entry: PlanEntry, end_time: float | None = None
+        self, entry: PlanEntry, end_time: float | None = None
     ) -> float | None:
         if entry.obstype != ObsType.AT:
             return None
@@ -537,9 +532,8 @@ class QueueDITL(DITLMixin, DITLStats):
             - max(0.0, float(entry.insaa))
         )
 
-    @staticmethod
-    def _is_short_science_entry(entry: PlanEntry) -> bool:
-        collection_time = QueueDITL._science_collection_time(entry)
+    def _is_short_science_entry(self, entry: PlanEntry) -> bool:
+        collection_time = self._science_collection_time(entry)
         if collection_time is None:
             return False
         return collection_time < max(0.0, float(entry.ss_min))
@@ -1055,6 +1049,9 @@ class QueueDITL(DITLMixin, DITLStats):
         return "Unknown"
 
     def _simulation_end_deadline(self) -> float:
+        """Calculate the simulation end deadline, which is either the
+        configured end time or the end of the current PPT, whichever is sooner.
+        """
         return self.uend if self.uend > 0.0 else self.end.timestamp()
 
     def _current_ppt_visibility_deadline(self, slew_end: float) -> float | None:

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1056,9 +1056,7 @@ class QueueDITL(DITLMixin, DITLStats):
         return "Unknown"
 
     def _simulation_end_deadline(self) -> float:
-        """Calculate the simulation end deadline, which is either the
-        configured end time or the end of the current PPT, whichever is sooner.
-        """
+        """Return the Unix timestamp for the end of the simulation."""
         return self.uend if self.uend > 0.0 else self.end.timestamp()
 
     def _current_ppt_visibility_deadline(self, slew_end: float) -> float | None:

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -11,6 +11,11 @@ from ..config import Constraint, GroundStationRegistry, MissionConfig
 from ..config.constants import DTOR
 
 
+def pass_slew_trigger_buffer(step_size: float) -> float:
+    """Return how early pass handling can trigger a slew, in seconds."""
+    return max(0.0, 2.0 * float(step_size))
+
+
 class Pass(BaseModel):
     """A groundstation pass consisting of the dwell phase.
 
@@ -258,9 +263,7 @@ class Pass(BaseModel):
         # Determine if we need to start slewing now
         time_until_slew = (self.begin - slewtime) - utime
 
-        # If we are within 2 ephem steps of needing to slew, return True
-        # FIXME: Is this buffer necessary?
-        if time_until_slew <= self.ephem.step_size * 2:
+        if time_until_slew <= pass_slew_trigger_buffer(self.ephem.step_size):
             return True
         else:
             return False

--- a/conops/targets/plan.py
+++ b/conops/targets/plan.py
@@ -61,6 +61,9 @@ class Plan:
     def append(self, ppt: PlanEntry) -> None:
         self.entries.append(ppt)
 
+    def pop(self) -> PlanEntry:
+        return self.entries.pop()
+
     def save(self, path: str | Path, *, indent: int = 2) -> Path:
         """Serialise the plan to a JSON file.
 

--- a/conops/targets/plan_entry.py
+++ b/conops/targets/plan_entry.py
@@ -85,9 +85,8 @@ class PlanEntry:
     @property
     def exposure(self) -> int:  # (),excludesaa=False):
         self.insaa = 0
-        return int(
-            self.end - self.begin - self.slewtime - self.insaa
-        )  # always an integer number of seconds
+        exposure = self.end - self.begin - self.slewtime - self.insaa
+        return max(0, int(exposure))  # always an integer number of seconds
 
     @exposure.setter
     def exposure(self, value: int) -> None:

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -71,6 +71,11 @@ class PlanEntrySchema(BaseModel):
     done: bool = False
     exposure: int = 0
 
+    @staticmethod
+    def _computed_exposure(entry: PlanEntry) -> int:
+        exposure = entry.end - entry.begin - entry.slewtime - entry.insaa
+        return max(0, int(exposure))
+
     @field_validator("begin", "end", mode="before")
     @classmethod
     def _coerce_time(cls, v: Any) -> float:
@@ -107,7 +112,7 @@ class PlanEntrySchema(BaseModel):
                 "exporig": data._exporig,
                 "isat": getattr(data, "isat", False),
                 "done": getattr(data, "done", False),
-                "exposure": data.end - data.begin - data.slewtime - data.insaa,
+                "exposure": cls._computed_exposure(data),
             }
         return data
 

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -12,6 +12,7 @@ from conops import (
     PassTimes,
 )
 from conops.config import AttitudeControlSystem
+from conops.simulation.passes import pass_slew_trigger_buffer
 
 
 class TestPassInitialization:
@@ -156,6 +157,10 @@ class TestPassMethods:
 
 class TestPassTimeToSlew:
     """Test Pass.time_to_slew method."""
+
+    def test_pass_slew_trigger_buffer_is_two_ephemeris_steps(self):
+        assert pass_slew_trigger_buffer(60.0) == 120.0
+        assert pass_slew_trigger_buffer(-60.0) == 0.0
 
     def test_time_to_slew_no_pass_profile(self, basic_pass_mock):
         """Test time_to_slew returns False when pass has no ra/dec profile."""

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -2,6 +2,7 @@
 
 import json
 import pathlib
+from unittest.mock import Mock
 
 import pytest
 
@@ -297,3 +298,32 @@ class TestPlanSchema:
         assert schema.entries == []
         assert schema.start == 0.0
         assert schema.end == 0.0
+
+    def test_from_plan_clamps_negative_exposure(self, tmp_path):
+        """Generated JSON should not contain negative exposure for truncated entries."""
+        from conops.targets.plan import Plan
+        from conops.targets.plan_entry import PlanEntry
+
+        config = Mock()
+        config.constraint = Mock()
+        config.constraint.ephem = Mock()
+        config.spacecraft_bus = Mock()
+        config.spacecraft_bus.attitude_control = Mock()
+
+        entry = PlanEntry(config=config)
+        entry.obstype = "AT"
+        entry.begin = 1000.0
+        entry.end = 1060.0
+        entry.slewtime = 224
+        entry.insaa = 0
+
+        plan = Plan()
+        plan.append(entry)
+
+        schema = PlanSchema.from_plan(plan)
+        assert schema.entries[0].exposure == 0
+
+        dest = tmp_path / "plan.json"
+        schema.save(dest)
+        raw = json.loads(dest.read_text())
+        assert raw["entries"][0]["exposure"] == 0

--- a/tests/plan_entry/test_plan_entry.py
+++ b/tests/plan_entry/test_plan_entry.py
@@ -136,6 +136,15 @@ class TestExposureProperty:
         assert exposure == 90  # 1100 - 1000 - 10
         assert plan_entry.insaa == 0
 
+    def test_exposure_clamps_when_window_is_shorter_than_slew(self, plan_entry):
+        """Exposure should not go negative for an aborted/no-collect entry."""
+        plan_entry.begin = 1000
+        plan_entry.end = 1060
+        plan_entry.slewtime = 224
+
+        exposure = plan_entry.exposure
+        assert exposure == 0
+
     # def test_exposure_with_saa_overlap(self, plan_entry):
     #     """Test exposure with SAA overlap."""
     #     plan_entry.begin = 1000

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -512,6 +512,7 @@ class TestFetchNewPPT:
         mock_ppt.next_vis = Mock(return_value=1000.0)
         mock_ppt.ss_max = 3600.0
         mock_ppt.ss_min = 300.0
+        mock_ppt.windows = [[0.0, 1e12]]
         cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
         assert queue_ditl.ppt is mock_ppt
@@ -531,6 +532,7 @@ class TestFetchNewPPT:
         mock_ppt.next_vis = Mock(return_value=1000.0)
         mock_ppt.ss_max = 3600.0
         mock_ppt.ss_min = 300.0
+        mock_ppt.windows = [[0.0, 1e12]]
         cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
         cast(Mock, queue_ditl.acs.enqueue_command).assert_called_once()
@@ -551,6 +553,7 @@ class TestFetchNewPPT:
         mock_ppt.next_vis = Mock(return_value=1000.0)
         mock_ppt.ss_max = 3600.0
         mock_ppt.ss_min = 300.0
+        mock_ppt.windows = [[0.0, 1e12]]
         cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
         # Check the log instead of print output
@@ -663,7 +666,9 @@ class TestFetchNewPPT:
         mock_ppt.next_vis = Mock(return_value=1000.0)
         mock_ppt.ss_max = 3600.0
         mock_ppt.ss_min = 500.0  # Requires 500 seconds
+        mock_ppt.windows = [[0.0, 1e12]]
         cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
+        queue_ditl.queue.targets = [mock_ppt]
 
         # No current pass
         cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
@@ -702,7 +707,9 @@ class TestFetchNewPPT:
         mock_ppt.next_vis = Mock(return_value=1000.0)
         mock_ppt.ss_max = 3600.0
         mock_ppt.ss_min = 200.0
+        mock_ppt.windows = [[0.0, 1e12]]
         cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
+        queue_ditl.queue.targets = [mock_ppt]
 
         cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
 
@@ -734,6 +741,7 @@ class TestFetchNewPPT:
         mock_ppt.next_vis = Mock(return_value=1000.0)
         mock_ppt.ss_max = 3600.0
         mock_ppt.ss_min = 100.0  # Requires 100 seconds
+        mock_ppt.windows = [[0.0, 1e12]]
         cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
 
         # No current pass
@@ -829,6 +837,7 @@ class TestFetchNewPPT:
         mock_ppt.next_vis = Mock(return_value=1000.0)
         mock_ppt.ss_max = 3600.0
         mock_ppt.ss_min = 300.0
+        mock_ppt.windows = [[0.0, 1e12]]
         cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
 
         # No blocking pass
@@ -862,6 +871,7 @@ class TestFetchNewPPT:
         mock_ppt.next_vis = Mock(return_value=1000.0)
         mock_ppt.ss_max = 3600.0
         mock_ppt.ss_min = 300.0
+        mock_ppt.windows = [[0.0, 1e12]]
         cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
 
         # No blocking pass
@@ -1134,9 +1144,11 @@ class TestCalcMethod:
         mock_ppt.next_vis = Mock(return_value=1543276800.0)
         mock_ppt.ss_max = 3600.0
         mock_ppt.ss_min = 300.0
+        mock_ppt.windows = [[0.0, 1e12]]
         mock_ppt.copy = Mock(return_value=Mock())
         mock_ppt.copy.return_value.begin = 1543622400
         mock_ppt.copy.return_value.end = 1543629600
+        mock_ppt.copy.return_value.obstype = "PPT"
 
         queue_ditl.queue.get = Mock(side_effect=[mock_ppt] + [None] * 1500)
         queue_ditl.calc()
@@ -1290,6 +1302,7 @@ class TestCalcMethod:
         science_copy.slewtime = science_entry.slewtime
         science_copy.insaa = science_entry.insaa
         science_copy.ss_min = science_entry.ss_min
+        science_copy.obsid = science_entry.obsid
         science_entry.copy = Mock(return_value=science_copy)
 
         charging_entry = Mock()
@@ -1340,9 +1353,11 @@ class TestCalcMethod:
         mock_ppt.next_vis = Mock(return_value=1543276800.0)
         mock_ppt.ss_max = 3600.0
         mock_ppt.ss_min = 300.0
+        mock_ppt.windows = [[0.0, 1e12]]
         mock_ppt.copy = Mock(return_value=Mock())
         mock_ppt.copy.return_value.begin = 1543622400
         mock_ppt.copy.return_value.end = 1543708800
+        mock_ppt.copy.return_value.obstype = "PPT"
         queue_ditl.queue.get = Mock(return_value=mock_ppt)
         queue_ditl.calc()
         if queue_ditl.plan:
@@ -1488,6 +1503,7 @@ class TestCalcMethod:
         mock_previous_ppt = Mock(spec=PlanEntry)
         mock_previous_ppt.begin = 1000.0
         mock_previous_ppt.end = 1000.0 + 86400 + 100  # Placeholder end time
+        mock_previous_ppt.obstype = "PPT"
         mock_previous_ppt.copy = Mock(return_value=mock_previous_ppt)
 
         # Create current PPT
@@ -1518,6 +1534,8 @@ class TestCalcMethod:
         previous_ppt.begin = 1000.0
         previous_ppt.end = 1000.0 + 86400 + 100
         previous_ppt.slewtime = 224.0
+        previous_ppt.insaa = 0.0
+        previous_ppt.ss_min = 300
         previous_ppt.obsid = 1001
 
         current_ppt = Mock()
@@ -1573,6 +1591,7 @@ class TestCalcMethod:
         mock_ppt = Mock(spec=PlanEntry)
         mock_ppt.begin = 1000.0
         mock_ppt.end = 1000.0 + 86400 + 100  # Placeholder end time
+        mock_ppt.obstype = "PPT"
 
         # Set up plan with the PPT and set current ppt to None
         queue_ditl.plan = [mock_ppt]
@@ -1593,6 +1612,7 @@ class TestCalcMethod:
         mock_ppt.begin = 1000.0
         mock_ppt.end = 2000.0
         mock_ppt.obsid = 1001  # Add obsid attribute
+        mock_ppt.obstype = "PPT"
 
         # Set up the PPT
         queue_ditl.plan = [mock_ppt]
@@ -1618,6 +1638,7 @@ class TestCalcMethod:
         mock_ppt.next_vis = Mock(return_value=1000.0)
         mock_ppt.ss_max = 3600.0
         mock_ppt.ss_min = 300.0
+        mock_ppt.windows = [[0.0, 1e12]]
         queue_ditl.queue.get = Mock(return_value=mock_ppt)
 
         # Create a mock current slew that's still slewing
@@ -1650,6 +1671,7 @@ class TestCalcMethod:
         mock_ppt.next_vis = Mock(return_value=1200.0)
         mock_ppt.ss_max = 3600.0
         mock_ppt.ss_min = 300.0
+        mock_ppt.windows = [[0.0, 1e12]]
         queue_ditl.queue.get = Mock(return_value=mock_ppt)
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
 
@@ -1672,6 +1694,7 @@ class TestCalcMethod:
         mock_ppt = Mock(spec=PlanEntry)
         mock_ppt.begin = 1000.0
         mock_ppt.end = 2000.0
+        mock_ppt.obstype = "PPT"
 
         # Set up the PPT
         queue_ditl.plan = [mock_ppt]
@@ -1693,6 +1716,7 @@ class TestCalcMethod:
         mock_charging_ppt = Mock(spec=PlanEntry)
         mock_charging_ppt.begin = 1000.0
         mock_charging_ppt.end = 2000.0
+        mock_charging_ppt.obstype = "PPT"
 
         # Set up the charging PPT
         queue_ditl.plan = [mock_charging_ppt]

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -435,10 +435,14 @@ class TestManagePPTLifecycle:
         mock_ppt.ra = 10.0
         mock_ppt.dec = 20.0
         mock_ppt.end = 2000.0
+        mock_ppt.obsid = 1001
         queue_ditl.ppt = mock_ppt
         queue_ditl.charging_ppt = None
+        cast(Mock, queue_ditl.constraint).in_constraint = Mock(return_value=True)
         queue_ditl._manage_ppt_lifecycle(1000.0, ACSMode.SLEWING)
         assert mock_ppt.exptime == 300.0
+        assert queue_ditl.ppt is mock_ppt
+        cast(Mock, queue_ditl.constraint).in_constraint.assert_not_called()
 
     def test_manage_ppt_becomes_constrained_terminates(
         self, queue_ditl: QueueDITL
@@ -650,6 +654,7 @@ class TestFetchNewPPT:
         self, queue_ditl: QueueDITL
     ) -> None:
         """Test target rejection when there's not enough time before next pass."""
+        queue_ditl.ephem.step_size = 60
         # Setup mock PPT with minimum observation time requirement
         mock_ppt = Mock()
         mock_ppt.ra = 45.0
@@ -684,10 +689,43 @@ class TestFetchNewPPT:
         assert "available before pass" in log_text
         assert str(mock_ppt.obsid) in log_text
 
+    def test_fetch_ppt_rejects_when_pass_slew_buffer_consumes_minimum_collect(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Pass admission should include the early trigger used by pass slews."""
+        queue_ditl.ephem.step_size = 60
+
+        mock_ppt = Mock()
+        mock_ppt.ra = 45.0
+        mock_ppt.dec = 30.0
+        mock_ppt.obsid = 1001
+        mock_ppt.next_vis = Mock(return_value=1000.0)
+        mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 200.0
+        cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
+
+        cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
+
+        mock_next_pass = Mock()
+        mock_next_pass.begin = 1450.0
+        mock_next_pass.gsstartra = 100.0
+        mock_next_pass.gsstartdec = 50.0
+        cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(
+            return_value=mock_next_pass
+        )
+
+        queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        assert queue_ditl.ppt is None
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "rejected - only 130s available before pass" in log_text
+
     def test_fetch_ppt_accepts_with_sufficient_observation_time(
         self, queue_ditl
     ) -> None:
         """Test target acceptance when there's enough time before next pass."""
+        queue_ditl.ephem.step_size = 60
         # Setup mock PPT
         mock_ppt = Mock()
         mock_ppt.ra = 45.0
@@ -716,6 +754,62 @@ class TestFetchNewPPT:
         assert queue_ditl.ppt is mock_ppt
         # Command should be enqueued
         cast(Mock, queue_ditl.acs.enqueue_command).assert_called_once()
+
+    def test_fetch_ppt_retries_when_top_target_cannot_collect(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Reject an infeasible top target and commit the next feasible target."""
+        queue_ditl.ephem.step_size = 60
+        bad_ppt = Mock()
+        bad_ppt.ra = 45.0
+        bad_ppt.dec = 30.0
+        bad_ppt.obsid = 1001
+        bad_ppt.done = False
+        bad_ppt.windows = []
+        bad_ppt.visible = Mock(return_value=[1000.0, 5000.0])
+        bad_ppt.next_vis = Mock(return_value=1000.0)
+        bad_ppt.ss_max = 3600.0
+        bad_ppt.ss_min = 300.0
+
+        good_ppt = Mock()
+        good_ppt.ra = 46.0
+        good_ppt.dec = 31.0
+        good_ppt.obsid = 1002
+        good_ppt.done = False
+        good_ppt.windows = []
+        good_ppt.visible = Mock(return_value=[1000.0, 5000.0])
+        good_ppt.next_vis = Mock(return_value=1000.0)
+        good_ppt.ss_max = 3600.0
+        good_ppt.ss_min = 30.0
+
+        targets = [bad_ppt, good_ppt]
+        queue_ditl.queue.targets = targets
+
+        def get_next_not_done(ra: float, dec: float, utime: float) -> Mock | None:
+            return next((target for target in targets if not target.done), None)
+
+        cast(Mock, queue_ditl.queue).get = Mock(side_effect=get_next_not_done)
+        cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
+
+        mock_next_pass = Mock()
+        mock_next_pass.begin = 1400.0
+        mock_next_pass.gsstartra = 100.0
+        mock_next_pass.gsstartdec = 50.0
+        cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(
+            return_value=mock_next_pass
+        )
+
+        queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        assert queue_ditl.ppt is good_ppt
+        assert bad_ppt.done is False
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_called_once()
+        command = cast(Mock, queue_ditl.acs.enqueue_command).call_args[0][0]
+        assert command.slew.obsid == good_ppt.obsid
+
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Target 1001 rejected" in log_text
+        assert "available before pass" in log_text
 
     def test_fetch_ppt_rejects_when_locked_roll_violates_constraint_in_window(
         self, queue_ditl
@@ -1123,6 +1217,113 @@ class TestCalcMethod:
         ]
         assert "START_BATTERY_CHARGE" in command_types
 
+    def test_initiate_charging_leaves_short_science_target_retryable(
+        self, queue_ditl
+    ) -> None:
+        science_ppt = Mock()
+        science_ppt.obstype = "AT"
+        science_ppt.begin = 1000.0
+        science_ppt.end = 1000.0 + 86400
+        science_ppt.slewtime = 200.0
+        science_ppt.insaa = 0.0
+        science_ppt.ss_min = 300.0
+        science_ppt.done = False
+        science_ppt.ra = 10.0
+        science_ppt.dec = 20.0
+        science_ppt.obsid = 1001
+
+        charging_ppt = Mock()
+        charging_ppt.ra = 100.0
+        charging_ppt.dec = 50.0
+        charging_ppt.obsid = 999001
+        charging_ppt.roll = 0.0
+
+        def interrupt_for_charging(utime, ephem, ra, dec, current_ppt):
+            current_ppt.end = utime
+            current_ppt.done = True
+            return charging_ppt
+
+        queue_ditl.ppt = science_ppt
+        queue_ditl.emergency_charging.initiate_emergency_charging = Mock(
+            side_effect=interrupt_for_charging
+        )
+
+        queue_ditl._initiate_charging(1250.0, 10.0, 20.0)
+
+        assert science_ppt.done is False
+        assert queue_ditl.ppt is charging_ppt
+        queue_ditl.acs.enqueue_command.assert_called_once()
+
+    def test_calc_drops_short_science_entry_when_charging_interrupts(
+        self, queue_ditl
+    ) -> None:
+        from datetime import timedelta
+
+        begin = queue_ditl.ephem.timestamp[0]
+        queue_ditl.begin = begin
+        queue_ditl.end = begin + timedelta(seconds=180)
+        queue_ditl.ephem.step_size = 60
+        queue_ditl.ephem.timestamp = [
+            begin + timedelta(seconds=i * 60) for i in range(4)
+        ]
+        queue_ditl.step_size = 60
+        queue_ditl.battery.battery_alert = True
+        queue_ditl.acs.get_mode = Mock(return_value=ACSMode.SCIENCE)
+        queue_ditl.acs.pointing = Mock(return_value=(10.0, 20.0, 0.0, 1001))
+
+        science_entry = Mock()
+        science_entry.obstype = "AT"
+        science_entry.begin = begin.timestamp()
+        science_entry.end = begin.timestamp() + 86400
+        science_entry.slewtime = 120.0
+        science_entry.insaa = 0.0
+        science_entry.ss_min = 300.0
+        science_entry.done = False
+        science_entry.ra = 10.0
+        science_entry.dec = 20.0
+        science_entry.obsid = 1001
+        science_entry.exptime = 1000
+        science_copy = Mock()
+        science_copy.obstype = science_entry.obstype
+        science_copy.begin = science_entry.begin
+        science_copy.end = science_entry.end
+        science_copy.slewtime = science_entry.slewtime
+        science_copy.insaa = science_entry.insaa
+        science_copy.ss_min = science_entry.ss_min
+        science_entry.copy = Mock(return_value=science_copy)
+
+        charging_entry = Mock()
+        charging_entry.obstype = "CHARGE"
+        charging_entry.begin = begin.timestamp()
+        charging_entry.end = begin.timestamp() + 86400
+        charging_entry.slewtime = 0.0
+        charging_entry.ra = 100.0
+        charging_entry.dec = 50.0
+        charging_entry.obsid = 999001
+        charging_entry.roll = 0.0
+        charging_entry.copy = Mock(return_value=charging_entry)
+
+        def interrupt_for_charging(utime, ephem, ra, dec, current_ppt):
+            current_ppt.end = utime
+            current_ppt.done = True
+            return charging_entry
+
+        queue_ditl.ppt = science_entry
+        queue_ditl.emergency_charging.should_initiate_charging = Mock(return_value=True)
+        queue_ditl.emergency_charging.initiate_emergency_charging = Mock(
+            side_effect=interrupt_for_charging
+        )
+
+        assert queue_ditl.calc() is True
+
+        science_entries = [
+            entry
+            for entry in queue_ditl.plan
+            if getattr(entry, "obstype", None) == "AT"
+        ]
+        assert science_entries == []
+        assert science_entry.done is False
+
     def test_calc_closes_final_ppt_end_set(self, queue_ditl) -> None:
         queue_ditl.year = 2018
         queue_ditl.day = 331
@@ -1307,6 +1508,60 @@ class TestCalcMethod:
             mock_previous_ppt.end == 2000.0
         )  # Should be set to current PPT begin time
         assert len(queue_ditl.plan) == 2  # Should have both PPTs now
+
+    def test_track_ppt_drops_science_entry_closed_before_collect(
+        self, queue_ditl
+    ) -> None:
+        """A science entry truncated before slew completion is not kept as AT."""
+        previous_ppt = Mock()
+        previous_ppt.obstype = "AT"
+        previous_ppt.begin = 1000.0
+        previous_ppt.end = 1000.0 + 86400 + 100
+        previous_ppt.slewtime = 224.0
+        previous_ppt.obsid = 1001
+
+        current_ppt = Mock()
+        current_ppt.begin = 1060.0
+        current_ppt.end = 3000.0
+        current_ppt.copy = Mock(return_value=current_ppt)
+
+        queue_ditl.plan = [previous_ppt]
+        queue_ditl.ppt = current_ppt
+
+        queue_ditl._track_ppt_in_timeline()
+
+        assert previous_ppt not in queue_ditl.plan
+        assert queue_ditl.plan == [current_ppt]
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Dropping under-collected science entry 1001" in log_text
+        assert "collected 0s" in log_text
+
+    def test_track_ppt_drops_science_entry_below_ss_min(self, queue_ditl) -> None:
+        """A science entry with less than ss_min collection is not kept as AT."""
+        previous_ppt = Mock()
+        previous_ppt.obstype = "AT"
+        previous_ppt.begin = 1000.0
+        previous_ppt.end = 1000.0 + 86400 + 100
+        previous_ppt.slewtime = 100.0
+        previous_ppt.insaa = 0.0
+        previous_ppt.ss_min = 300.0
+        previous_ppt.obsid = 1002
+
+        current_ppt = Mock()
+        current_ppt.begin = 1350.0
+        current_ppt.end = 3000.0
+        current_ppt.copy = Mock(return_value=current_ppt)
+
+        queue_ditl.plan = [previous_ppt]
+        queue_ditl.ppt = current_ppt
+
+        queue_ditl._track_ppt_in_timeline()
+
+        assert previous_ppt not in queue_ditl.plan
+        assert queue_ditl.plan == [current_ppt]
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Dropping under-collected science entry 1002" in log_text
+        assert "collected 250s of required 300s" in log_text
 
     def test_close_ppt_timeline_if_needed_closes_when_ppt_none(
         self, queue_ditl


### PR DESCRIPTION
## Summary

Closes #135.

This fixes the scheduler invariant that science `AT` entries should only be emitted when they collect at least `ss_min` after slew/INSAA.

Changes:
- reject science targets that cannot collect `ss_min` before the next science deadline, then retry the next queue candidate
- drop science plan fragments that get closed before collecting `ss_min`
- avoid normal science termination while ACS is still slewing
- keep interrupted under-collected science targets retryable after emergency charging
- clamp `PlanEntry.exposure` at zero so serialized plans do not report negative exposure

## Validation

- `ruff check conops/ditl/queue_ditl.py conops/targets/plan_entry.py tests/scheduler_queue/test_queue_ditl.py tests/plan_entry/test_plan_entry.py`
- `mypy --strict conops/ditl/queue_ditl.py conops/targets/plan_entry.py`
- `pytest`

Result: `1920 passed, 1 skipped`.

Closed-loop regenerated comparison against the reconstructed problematic Tamalpais case:
- invalid v0: 36 short science entries, 16 negative exposures
- fixed run: 0 short science entries, 0 negative exposures
- observing time increased from `18:30:42` to `19:33:02`
- slewing decreased from `04:35:18` to `03:30:43`