### PR TITLE
feat: represent commanded ground-station passes as plan activities

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -19,7 +19,7 @@ from ..common.vector import attitude_to_quat
 from ..config import MissionConfig
 from ..simulation.acs_command import ACSCommand
 from ..simulation.emergency_charging import EmergencyCharging
-from ..simulation.passes import pass_slew_trigger_buffer
+from ..simulation.passes import Pass, pass_slew_trigger_buffer
 from ..simulation.roll import optimum_roll
 from ..simulation.slew import Slew
 from ..targets import Plan, PlanEntry, Pointing, Queue
@@ -150,6 +150,7 @@ class QueueDITL(DITLMixin, DITLStats):
         # Set True when the queue is empty or all candidates are rejected; False on
         # successful dispatch; None during a pass (spacecraft is occupied).
         self._ppt_unavailable: bool | None = None
+        self._planned_gsp_keys: set[tuple[str, float, float]] = set()
 
     def get_acs_queue_status(self) -> dict[str, Any]:
         """
@@ -713,6 +714,9 @@ class QueueDITL(DITLMixin, DITLStats):
 
         # Fetch new PPT if none is active
         if self.ppt is None:
+            if self._gsp_activity_in_progress(utime):
+                self._ppt_unavailable = None
+                return
             self._fetch_new_ppt(utime, ra, dec)
 
     def _should_initiate_charging(self, utime: float) -> bool:
@@ -797,12 +801,133 @@ class QueueDITL(DITLMixin, DITLStats):
                     description="No groundstation passes scheduled.",
                 )
 
+    @staticmethod
+    def _ground_pass_times(gspass: Pass) -> tuple[float, float]:
+        return float(gspass.begin), float(gspass.end)
+
+    def _ground_pass_key(self, gspass: Pass) -> tuple[str, float, float]:
+        pass_begin, pass_end = self._ground_pass_times(gspass)
+        return gspass.station, pass_begin, pass_end
+
+    def _overlaps_planned_gsp(self, gspass: Pass) -> bool:
+        pass_begin, pass_end = self._ground_pass_times(gspass)
+        return any(
+            entry.obstype == ObsType.GSP
+            and pass_begin < float(entry.end)
+            and pass_end > float(entry.begin)
+            for entry in self.plan
+        )
+
+    def _gsp_activity_in_progress(self, utime: float) -> bool:
+        return any(
+            entry.obstype == ObsType.GSP
+            and float(entry.begin) <= utime < float(entry.end)
+            for entry in self.plan
+        )
+
+    def _terminate_active_ppt_for_gsp(self, utime: float) -> None:
+        if self.ppt is None:
+            return
+        if self.ppt == self.charging_ppt:
+            self._terminate_charging_ppt(utime)
+        else:
+            self._terminate_science_ppt_for_pass(utime)
+
+    def _gsp_plan_entry_allowed(self, gspass: Pass, reserved_begin: float) -> bool:
+        """Check whether this pass should be represented in the exported plan."""
+        key = self._ground_pass_key(gspass)
+        if key in self._planned_gsp_keys:
+            return True
+
+        if self._overlaps_planned_gsp(gspass):
+            self.log.log_event(
+                utime=reserved_begin,
+                event_type="PASS",
+                description=f"Skipping overlapping pass opportunity for {gspass.station}",
+                obsid=gspass.obsid,
+                acs_mode=self.acs.acsmode,
+            )
+            return False
+
+        return True
+
+    def _record_gsp_plan_entry(self, gspass: Pass, reserved_begin: float) -> bool:
+        """Record an accepted ground-station pass command in the exported plan."""
+        key = self._ground_pass_key(gspass)
+        if key in self._planned_gsp_keys:
+            return True
+
+        station, pass_begin, pass_end = key
+        entry_begin = float(reserved_begin)
+
+        self._terminate_active_ppt_for_gsp(entry_begin)
+
+        if len(self.plan) > 0:
+            last_entry = self.plan[-1]
+            if last_entry.obstype != ObsType.GSP and last_entry.end > entry_begin:
+                self._close_last_plan_entry(entry_begin)
+
+        entry = PlanEntry(config=self.config)
+        entry.name = f"{station}_PASS"
+        entry.ra = float(gspass.gsstartra)
+        entry.dec = float(gspass.gsstartdec)
+        entry.begin = entry_begin
+        entry.end = pass_end
+        entry.slewtime = max(0, int(round(pass_begin - entry_begin)))
+        entry.obsid = int(gspass.obsid)
+        entry.obstype = ObsType.GSP
+        entry.ss_min = 0
+        contact_duration = max(0, int(round(pass_end - entry_begin - entry.slewtime)))
+        entry.ss_max = contact_duration
+        entry.exptime = contact_duration
+        entry.station = station
+        entry.contact_begin = pass_begin
+        entry.contact_end = pass_end
+
+        self.plan.append(entry)
+        self._planned_gsp_keys.add(key)
+        self.log.log_event(
+            utime=entry_begin,
+            event_type="PASS",
+            description=(
+                f"Added GSP plan entry for {station} pass from "
+                f"{unixtime2date(entry_begin)} to {unixtime2date(pass_end)}"
+            ),
+            obsid=entry.obsid,
+            acs_mode=self.acs.acsmode,
+        )
+        return True
+
     def _check_and_manage_passes(self, utime: float, ra: float, dec: float) -> None:
         """Check pass timing and send appropriate commands to ACS."""
+
+        if self.acs.in_safe_mode or self.acs.acsmode == ACSMode.SAFE:
+            return
+
+        commanded_pass = self.acs.current_pass
+        if (
+            self.acs.acsmode == ACSMode.PASS
+            and commanded_pass is not None
+            and not commanded_pass.in_pass(utime)
+        ):
+            self.log.log_event(
+                utime=utime,
+                event_type="PASS",
+                description="Commanded pass ended, commanding ACS to end pass",
+                acs_mode=self.acs.acsmode,
+            )
+            command = ACSCommand(
+                command_type=ACSCommandType.END_PASS,
+                execution_time=utime,
+            )
+            self.acs.enqueue_command(command)
+            return
 
         # Check if we're in a pass, if yes, command ACS to start the pass
         current_pass = self.acs.passrequests.current_pass(utime)
         if current_pass is not None and self.acs.acsmode != ACSMode.PASS:
+            if not self._gsp_plan_entry_allowed(current_pass, reserved_begin=utime):
+                return
             self.log.log_event(
                 utime=utime,
                 event_type="PASS",
@@ -814,6 +939,7 @@ class QueueDITL(DITLMixin, DITLStats):
                 execution_time=utime,
             )
             self.acs.enqueue_command(command)
+            self._record_gsp_plan_entry(current_pass, reserved_begin=utime)
             return
 
         # Check if a pass just ended, if yes, command ACS to end the pass.
@@ -849,6 +975,8 @@ class QueueDITL(DITLMixin, DITLStats):
 
         # Check if it's time to start slewing for the next pass
         if next_pass.time_to_slew(utime=utime, ra=ra, dec=dec):
+            if not self._gsp_plan_entry_allowed(next_pass, reserved_begin=utime):
+                return
             # If it's time to slew, enqueue the slew command
             self.log.log_event(
                 utime=utime,
@@ -873,6 +1001,7 @@ class QueueDITL(DITLMixin, DITLStats):
                 slew=slew,
             )
             self.acs.enqueue_command(command)
+            self._record_gsp_plan_entry(next_pass, reserved_begin=utime)
             return
 
     def _handle_pass_mode(self, utime: float) -> None:

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -801,27 +801,20 @@ class QueueDITL(DITLMixin, DITLStats):
                     description="No groundstation passes scheduled.",
                 )
 
-    @staticmethod
-    def _ground_pass_times(gspass: Pass) -> tuple[float, float]:
-        return float(gspass.begin), float(gspass.end)
-
     def _ground_pass_key(self, gspass: Pass) -> tuple[str, float, float]:
-        pass_begin, pass_end = self._ground_pass_times(gspass)
-        return gspass.station, pass_begin, pass_end
+        return gspass.station, gspass.begin, gspass.end
 
     def _overlaps_planned_gsp(self, gspass: Pass) -> bool:
-        pass_begin, pass_end = self._ground_pass_times(gspass)
         return any(
             entry.obstype == ObsType.GSP
-            and pass_begin < float(entry.end)
-            and pass_end > float(entry.begin)
+            and gspass.begin < entry.end
+            and gspass.end > entry.begin
             for entry in self.plan
         )
 
     def _gsp_activity_in_progress(self, utime: float) -> bool:
         return any(
-            entry.obstype == ObsType.GSP
-            and float(entry.begin) <= utime < float(entry.end)
+            entry.obstype == ObsType.GSP and entry.begin <= utime < entry.end
             for entry in self.plan
         )
 
@@ -858,26 +851,27 @@ class QueueDITL(DITLMixin, DITLStats):
             return True
 
         station, pass_begin, pass_end = key
-        entry_begin = float(reserved_begin)
 
-        self._terminate_active_ppt_for_gsp(entry_begin)
+        self._terminate_active_ppt_for_gsp(reserved_begin)
 
         if len(self.plan) > 0:
             last_entry = self.plan[-1]
-            if last_entry.obstype != ObsType.GSP and last_entry.end > entry_begin:
-                self._close_last_plan_entry(entry_begin)
+            if last_entry.obstype != ObsType.GSP and last_entry.end > reserved_begin:
+                self._close_last_plan_entry(reserved_begin)
 
         entry = PlanEntry(config=self.config)
         entry.name = f"{station}_PASS"
-        entry.ra = float(gspass.gsstartra)
-        entry.dec = float(gspass.gsstartdec)
-        entry.begin = entry_begin
+        entry.ra = gspass.gsstartra
+        entry.dec = gspass.gsstartdec
+        entry.begin = reserved_begin
         entry.end = pass_end
-        entry.slewtime = max(0, int(round(pass_begin - entry_begin)))
-        entry.obsid = int(gspass.obsid)
+        entry.slewtime = max(0, int(round(pass_begin - reserved_begin)))
+        entry.obsid = gspass.obsid
         entry.obstype = ObsType.GSP
         entry.ss_min = 0
-        contact_duration = max(0, int(round(pass_end - entry_begin - entry.slewtime)))
+        contact_duration = max(
+            0, int(round(pass_end - reserved_begin - entry.slewtime))
+        )
         entry.ss_max = contact_duration
         entry.exptime = contact_duration
         entry.station = station
@@ -887,11 +881,11 @@ class QueueDITL(DITLMixin, DITLStats):
         self.plan.append(entry)
         self._planned_gsp_keys.add(key)
         self.log.log_event(
-            utime=entry_begin,
+            utime=reserved_begin,
             event_type="PASS",
             description=(
                 f"Added GSP plan entry for {station} pass from "
-                f"{unixtime2date(entry_begin)} to {unixtime2date(pass_end)}"
+                f"{unixtime2date(reserved_begin)} to {unixtime2date(pass_end)}"
             ),
             obsid=entry.obsid,
             acs_mode=self.acs.acsmode,

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -794,6 +794,16 @@ class QueueDITL(DITLMixin, DITLStats):
                         event_type="PASS",
                         description=f"Scheduled pass: {p}",
                     )
+                dropped_passes = self.acs.passrequests.dropped_overlapping_passes
+                for dropped, selected in dropped_passes:
+                    self.log.log_event(
+                        utime=self.ustart,
+                        event_type="PASS",
+                        description=(
+                            f"Skipped overlapping pass opportunity: {dropped} "
+                            f"overlaps selected pass {selected}"
+                        ),
+                    )
             else:
                 self.log.log_event(
                     utime=self.ustart,

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -291,6 +291,7 @@ class PassTimes:
 
         self.config = config
         self.passes = []
+        self.dropped_overlapping_passes: list[tuple[Pass, Pass]] = []
         self.length = 1
 
         # Ground stations registry from config
@@ -333,6 +334,35 @@ class PassTimes:
                 sched.extend([gspass])
                 last = sched[-1].begin
         return sched
+
+    def _station_downlink_rate_mbps(self, gspass: Pass) -> float:
+        try:
+            rate = self.ground_stations.get(gspass.station).get_overall_max_downlink()
+        except KeyError:
+            return 0.0
+        return 0.0 if rate is None else rate
+
+    def _pass_selection_key(self, gspass: Pass) -> tuple[float, float, float]:
+        rate = self._station_downlink_rate_mbps(gspass)
+        return (rate * gspass.length, gspass.length, -gspass.begin)
+
+    def _deconflict_overlapping_passes(self) -> None:
+        selected: list[Pass] = []
+        self.dropped_overlapping_passes = []
+
+        for gspass in sorted(self.passes, key=lambda x: x.begin, reverse=False):
+            if not selected or selected[-1].end <= gspass.begin:
+                selected.append(gspass)
+                continue
+
+            incumbent = selected[-1]
+            if self._pass_selection_key(gspass) > self._pass_selection_key(incumbent):
+                selected[-1] = gspass
+                self.dropped_overlapping_passes.append((incumbent, gspass))
+            else:
+                self.dropped_overlapping_passes.append((gspass, incumbent))
+
+        self.passes = selected
 
     def get(self, year: int, day: int, length: int = 1) -> None:
         """Calculate the passes using rust_ephem GroundEphemeris for vectorized operations."""
@@ -506,3 +536,4 @@ class PassTimes:
 
         # Order the passes by time
         self.passes.sort(key=lambda x: x.begin, reverse=False)
+        self._deconflict_overlapping_passes()

--- a/conops/targets/plan_entry.py
+++ b/conops/targets/plan_entry.py
@@ -25,6 +25,9 @@ class PlanEntry:
     merit: float
     saa: SAA | None
     slewpath: tuple[list[float], list[float]]
+    station: str | None
+    contact_begin: float | None
+    contact_end: float | None
 
     def __init__(
         self,
@@ -51,6 +54,9 @@ class PlanEntry:
         self.insaa = 0
         self.end = 0
         self.obsid = 0
+        self.station = None
+        self.contact_begin = None
+        self.contact_end = None
 
         self.saa = None
         self.merit = 101

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -70,22 +70,29 @@ class PlanEntrySchema(BaseModel):
     isat: bool = False
     done: bool = False
     exposure: int = 0
+    station: str | None = None
+    contact_begin: float | None = None
+    contact_end: float | None = None
 
     @staticmethod
     def _computed_exposure(entry: PlanEntry) -> int:
         exposure = entry.end - entry.begin - entry.slewtime - entry.insaa
         return max(0, int(exposure))
 
-    @field_validator("begin", "end", mode="before")
+    @field_validator("begin", "end", "contact_begin", "contact_end", mode="before")
     @classmethod
-    def _coerce_time(cls, v: Any) -> float:
+    def _coerce_time(cls, v: Any) -> float | None:
         """Accept Unix timestamps (float/int) or ISO-8601 strings."""
+        if v is None:
+            return None
         if isinstance(v, str):
             return datetime.fromisoformat(v).timestamp()
         return float(v)
 
-    @field_serializer("begin", "end")
-    def _serialize_time(self, v: float) -> str:
+    @field_serializer("begin", "end", "contact_begin", "contact_end")
+    def _serialize_time(self, v: float | None) -> str | None:
+        if v is None:
+            return None
         return datetime.fromtimestamp(v, tz=timezone.utc).isoformat()
 
     @model_validator(mode="before")
@@ -113,6 +120,9 @@ class PlanEntrySchema(BaseModel):
                 "isat": getattr(data, "isat", False),
                 "done": getattr(data, "done", False),
                 "exposure": cls._computed_exposure(data),
+                "station": getattr(data, "station", None),
+                "contact_begin": getattr(data, "contact_begin", None),
+                "contact_end": getattr(data, "contact_end", None),
             }
         return data
 
@@ -296,7 +306,7 @@ class PlanSchema(BaseModel):
         else:
             schema = self
             dest.parent.mkdir(parents=True, exist_ok=True)
-        payload = schema.model_dump(mode="json")
+        payload = schema.model_dump(mode="json", exclude_none=True)
         dest.write_text(json.dumps(payload, indent=indent), encoding="utf-8")
         return dest.resolve()
 

--- a/conops/visualization/mpl/ditl_timeline.py
+++ b/conops/visualization/mpl/ditl_timeline.py
@@ -14,7 +14,7 @@ from matplotlib.figure import Figure
 from conops.ditl.ditl import DITL
 from conops.ditl.queue_ditl import QueueDITL
 
-from ...common import ACSMode
+from ...common import ACSMode, ObsType
 from ...config import ObservationCategories
 from ...config.visualization import VisualizationConfig
 
@@ -373,6 +373,9 @@ def _extract_observations(
     }
 
     for ppt in ditl.plan:
+        if ppt.obstype == ObsType.GSP:
+            continue
+
         # Calculate observation start and duration
         obs_start = (ppt.begin + ppt.slewtime - t_start) / 3600 - offset_hours
         obs_duration = (ppt.end - (ppt.begin + ppt.slewtime)) / 3600

--- a/conops/visualization/plotly/ditl_timeline.py
+++ b/conops/visualization/plotly/ditl_timeline.py
@@ -15,7 +15,7 @@ from matplotlib.axes import Axes
 from conops.ditl.ditl import DITL
 from conops.ditl.queue_ditl import QueueDITL
 
-from ...common import ACSMode
+from ...common import ACSMode, ObsType
 from ...config import ObservationCategories
 from ...config.visualization import VisualizationConfig
 
@@ -98,6 +98,9 @@ def _extract_observations(
     }
 
     for ppt in ditl.plan:
+        if ppt.obstype == ObsType.GSP:
+            continue
+
         # Calculate observation start and duration
         obs_start = (ppt.begin + ppt.slewtime - t_start) / 3600 - offset_hours
         obs_duration = (ppt.end - (ppt.begin + ppt.slewtime)) / 3600

--- a/docs/communications.rst
+++ b/docs/communications.rst
@@ -288,6 +288,48 @@ Example:
    # Spacecraft: S @ 10 Mbps, X @ 150 Mbps
    # Effective rate: 150 Mbps (X-band, SC limited)
 
+Ground Station Pass (GSP) Plan Entries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When :class:`~conops.ditl.queue_ditl.QueueDITL` executes a Day-In-The-Life simulation,
+commanded ground station passes are automatically exported as ``GSP`` plan entries in the
+observation plan. These entries capture:
+
+* **Station identification**: Which ground station is used (``station`` field)
+* **Contact window**: Actual pass start/end times (``contact_begin``, ``contact_end``)
+* **Preparation time**: Slew time to point at the station before contact begins
+* **Deconfliction**: When multiple stations are simultaneously visible, the system selects
+  the pass with the highest expected data volume (downlink rate × duration)
+
+**Key behavior:**
+
+* GSP entries are created only for passes the spacecraft actually commands and executes
+* Overlapping pass opportunities are automatically deconflicted; the highest-value pass is selected
+* Passes are not commanded (and no GSP entry is created) when the spacecraft is in SAFE mode
+* GSP entries are excluded from science observation timelines in visualization plots
+
+**Example workflow:**
+
+.. code-block:: python
+
+   from conops import QueueDITL, MissionConfig
+   from conops.ephemeris import TLEEphemeris
+
+   # Run DITL with ground station passes
+   ditl = QueueDITL(config=config, ephem=ephem, queue=queue)
+   ditl.calc()
+
+   # Export plan with GSP entries
+   ditl.plan.save("observation_plan.json")
+
+   # GSP entries appear in the saved plan with obstype="GSP"
+   for entry in ditl.plan:
+       if entry.obstype == ObsType.GSP:
+           print(f"Ground pass: {entry.station} from "
+                 f"{entry.contact_begin} to {entry.contact_end}")
+
+See :doc:`plan_serialization` for details on the GSP entry format and serialization.
+
 Implementation Notes
 --------------------
 

--- a/docs/data_management.rst
+++ b/docs/data_management.rst
@@ -198,6 +198,59 @@ During a ground station pass in DITL simulation:
    time_step = 60  # seconds
    data_downlinked = downlink_rate_gbps * time_step  # 6.0 Gb
 
+Ground Station Pass Plan Entries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting with version 0.2.0, :class:`~conops.ditl.queue_ditl.QueueDITL` automatically
+creates plan entries for commanded ground station passes. These ``GSP`` (Ground Station Pass)
+entries appear in the exported observation plan alongside science observations.
+
+**Pass Deconfliction**
+
+When multiple ground stations are visible simultaneously (overlapping pass windows),
+COASTSim automatically selects the pass with the highest expected data volume:
+
+.. code-block:: python
+
+   # Selection metric: downlink_rate × pass_duration
+   # Prefers: higher data volume > longer pass > earlier start time
+
+Overlapping opportunities that are not selected are logged but not executed, preventing
+accidental "tail contacts" where a second pass starts during an ongoing pass.
+
+**Pass Metadata**
+
+Each GSP entry includes:
+
+* ``station``: Ground station code (e.g., ``"SGS"``, ``"TRO"``)
+* ``contact_begin``: Actual pass start time
+* ``contact_end``: Actual pass end time
+* ``slewtime``: Time spent slewing to point at the station
+
+The GSP entry's ``begin`` time marks when the spacecraft reserves the pass window
+(potentially including slew preparation), while ``contact_begin`` marks when data
+downlink actually starts.
+
+**Example:**
+
+.. code-block:: python
+
+   from conops import QueueDITL
+
+   ditl = QueueDITL(config=config, ephem=ephem, queue=queue)
+   ditl.calc()
+
+   # Find ground station passes in the plan
+   for entry in ditl.plan:
+       if entry.obstype == ObsType.GSP:
+           downlink_time = entry.contact_end - entry.contact_begin
+           rate = config.ground_stations.get(entry.station).get_overall_max_downlink()
+           volume = rate * downlink_time / 1000.0  # Convert to Gb
+           print(f"{entry.station}: {downlink_time}s at {rate} Mbps = {volume:.1f} Gb")
+
+See :doc:`plan_serialization` for complete details on GSP entry format and
+:doc:`communications` for pass selection behavior.
+
 Integration with DITL
 ----------------------
 

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -104,6 +104,30 @@ The JSON file contains a metadata envelope followed by the entry list.
          "isat": false,
          "done": true,
          "exposure": 880
+       },
+       {
+         "name": "SGS_PASS",
+         "ra": 120.0,
+         "dec": 45.0,
+         "roll": 0.0,
+         "begin": "2025-12-01T00:18:00+00:00",
+         "end": "2025-12-01T00:28:00+00:00",
+         "merit": 101.0,
+         "slewtime": 120,
+         "insaa": 0,
+         "obsid": 65535,
+         "obstype": "GSP",
+         "slewdist": 5.2,
+         "ss_min": 45.0,
+         "ss_max": 180.0,
+         "exptime": 480,
+         "exporig": 600,
+         "isat": false,
+         "done": true,
+         "exposure": 480,
+         "station": "SGS",
+         "contact_begin": "2025-12-01T00:20:00+00:00",
+         "contact_end": "2025-12-01T00:28:00+00:00"
        }
      ]
    }
@@ -211,6 +235,65 @@ Entry Fields
    * - ``exposure``
      - int
      - Net science exposure time: ``end − begin − slewtime − insaa`` (seconds).
+   * - ``station``
+     - string | null
+     - Ground station code for ``GSP`` (Ground Station Pass) entries. Only present for
+       ``obstype="GSP"``. Identifies which station is used for the commanded pass.
+   * - ``contact_begin``
+     - string | null
+     - ISO-8601 UTC timestamp of when the ground station contact window begins. Only present
+       for ``obstype="GSP"``. This is the actual pass start time; ``begin`` is the reservation
+       time (which may include slew preparation).
+   * - ``contact_end``
+     - string | null
+     - ISO-8601 UTC timestamp of when the ground station contact window ends. Only present
+       for ``obstype="GSP"``. Typically matches ``end``.
+
+Ground Station Pass (GSP) Entries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Ground station pass entries (``obstype="GSP"``) represent commanded communication windows
+with ground stations. Unlike science observations, these entries capture the reservation
+and execution of data downlink passes.
+
+**Key characteristics of GSP entries:**
+
+* **Automatic creation**: Created by :class:`~conops.ditl.queue_ditl.QueueDITL` when the
+  spacecraft enters a ground station visibility window.
+* **Pass reservation**: The ``begin`` time marks when the spacecraft reserves the window
+  (potentially including slew preparation), while ``contact_begin`` marks the actual start
+  of the ground station contact.
+* **Metadata fields**: The ``station``, ``contact_begin``, and ``contact_end`` fields are
+  only present for GSP entries (``null`` or omitted for other observation types).
+* **Deconfliction**: When multiple ground stations are visible simultaneously, COASTSim
+  automatically selects the pass with the highest expected data volume (downlink rate × duration).
+  Dropped overlapping opportunities are logged but not exported to the plan.
+* **Visualization**: GSP entries are excluded from the science observation bands in
+  :func:`~conops.visualization.mpl.ditl_timeline.plot_ditl_timeline` and
+  :func:`~conops.visualization.plotly.ditl_timeline.plot_ditl_timeline`.
+  Ground station passes are still shown in the timeline's dedicated "Ground Contact" row.
+* **Safe mode**: No GSP entries are created when the spacecraft is in SAFE mode.
+
+**Example GSP entry:**
+
+.. code-block:: json
+
+   {
+     "name": "TRO_PASS",
+     "obstype": "GSP",
+     "station": "TRO",
+     "begin": "2025-12-01T12:00:00+00:00",
+     "contact_begin": "2025-12-01T12:02:00+00:00",
+     "contact_end": "2025-12-01T12:12:00+00:00",
+     "end": "2025-12-01T12:12:00+00:00",
+     "slewtime": 120,
+     "exptime": 600,
+     "obsid": 65535
+   }
+
+In this example, the spacecraft begins reserving the pass window at 12:00:00 (``begin``),
+uses 2 minutes for slew preparation (``slewtime``), and the actual ground station contact
+runs from 12:02:00 to 12:12:00 (``contact_begin`` to ``contact_end``).
 
 .. _auto-versioning:
 

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -11,7 +11,7 @@ from conops import (
     Pass,
     PassTimes,
 )
-from conops.config import AttitudeControlSystem
+from conops.config import AttitudeControlSystem, BandCapability, GroundStation
 from conops.simulation.passes import pass_slew_trigger_buffer
 
 
@@ -419,6 +419,77 @@ class TestPassTimes:
         with patch("numpy.random.random", return_value=0.95):
             scheduled = pt.request_passes(req_gsnum=10, gsprob=0.9)
             assert len(scheduled) == 0
+
+    def test_deconflict_overlapping_passes_prefers_more_data_volume(
+        self, mock_constraint, mock_config
+    ):
+        """Overlapping station opportunities should reduce to one commanded pass."""
+        stations = GroundStationRegistry()
+        stations.add(
+            GroundStation(
+                code="LOW",
+                name="Low rate",
+                latitude_deg=0.0,
+                longitude_deg=0.0,
+                bands=[BandCapability(band="S", downlink_rate_mbps=10.0)],
+            )
+        )
+        stations.add(
+            GroundStation(
+                code="HIGH",
+                name="High rate",
+                latitude_deg=1.0,
+                longitude_deg=1.0,
+                bands=[BandCapability(band="S", downlink_rate_mbps=50.0)],
+            )
+        )
+        mock_config.ground_stations = stations
+        pt = PassTimes(config=mock_config)
+
+        low = Pass(config=mock_config, station="LOW", begin=1000.0, length=600.0)
+        high = Pass(config=mock_config, station="HIGH", begin=1050.0, length=480.0)
+        later = Pass(config=mock_config, station="LOW", begin=1530.0, length=600.0)
+        pt.passes = [low, high, later]
+
+        pt._deconflict_overlapping_passes()
+
+        assert pt.passes == [high, later]
+        assert pt.dropped_overlapping_passes == [(low, high)]
+
+    def test_deconflict_overlapping_passes_prefers_earlier_start_on_tie(
+        self, mock_constraint, mock_config
+    ):
+        """Equal-value overlapping opportunities should keep the earlier pass."""
+        stations = GroundStationRegistry()
+        stations.add(
+            GroundStation(
+                code="A",
+                name="Station A",
+                latitude_deg=0.0,
+                longitude_deg=0.0,
+                bands=[BandCapability(band="S", downlink_rate_mbps=10.0)],
+            )
+        )
+        stations.add(
+            GroundStation(
+                code="B",
+                name="Station B",
+                latitude_deg=1.0,
+                longitude_deg=1.0,
+                bands=[BandCapability(band="S", downlink_rate_mbps=10.0)],
+            )
+        )
+        mock_config.ground_stations = stations
+        pt = PassTimes(config=mock_config)
+
+        earlier = Pass(config=mock_config, station="A", begin=1000.0, length=600.0)
+        later = Pass(config=mock_config, station="B", begin=1050.0, length=600.0)
+        pt.passes = [earlier, later]
+
+        pt._deconflict_overlapping_passes()
+
+        assert pt.passes == [earlier]
+        assert pt.dropped_overlapping_passes == [(later, earlier)]
 
     def test_get_requires_ephemeris(self, mock_constraint, mock_config):
         """Test PassTimes initialization requires ephemeris."""

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -102,6 +102,27 @@ class TestPlanEntrySchema:
         ):
             assert key in dumped, f"Missing key: {key}"
 
+    def test_gsp_contact_metadata_roundtrips(self):
+        entry = PlanEntrySchema(
+            **dict(
+                _ENTRY_DICT,
+                obstype="GSP",
+                station="TRO",
+                contact_begin=1_000_120.0,
+                contact_end=1_000_720.0,
+            )
+        )
+
+        dumped = entry.model_dump(mode="json")
+        assert dumped["station"] == "TRO"
+        assert dumped["contact_begin"] == "1970-01-12T13:48:40+00:00"
+        assert dumped["contact_end"] == "1970-01-12T13:58:40+00:00"
+
+        reloaded = PlanEntrySchema(**dumped)
+        assert reloaded.station == "TRO"
+        assert reloaded.contact_begin == pytest.approx(1_000_120.0)
+        assert reloaded.contact_end == pytest.approx(1_000_720.0)
+
 
 # ── PlanSchema ─────────────────────────────────────────────────────────────────
 
@@ -202,6 +223,9 @@ class TestPlanSchema:
         assert isinstance(entry["begin"], str), "begin should be an ISO-8601 string"
         assert isinstance(entry["end"], str), "end should be an ISO-8601 string"
         assert "T" in entry["begin"]
+        assert "station" not in entry
+        assert "contact_begin" not in entry
+        assert "contact_end" not in entry
 
     def test_load_existing_example_json(self):
         """Load a plan JSON file produced by a previous version (backward compat)."""

--- a/tests/scheduler_queue/conftest.py
+++ b/tests/scheduler_queue/conftest.py
@@ -156,6 +156,7 @@ def queue_ditl(mock_config: Mock, mock_ephem: DummyEphemeris) -> QueueDITL:
 
         mock_acs.acsmode = ACSMode.SCIENCE
         mock_acs.get_mode = Mock(return_value=ACSMode.SCIENCE)
+        mock_acs.in_safe_mode = False
         mock_acs.in_eclipse = False
         # Add star tracker attributes for Housekeeping telemetry
         mock_acs.configure_mock(
@@ -587,6 +588,7 @@ def queue_ditl_no_queue_log(
 
         mock_acs.acsmode = ACSMode.SCIENCE
         mock_acs.get_mode = Mock(return_value=ACSMode.SCIENCE)
+        mock_acs.in_safe_mode = False
         mock_acs.in_eclipse = False
         # Add star tracker attributes for Housekeeping telemetry
         mock_acs.configure_mock(
@@ -662,6 +664,7 @@ def queue_ditl_acs_no_ephem(
 
         mock_acs.acsmode = ACSMode.SCIENCE
         mock_acs.get_mode = Mock(return_value=ACSMode.SCIENCE)
+        mock_acs.in_safe_mode = False
         mock_acs.in_eclipse = False
         # Add star tracker attributes for Housekeeping telemetry
         mock_acs.configure_mock(

--- a/tests/scheduler_queue/conftest.py
+++ b/tests/scheduler_queue/conftest.py
@@ -129,6 +129,7 @@ def queue_ditl(mock_config: Mock, mock_ephem: DummyEphemeris) -> QueueDITL:
         # Mock PassTimes
         mock_pt = Mock()
         mock_pt.passes = []
+        mock_pt.dropped_overlapping_passes = []
         mock_pt.get = Mock()
         mock_pt.check_pass_timing = Mock(
             return_value={"start_pass": None, "end_pass": False, "updated_pass": None}

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -6,8 +6,10 @@ from unittest.mock import Mock, patch
 import pytest
 
 from conops import ACSCommandType, ACSMode, Pass, QueueDITL
+from conops.common.enums import ObsType
 from conops.config.config import MissionConfig
 from conops.ditl.telemetry import Housekeeping
+from conops.targets import PlanEntry, PlanSchema
 
 
 class TestQueueDITLInitialization:
@@ -1983,7 +1985,7 @@ class TestCheckAndManagePasses:
         """Test that START_PASS is issued when entering a pass."""
         utime = 1000.0
         ra, dec = 10.0, 20.0
-        pass_obj = Mock()
+        pass_obj = Pass(station="GS_TEST", begin=950.0, length=600.0)
         queue_ditl.acs.passrequests.current_pass = Mock(return_value=pass_obj)
         queue_ditl.acs.acsmode = ACSMode.SCIENCE  # Not in pass yet
         queue_ditl._check_and_manage_passes(utime, ra, dec)
@@ -1995,7 +1997,7 @@ class TestCheckAndManagePasses:
         """Test that START_PASS command is enqueued when entering pass."""
         utime = 1000.0
         ra, dec = 10.0, 20.0
-        pass_obj = Mock()
+        pass_obj = Pass(station="GS_TEST", begin=950.0, length=600.0)
         queue_ditl.acs.passrequests.current_pass = Mock(return_value=pass_obj)
         queue_ditl.acs.acsmode = ACSMode.SCIENCE  # Not in pass yet
         queue_ditl._check_and_manage_passes(utime, ra, dec)
@@ -2007,7 +2009,7 @@ class TestCheckAndManagePasses:
         """Test START_PASS command has correct type and execution time."""
         utime = 1000.0
         ra, dec = 10.0, 20.0
-        pass_obj = Mock()
+        pass_obj = Pass(station="GS_TEST", begin=950.0, length=600.0)
         queue_ditl.acs.passrequests.current_pass = Mock(return_value=pass_obj)
         queue_ditl.acs.acsmode = ACSMode.SCIENCE  # Not in pass yet
         queue_ditl._check_and_manage_passes(utime, ra, dec)
@@ -2138,13 +2140,13 @@ class TestCheckAndManagePasses:
         utime = 1000.0
         ra, dec = 10.0, 20.0
 
-        # Create a mock pass object
-        pass_obj = Mock()
-        pass_obj.station = "GS_TEST"
-        pass_obj.begin = 1100.0
-        pass_obj.gsstartra = 100.0
-        pass_obj.gsstartdec = 50.0
-        pass_obj.time_to_slew = Mock(return_value=True)
+        pass_obj = Pass(
+            station="GS_TEST",
+            begin=1100.0,
+            length=600.0,
+            gsstartra=100.0,
+            gsstartdec=50.0,
+        )
 
         # Mock the pass request methods
         queue_ditl.acs.passrequests.current_pass = Mock(return_value=None)
@@ -2152,7 +2154,8 @@ class TestCheckAndManagePasses:
         queue_ditl.acs.acsmode = ACSMode.SCIENCE
 
         # Call the method
-        queue_ditl._check_and_manage_passes(utime, ra, dec)
+        with patch.object(Pass, "time_to_slew", return_value=True):
+            queue_ditl._check_and_manage_passes(utime, ra, dec)
 
         # Verify a slew command was enqueued
         queue_ditl.acs.enqueue_command.assert_called_once()
@@ -2170,6 +2173,250 @@ class TestCheckAndManagePasses:
         # Verify slew points to the pass start position
         assert command.slew.endra == pass_obj.gsstartra
         assert command.slew.enddec == pass_obj.gsstartdec
+
+    def test_check_and_manage_passes_exports_gsp_plan_entry_for_pass_slew(
+        self, queue_ditl, tmp_path
+    ) -> None:
+        """Pass slew reservation should create an exported GSP plan entry."""
+        utime = 1000.0
+        ra, dec = 10.0, 20.0
+
+        pass_obj = Pass(
+            station="GS_TEST",
+            begin=1100.0,
+            length=600.0,
+            gsstartra=100.0,
+            gsstartdec=50.0,
+            obsid=4242,
+        )
+
+        queue_ditl.acs.passrequests.current_pass = Mock(return_value=None)
+        queue_ditl.acs.passrequests.next_pass = Mock(return_value=pass_obj)
+        queue_ditl.acs.acsmode = ACSMode.SCIENCE
+
+        with patch.object(Pass, "time_to_slew", return_value=True):
+            queue_ditl._check_and_manage_passes(utime, ra, dec)
+            queue_ditl._check_and_manage_passes(utime, ra, dec)
+
+        gsp_entries = [
+            entry for entry in queue_ditl.plan if entry.obstype == ObsType.GSP
+        ]
+        assert len(gsp_entries) == 1
+        entry = gsp_entries[0]
+        assert entry.name == "GS_TEST_PASS"
+        assert entry.begin == utime
+        assert entry.slewtime == 100
+        assert entry.end == pass_obj.end
+        assert entry.exposure == 600
+        assert entry.exptime == 600
+        assert entry.station == "GS_TEST"
+        assert entry.contact_begin == pass_obj.begin
+        assert entry.contact_end == pass_obj.end
+
+        schema = PlanSchema.from_plan(queue_ditl.plan)
+        assert schema.entries[0].obstype == ObsType.GSP
+        assert schema.entries[0].station == "GS_TEST"
+        assert schema.entries[0].contact_begin == pass_obj.begin
+        saved_path = schema.save(tmp_path / "plan.json")
+        assert '"obstype": "GSP"' in saved_path.read_text()
+        assert '"station": "GS_TEST"' in saved_path.read_text()
+
+    def test_check_and_manage_passes_records_gsp_after_pass_slew_command_enqueue(
+        self, queue_ditl
+    ) -> None:
+        """A GSP plan entry should only be recorded after the pass command path."""
+        utime = 1000.0
+        pass_obj = Pass(
+            station="GS_TEST",
+            begin=1100.0,
+            length=600.0,
+            gsstartra=100.0,
+            gsstartdec=50.0,
+        )
+        enqueued_commands = []
+
+        def enqueue_command(command) -> None:
+            assert not any(entry.obstype == ObsType.GSP for entry in queue_ditl.plan)
+            enqueued_commands.append(command)
+
+        queue_ditl.acs.enqueue_command.side_effect = enqueue_command
+        queue_ditl.acs.passrequests.current_pass = Mock(return_value=None)
+        queue_ditl.acs.passrequests.next_pass = Mock(return_value=pass_obj)
+        queue_ditl.acs.acsmode = ACSMode.SCIENCE
+        queue_ditl.acs.in_safe_mode = False
+
+        with patch.object(Pass, "time_to_slew", return_value=True):
+            queue_ditl._check_and_manage_passes(utime, 10.0, 20.0)
+
+        assert enqueued_commands[0].command_type == ACSCommandType.SLEW_TO_TARGET
+        gsp_entries = [
+            entry for entry in queue_ditl.plan if entry.obstype == ObsType.GSP
+        ]
+        assert len(gsp_entries) == 1
+
+    def test_check_and_manage_passes_safe_mode_does_not_export_gsp(
+        self, queue_ditl
+    ) -> None:
+        """SAFE mode should not create a plan entry for a pass ACS will not command."""
+        pass_obj = Pass(
+            station="GS_TEST",
+            begin=1100.0,
+            length=600.0,
+            gsstartra=100.0,
+            gsstartdec=50.0,
+        )
+        queue_ditl.acs.acsmode = ACSMode.SAFE
+        queue_ditl.acs.in_safe_mode = True
+        queue_ditl.acs.passrequests.current_pass = Mock(return_value=pass_obj)
+        queue_ditl.acs.passrequests.next_pass = Mock(return_value=pass_obj)
+
+        with patch.object(Pass, "time_to_slew", return_value=True):
+            queue_ditl._check_and_manage_passes(1000.0, 10.0, 20.0)
+
+        queue_ditl.acs.enqueue_command.assert_not_called()
+        queue_ditl.acs.passrequests.current_pass.assert_not_called()
+        queue_ditl.acs.passrequests.next_pass.assert_not_called()
+        assert list(queue_ditl.plan) == []
+
+    def test_check_and_manage_passes_gsp_terminates_active_ppt_once(
+        self, queue_ditl
+    ) -> None:
+        """Reserving a pass should end active science and not re-add it later."""
+        utime = 1000.0
+        ra, dec = 10.0, 20.0
+        ppt = PlanEntry(config=queue_ditl.config)
+        ppt.name = "SCIENCE"
+        ppt.obstype = ObsType.AT
+        ppt.begin = 900.0
+        ppt.end = 5000.0
+        ppt.slewtime = 0
+        ppt.ss_min = 10
+        queue_ditl.ppt = ppt
+        queue_ditl.plan.append(ppt)
+
+        pass_obj = Pass(
+            station="GS_TEST",
+            begin=1100.0,
+            length=600.0,
+            gsstartra=100.0,
+            gsstartdec=50.0,
+        )
+        queue_ditl.acs.passrequests.current_pass = Mock(return_value=None)
+        queue_ditl.acs.passrequests.next_pass = Mock(return_value=pass_obj)
+        queue_ditl.acs.acsmode = ACSMode.SCIENCE
+
+        with patch.object(Pass, "time_to_slew", return_value=True):
+            queue_ditl._check_and_manage_passes(utime, ra, dec)
+
+        assert queue_ditl.ppt is None
+        assert [entry.obstype for entry in queue_ditl.plan] == [ObsType.AT, ObsType.GSP]
+        assert queue_ditl.plan[0].end == utime
+
+        queue_ditl._track_ppt_in_timeline()
+        assert [entry.obstype for entry in queue_ditl.plan] == [ObsType.AT, ObsType.GSP]
+
+        queue_ditl.queue.get.reset_mock()
+        queue_ditl._handle_science_mode(utime, ra, dec, ACSMode.SCIENCE)
+        queue_ditl.queue.get.assert_not_called()
+
+    def test_check_and_manage_passes_skips_overlapping_unselected_pass(
+        self, queue_ditl
+    ) -> None:
+        """Overlapping pass opportunities should not become accidental tail contacts."""
+        selected_pass = Pass(
+            station="SGS",
+            begin=1000.0,
+            length=600.0,
+            gsstartra=100.0,
+            gsstartdec=50.0,
+        )
+        overlapping_pass = Pass(
+            station="TRO",
+            begin=1050.0,
+            length=600.0,
+            gsstartra=120.0,
+            gsstartdec=60.0,
+        )
+        assert queue_ditl._record_gsp_plan_entry(selected_pass, reserved_begin=900.0)
+
+        queue_ditl.acs.enqueue_command.reset_mock()
+        queue_ditl.acs.passrequests.current_pass = Mock(return_value=overlapping_pass)
+        queue_ditl.acs.acsmode = ACSMode.SCIENCE
+
+        queue_ditl._check_and_manage_passes(1600.0, 10.0, 20.0)
+
+        gsp_entries = [
+            entry for entry in queue_ditl.plan if entry.obstype == ObsType.GSP
+        ]
+        assert len(gsp_entries) == 1
+        assert gsp_entries[0].station == "SGS"
+        queue_ditl.acs.enqueue_command.assert_not_called()
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Skipping overlapping pass opportunity for TRO" in log_text
+
+    def test_check_and_manage_passes_ends_commanded_pass_before_overlap(
+        self, queue_ditl
+    ) -> None:
+        """An overlapping opportunity should not keep the commanded pass open."""
+        selected_pass = Pass(
+            station="SGS",
+            begin=1000.0,
+            length=600.0,
+            gsstartra=100.0,
+            gsstartdec=50.0,
+        )
+        overlapping_pass = Pass(
+            station="TRO",
+            begin=1050.0,
+            length=600.0,
+            gsstartra=120.0,
+            gsstartdec=60.0,
+        )
+        assert queue_ditl._record_gsp_plan_entry(selected_pass, reserved_begin=900.0)
+
+        queue_ditl.acs.acsmode = ACSMode.PASS
+        queue_ditl.acs.current_pass = selected_pass
+        queue_ditl.acs.passrequests.current_pass = Mock(return_value=overlapping_pass)
+
+        queue_ditl._check_and_manage_passes(1601.0, 10.0, 20.0)
+
+        cmd = queue_ditl.acs.enqueue_command.call_args[0][0]
+        assert cmd.command_type == ACSCommandType.END_PASS
+        gsp_entries = [
+            entry for entry in queue_ditl.plan if entry.obstype == ObsType.GSP
+        ]
+        assert len(gsp_entries) == 1
+        assert gsp_entries[0].station == "SGS"
+
+    def test_check_and_manage_passes_exports_gsp_plan_entry_when_pass_starts(
+        self, queue_ditl
+    ) -> None:
+        """Entering an active pass should export GSP even if no prep slew was reserved."""
+        utime = 1000.0
+        ra, dec = 10.0, 20.0
+        pass_obj = Pass(
+            station="GS_ACTIVE",
+            begin=950.0,
+            length=600.0,
+            gsstartra=80.0,
+            gsstartdec=30.0,
+            obsid=3131,
+        )
+
+        queue_ditl.acs.passrequests.current_pass = Mock(return_value=pass_obj)
+        queue_ditl.acs.acsmode = ACSMode.SCIENCE
+
+        queue_ditl._check_and_manage_passes(utime, ra, dec)
+
+        entry = queue_ditl.plan[0]
+        assert entry.obstype == ObsType.GSP
+        assert entry.name == "GS_ACTIVE_PASS"
+        assert entry.begin == utime
+        assert entry.slewtime == 0
+        assert entry.end == pass_obj.end
+        assert entry.exposure == 550
+        assert entry.exptime == 550
+        assert entry.contact_begin == pass_obj.begin
 
     def test_check_and_manage_passes_skip_slew_when_already_slewing(
         self, queue_ditl
@@ -2920,6 +3167,7 @@ class TestQueueDITLCoverage:
             from conops import ACSMode
 
             mock_acs.acsmode = ACSMode.SCIENCE
+            mock_acs.in_safe_mode = False
             mock_acs_class.return_value = mock_acs
 
             # Mock solar panel
@@ -2981,6 +3229,7 @@ class TestQueueDITLCoverage:
             from conops import ACSMode
 
             mock_acs.acsmode = ACSMode.SCIENCE
+            mock_acs.in_safe_mode = False
             mock_acs_class.return_value = mock_acs
 
             # Mock solar panel
@@ -3045,6 +3294,7 @@ class TestQueueDITLCoverage:
             from conops import ACSMode
 
             mock_acs.acsmode = ACSMode.SCIENCE
+            mock_acs.in_safe_mode = False
             mock_acs_class.return_value = mock_acs
 
             # Mock solar panel

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -148,6 +148,29 @@ class TestScheduleGroundstationPasses:
         assert "Pass 1" in log_text
         assert "Pass 2" in log_text
 
+    def test_schedule_passes_logs_skipped_overlapping_passes(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.acs.passrequests.passes = []
+
+        selected = Mock()
+        selected.__str__ = Mock(return_value="Selected pass")
+        dropped = Mock()
+        dropped.__str__ = Mock(return_value="Dropped pass")
+
+        def populate_passes(year: int, day: int, length: int) -> None:
+            queue_ditl.acs.passrequests.passes = [selected]
+            queue_ditl.acs.passrequests.dropped_overlapping_passes = [
+                (dropped, selected)
+            ]
+
+        cast(Mock, queue_ditl.acs.passrequests.get).side_effect = populate_passes
+        queue_ditl._schedule_groundstation_passes()
+
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Skipped overlapping pass opportunity: Dropped pass" in log_text
+        assert "overlaps selected pass Selected pass" in log_text
+
 
 class TestDetermineMode:
     """Test mode determination now handled by ACS.get_mode() - these tests use real ACS instance."""

--- a/tests/visualization/test_ditl_timeline.py
+++ b/tests/visualization/test_ditl_timeline.py
@@ -280,6 +280,42 @@ class TestPlotDitlTimeline:
         # Clean up
         plt.close(fig)
 
+    def test_gsp_entries_are_not_extracted_as_observations(self) -> None:
+        """Ground-station passes should not be plotted as science observations."""
+        from conops.common import ObsType
+        from conops.visualization.mpl.ditl_timeline import (
+            _extract_observations as extract_mpl_observations,
+        )
+        from conops.visualization.plotly.ditl_timeline import (
+            _extract_observations as extract_plotly_observations,
+        )
+
+        science_entry = Mock(
+            obstype=ObsType.AT,
+            begin=0.0,
+            end=600.0,
+            slewtime=60.0,
+            obsid=10000,
+        )
+        gsp_entry = Mock(
+            obstype=ObsType.GSP,
+            begin=600.0,
+            end=1200.0,
+            slewtime=120.0,
+            obsid=65535,
+        )
+        ditl = Mock(plan=[science_entry, gsp_entry])
+
+        for extract_observations in (
+            extract_mpl_observations,
+            extract_plotly_observations,
+        ):
+            observations = extract_observations(ditl, t_start=0.0, offset_hours=0.0)
+            segments = [
+                segment for category in observations.values() for segment in category
+            ]
+            assert segments == [(1 / 60, 0.15)]
+
     def test_plot_ditl_timeline_show_saa(self, mock_ditl_with_ephem: Mock) -> None:
         """Test plot_ditl_timeline with SAA passages shown."""
         fig, ax = plot_ditl_timeline(mock_ditl_with_ephem, show_saa=True)


### PR DESCRIPTION
## Summary
- Add `GSP` plan entries for ground-station pass activities that COAST actually commands
- Include pass metadata in plan JSON: `station`, `contact_begin`, `contact_end`
- Reserve the GSP window in the queue plan so science/charging entries are closed before the pass
- Avoid exporting overlapping unselected pass opportunities
- End the commanded pass based on `acs.current_pass`, so overlapping pass opportunities do not create accidental tail contacts
- Skip pass handling/export while ACS is in SAFE
- Exclude `GSP` entries from science-observation timeline extraction

Closes #138