### PR TITLE
fix: cancel superseded ACS slew commands

### DIFF
--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -205,9 +205,9 @@ class ACS:
                 ),
             )
 
-    @classmethod
-    def _command_label(cls, command: ACSCommand) -> str:
-        obsid = cls._command_obsid(command)
+    @staticmethod
+    def _command_label(command: ACSCommand) -> str:
+        obsid = ACS._command_obsid(command)
         if obsid is None:
             return command.command_type.name
         return f"{command.command_type.name} obsid={obsid}"

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -161,6 +161,12 @@ class ACS:
             )
             return
 
+        if command.command_type in (
+            ACSCommandType.SLEW_TO_TARGET,
+            ACSCommandType.START_PASS,
+        ):
+            self._cancel_pending_slew_commands(command)
+
         self.command_queue.append(command)
         self.command_queue.sort(key=lambda cmd: cmd.execution_time)
         self._log_or_print(
@@ -168,6 +174,49 @@ class ACS:
             "ACS",
             f"{unixtime2date(command.execution_time)}: Enqueued {command.command_type.name} command for execution  (queue size: {len(self.command_queue)})",
         )
+
+    def _cancel_pending_slew_commands(self, replacement: ACSCommand) -> None:
+        """Drop queued target slews superseded by a newer attitude decision."""
+        pending_slews = [
+            command
+            for command in self.command_queue
+            if command.command_type == ACSCommandType.SLEW_TO_TARGET
+        ]
+        if not pending_slews:
+            return
+
+        self.command_queue = [
+            command
+            for command in self.command_queue
+            if command.command_type != ACSCommandType.SLEW_TO_TARGET
+        ]
+        replacement_label = self._command_label(replacement)
+        for canceled in pending_slews:
+            canceled_obsid = self._command_obsid(canceled)
+            self._log_or_print(
+                replacement.execution_time,
+                "ACS",
+                (
+                    f"{unixtime2date(replacement.execution_time)}: Canceled pending "
+                    f"SLEW_TO_TARGET command scheduled for "
+                    f"{unixtime2date(canceled.execution_time)} "
+                    f"(obsid={canceled_obsid}) - superseded by "
+                    f"{replacement_label}"
+                ),
+            )
+
+    @classmethod
+    def _command_label(cls, command: ACSCommand) -> str:
+        obsid = cls._command_obsid(command)
+        if obsid is None:
+            return command.command_type.name
+        return f"{command.command_type.name} obsid={obsid}"
+
+    @staticmethod
+    def _command_obsid(command: ACSCommand) -> int | None:
+        if command.slew is not None:
+            return getattr(command.slew, "obsid", command.obsid)
+        return command.obsid
 
     def _process_commands(self, utime: float) -> None:
         """Process all commands scheduled for execution at or before current time."""

--- a/tests/acs/test_acs_coverage.py
+++ b/tests/acs/test_acs_coverage.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import Mock, patch
 
-from conops import ACSCommand, ACSCommandType, ACSMode, Pass, Slew
+from conops import ACSCommand, ACSCommandType, ACSMode, DITLLog, Pass, Slew
 
 
 class TestExecuteCommandCoverage:
@@ -109,6 +109,81 @@ class TestExecuteCommandCoverage:
         with patch.object(acs, "_start_slew") as mock_start_slew:
             acs._start_pass(command, 1514764800.0)
             mock_start_slew.assert_not_called()
+
+
+class TestEnqueueCommandQueueManagement:
+    """Test command-queue replacement behavior."""
+
+    def _make_slew_command(self, execution_time: float, obsid: int) -> ACSCommand:
+        slew = Mock(spec=Slew)
+        slew.obsid = obsid
+        slew.obstype = "PPT"
+        return ACSCommand(
+            command_type=ACSCommandType.SLEW_TO_TARGET,
+            execution_time=execution_time,
+            slew=slew,
+        )
+
+    def test_new_slew_cancels_pending_slew_command(self, acs) -> None:
+        acs.log = DITLLog()
+        stale_return = self._make_slew_command(1514767440.0, 10019)
+        end_pass = ACSCommand(
+            command_type=ACSCommandType.END_PASS,
+            execution_time=1514767200.0,
+        )
+        replacement = self._make_slew_command(1514767260.0, 10053)
+        acs.command_queue = [stale_return, end_pass]
+
+        acs.enqueue_command(replacement)
+
+        assert all(command is not stale_return for command in acs.command_queue)
+        assert any(command is end_pass for command in acs.command_queue)
+        assert any(command is replacement for command in acs.command_queue)
+        assert [command.execution_time for command in acs.command_queue] == [
+            1514767200.0,
+            1514767260.0,
+        ]
+
+        log_text = "\n".join(event.description for event in acs.log.events)
+        assert "Canceled pending SLEW_TO_TARGET" in log_text
+        assert "obsid=10019" in log_text
+        assert "obsid=10053" in log_text
+
+    def test_non_slew_command_preserves_pending_slew_command(self, acs) -> None:
+        pending_slew = self._make_slew_command(1514767440.0, 10019)
+        end_pass = ACSCommand(
+            command_type=ACSCommandType.END_PASS,
+            execution_time=1514767200.0,
+        )
+        acs.command_queue = [pending_slew]
+
+        acs.enqueue_command(end_pass)
+
+        assert any(command is pending_slew for command in acs.command_queue)
+        assert any(command is end_pass for command in acs.command_queue)
+        assert [command.execution_time for command in acs.command_queue] == [
+            1514767200.0,
+            1514767440.0,
+        ]
+
+    def test_start_pass_cancels_pending_slew_command(self, acs) -> None:
+        acs.log = DITLLog()
+        stale_return = self._make_slew_command(1514767440.0, 10019)
+        start_pass = ACSCommand(
+            command_type=ACSCommandType.START_PASS,
+            execution_time=1514767200.0,
+        )
+        acs.command_queue = [stale_return]
+
+        acs.enqueue_command(start_pass)
+
+        assert all(command is not stale_return for command in acs.command_queue)
+        assert acs.command_queue == [start_pass]
+
+        log_text = "\n".join(event.description for event in acs.log.events)
+        assert "Canceled pending SLEW_TO_TARGET" in log_text
+        assert "obsid=10019" in log_text
+        assert "superseded by START_PASS" in log_text
 
 
 class TestStartSlewCoverage:


### PR DESCRIPTION
Closes #141.

Summary:
- Treat queued SLEW_TO_TARGET commands as the pending ACS attitude intent.
- Cancel older pending target slews when ACS accepts a newer target slew or pass-start attitude decision.
- Log each canceled pending slew with its scheduled time, obsid, and superseding command.
- Add regression coverage for science-slew supersession, START_PASS supersession, and non-superseding commands preserving pending slews.
