### PR TITLE
fix: sync plan slew metadata with ACS execution

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -700,9 +700,7 @@ class QueueDITL(DITLMixin, DITLStats):
 
     @staticmethod
     def _entry_matches_slew(entry: PlanEntry, slew: Slew) -> bool:
-        return entry.obstype == ObsType.AT and getattr(entry, "obsid", None) == getattr(
-            slew, "obsid", None
-        )
+        return entry.obstype == ObsType.AT and entry.obsid == slew.obsid
 
     def _sync_slew_metadata(self, slew: Slew) -> None:
         if slew.obstype != ObsType.PPT:

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -151,6 +151,7 @@ class QueueDITL(DITLMixin, DITLStats):
         # successful dispatch; None during a pass (spacecraft is occupied).
         self._ppt_unavailable: bool | None = None
         self._planned_gsp_keys: set[tuple[str, float, float]] = set()
+        self._synced_executed_slew_count = 0
 
     def get_acs_queue_status(self) -> dict[str, Any]:
         """
@@ -414,6 +415,7 @@ class QueueDITL(DITLMixin, DITLStats):
 
             # Get current pointing and mode from ACS
             ra, dec, roll, obsid = self.acs.pointing(utime)
+            self._sync_acs_slew_metadata()
             mode = self.acs.get_mode(utime)
 
             # Check pass timing and manage passes
@@ -683,6 +685,60 @@ class QueueDITL(DITLMixin, DITLStats):
             # Charging PPTs use exactly 86400, science obs use larger values
             if last_entry.end >= last_entry.begin + 86400:
                 self._close_last_plan_entry(utime)
+
+    @staticmethod
+    def _apply_slew_metadata(
+        entry: PlanEntry, slew: Slew, *, update_end: bool = False
+    ) -> None:
+        entry.begin = int(slew.slewstart)
+        entry.slewtime = int(round(slew.slewtime))
+        entry.slewdist = float(slew.slewdist)
+        entry.slewpath = slew.slewpath
+        entry.roll = float(slew.endroll)
+        if update_end:
+            entry.end = int(slew.slewstart + slew.slewtime + entry.ss_max)
+
+    @staticmethod
+    def _entry_matches_slew(entry: PlanEntry, slew: Slew) -> bool:
+        return entry.obstype == ObsType.AT and getattr(entry, "obsid", None) == getattr(
+            slew, "obsid", None
+        )
+
+    def _sync_slew_metadata(self, slew: Slew) -> None:
+        if slew.obstype != ObsType.PPT:
+            return
+
+        if self.ppt is not None and self._entry_matches_slew(self.ppt, slew):
+            self._apply_slew_metadata(self.ppt, slew, update_end=True)
+
+        for entry in reversed(list(self.plan)):
+            if self._entry_matches_slew(entry, slew):
+                update_end = entry.end >= entry.begin + 86400
+                self._apply_slew_metadata(entry, slew, update_end=update_end)
+                return
+
+    def _sync_acs_slew_metadata(self) -> None:
+        """Copy ACS science slew metadata onto exported plan entries."""
+        new_commands = self.acs.executed_commands[self._synced_executed_slew_count :]
+        for command in new_commands:
+            if command.command_type == ACSCommandType.SLEW_TO_TARGET:
+                slew = command.slew
+                if isinstance(slew, Slew):
+                    self._sync_slew_metadata(slew)
+        self._synced_executed_slew_count = len(self.acs.executed_commands)
+
+        if isinstance(self.acs.current_slew, Slew):
+            self._sync_slew_metadata(self.acs.current_slew)
+
+    def _expected_slew_start_attitude(
+        self, utime: float, execution_time: float
+    ) -> tuple[float, float, float]:
+        active_slew = self.acs.last_slew
+        if isinstance(active_slew, Slew) and active_slew.is_slewing(utime):
+            slewend = active_slew.slewstart + active_slew.slewtime
+            if execution_time >= slewend:
+                return active_slew.endra, active_slew.enddec, active_slew.endroll
+        return self.acs.ra, self.acs.dec, self.acs.roll
 
     def _handle_mode_operations(
         self, mode: ACSMode, utime: float, ra: float, dec: float
@@ -1354,10 +1410,6 @@ class QueueDITL(DITLMixin, DITLStats):
                 self._ppt_unavailable = True
                 return
 
-            # Initialize slew start positions from current ACS pointing
-            slew.startra = self.acs.ra
-            slew.startdec = self.acs.dec
-
             # Calculate slew timing
             execution_time = utime
 
@@ -1390,6 +1442,9 @@ class QueueDITL(DITLMixin, DITLStats):
                 execution_time = visstart
 
             slew.slewstart = execution_time
+            slew.startra, slew.startdec, slew.startroll = (
+                self._expected_slew_start_attitude(utime, execution_time)
+            )
 
             # When ignore_roll=True, verify that a valid roll exists before slewing.
             # optimum_roll() falls back to the unconstrained solar roll when
@@ -1430,7 +1485,6 @@ class QueueDITL(DITLMixin, DITLStats):
                 self.config.solar_panel,
                 self.config.constraint,
             )
-            self.ppt.roll = slew.endroll
             slew.calc_slewtime()
 
             # Validate that the locked roll satisfies constraints for at least
@@ -1504,12 +1558,8 @@ class QueueDITL(DITLMixin, DITLStats):
             ):
                 return
 
+            self._apply_slew_metadata(self.ppt, slew, update_end=True)
             self.acs.slew_dists.append(slew.slewdist)
-
-            # Update PPT timing based on slew
-            self.ppt.begin = int(execution_time)
-            # Update PPT end time to ensure it has enough time for slew + max observation
-            self.ppt.end = int(execution_time + slew.slewtime + self.ppt.ss_max)
 
             self.log.log_event(
                 utime=utime,

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -305,11 +305,13 @@ class ACS:
         slew.slewstart = utime
         slew.calc_slewtime()
 
+        slewdist = float(getattr(slew, "slewdist", 0.0))
         self._log_or_print(
             utime,
             "SLEW",
             f"{unixtime2date(utime)}: Starting slew from RA={self.ra:.2f} Dec={self.dec:.2f} "
-            f"to RA={slew.endra:.2f} Dec={slew.enddec:.2f} (duration: {slew.slewtime:.1f}s)",
+            f"to RA={slew.endra:.2f} Dec={slew.enddec:.2f} "
+            f"(duration: {slew.slewtime:.1f}s, distance: {slewdist:.1f} deg)",
         )
 
         self.current_slew = slew

--- a/tests/scheduler_queue/conftest.py
+++ b/tests/scheduler_queue/conftest.py
@@ -148,10 +148,12 @@ def queue_ditl(mock_config: Mock, mock_ephem: DummyEphemeris) -> QueueDITL:
         mock_acs.enqueue_command = Mock()
         mock_acs.passrequests = mock_pt
         mock_acs.slew_dists = []
+        mock_acs.executed_commands = []
         mock_acs.last_slew = None
         mock_acs.current_slew = None  # No active slew by default
         mock_acs.ra = 0.0  # Current pointing RA
         mock_acs.dec = 0.0  # Current pointing Dec
+        mock_acs.roll = 0.0  # Current roll angle
         # Set acsmode to a real ACSMode enum value for logging
         from conops import ACSMode
 

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from conops import ACSCommandType, ACSMode, Pass, QueueDITL
+from conops import ACS, ACSCommand, ACSCommandType, ACSMode, Pass, QueueDITL, Slew
 from conops.common.enums import ObsType
 from conops.config.config import MissionConfig
 from conops.ditl.telemetry import Housekeeping
@@ -567,6 +567,189 @@ class TestFetchNewPPT:
         assert command.slew.endra == 45.0
         assert command.slew.enddec == 30.0
         assert command.slew.obsid == 1001
+
+    def test_fetch_ppt_copies_command_slew_metadata_to_target(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        mock_ppt = Mock()
+        mock_ppt.ra = 45.0
+        mock_ppt.dec = 30.0
+        mock_ppt.obsid = 1001
+        mock_ppt.next_vis = Mock(return_value=1000.0)
+        mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 300.0
+        mock_ppt.windows = [[0.0, 1e12]]
+        mock_ppt.slewtime = 12
+        mock_ppt.slewdist = 3.0
+        queue_ditl.acs.roll = 25.0
+        cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
+
+        queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        command = cast(Mock, queue_ditl.acs.enqueue_command).call_args[0][0]
+        assert mock_ppt.begin == command.slew.slewstart
+        assert mock_ppt.roll == command.slew.endroll
+        assert mock_ppt.slewtime == int(round(command.slew.slewtime))
+        assert mock_ppt.slewdist == pytest.approx(command.slew.slewdist)
+
+    def test_sync_acs_slew_metadata_updates_exported_plan_entry(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        target = PlanEntry(config=queue_ditl.config)
+        target.obstype = ObsType.AT
+        target.obsid = 1001
+        target.ss_max = 3600.0
+        target.begin = 1000.0
+        target.end = 1000.0 + 86400.0
+        target.slewtime = 5
+        target.slewdist = 2.0
+
+        entry = target.copy()
+        entry.slewtime = 1
+        entry.slewdist = 1.0
+        queue_ditl.plan.append(entry)
+        queue_ditl.ppt = target
+
+        slew = Slew(config=queue_ditl.config)
+        slew.obstype = ObsType.PPT
+        slew.obsid = target.obsid
+        slew.at = target
+        slew.slewstart = 1000.0
+        slew.startra = 10.0
+        slew.startdec = 20.0
+        slew.startroll = 25.0
+        slew.endra = 45.0
+        slew.enddec = 30.0
+        slew.endroll = 70.0
+        slew.calc_slewtime()
+        queue_ditl.acs.executed_commands = []
+        queue_ditl.acs.current_slew = slew
+
+        queue_ditl._sync_acs_slew_metadata()
+
+        assert target.slewtime == int(round(slew.slewtime))
+        assert target.slewdist == pytest.approx(slew.slewdist)
+        assert entry.slewtime == int(round(slew.slewtime))
+        assert entry.slewdist == pytest.approx(slew.slewdist)
+        assert entry.end == int(slew.slewstart + slew.slewtime + entry.ss_max)
+
+    def test_exported_slew_metadata_matches_acs_slew_event(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        acs = ACS(config=queue_ditl.config, log=queue_ditl.log)
+        acs.ra = 10.0
+        acs.dec = 20.0
+        acs.roll = 25.0
+        queue_ditl.acs = acs
+
+        target = PlanEntry(config=queue_ditl.config)
+        target.obstype = ObsType.AT
+        target.obsid = 1001
+        target.ss_max = 3600.0
+        target.begin = 1000.0
+        target.end = 1000.0 + 86400.0
+        target.slewtime = 5
+        target.slewdist = 2.0
+        queue_ditl.plan.append(target.copy())
+        queue_ditl.ppt = target
+
+        slew = Slew(config=queue_ditl.config)
+        slew.obstype = ObsType.PPT
+        slew.obsid = target.obsid
+        slew.at = target
+        slew.endra = 45.0
+        slew.enddec = 30.0
+        slew.endroll = 70.0
+
+        acs._start_slew(slew, 1000.0)
+        queue_ditl._sync_acs_slew_metadata()
+
+        entry = queue_ditl.plan[0]
+        slew_event = next(
+            event
+            for event in queue_ditl.log.events
+            if event.event_type == "SLEW" and "Starting slew" in event.description
+        )
+        assert entry.slewtime == int(round(slew.slewtime))
+        assert entry.slewdist == pytest.approx(slew.slewdist)
+        assert f"duration: {float(entry.slewtime):.1f}s" in slew_event.description
+        assert f"distance: {entry.slewdist:.1f} deg" in slew_event.description
+
+    def test_syncs_each_executed_science_slew_command(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entries = []
+        slews = []
+        for index, obsid in enumerate((1001, 1002)):
+            entry = PlanEntry(config=queue_ditl.config)
+            entry.obstype = ObsType.AT
+            entry.obsid = obsid
+            entry.ss_max = 3600.0
+            entry.begin = 940.0
+            entry.end = entry.begin + 86400.0
+            entry.slewtime = 5
+            entry.slewdist = 2.0
+            queue_ditl.plan.append(entry)
+            entries.append(entry)
+
+            slew = Slew(config=queue_ditl.config)
+            slew.obstype = ObsType.PPT
+            slew.obsid = obsid
+            slew.slewstart = 1000.0
+            slew.startra = 10.0
+            slew.startdec = 20.0
+            slew.startroll = 25.0
+            slew.endra = 45.0 + index
+            slew.enddec = 30.0 + index
+            slew.endroll = 70.0 + index
+            slew.calc_slewtime()
+            slews.append(slew)
+
+        queue_ditl.acs.executed_commands = [
+            ACSCommand(
+                command_type=ACSCommandType.SLEW_TO_TARGET,
+                execution_time=slew.slewstart,
+                slew=slew,
+            )
+            for slew in slews
+        ]
+        queue_ditl.acs.current_slew = slews[-1]
+
+        queue_ditl._sync_acs_slew_metadata()
+
+        for entry, slew in zip(entries, slews):
+            assert entry.begin == int(slew.slewstart)
+            assert entry.slewtime == int(round(slew.slewtime))
+            assert entry.slewdist == pytest.approx(slew.slewdist)
+            assert entry.roll == pytest.approx(slew.endroll)
+
+    def test_rejected_ppt_keeps_queue_estimate_metadata(self, queue_ditl) -> None:
+        mock_ppt = Mock()
+        mock_ppt.ra = 45.0
+        mock_ppt.dec = 30.0
+        mock_ppt.obsid = 1001
+        mock_ppt.next_vis = Mock(return_value=1000.0)
+        mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 300.0
+        mock_ppt.windows = [[0.0, 1e12]]
+        mock_ppt.begin = 10.0
+        mock_ppt.end = 20.0
+        mock_ppt.roll = 5.0
+        mock_ppt.slewtime = 12
+        mock_ppt.slewdist = 3.0
+        cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
+        cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
+        cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(return_value=None)
+        queue_ditl.constraint.in_constraint = Mock(return_value=True)
+
+        queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
+        assert mock_ppt.begin == 10.0
+        assert mock_ppt.end == 20.0
+        assert mock_ppt.roll == 5.0
+        assert mock_ppt.slewtime == 12
+        assert mock_ppt.slewdist == 3.0
 
     def test_fetch_ppt_prints_messages(
         self, queue_ditl: QueueDITL, capsys: pytest.CaptureFixture[str]
@@ -1671,6 +1854,9 @@ class TestCalcMethod:
         mock_current_slew.is_slewing = Mock(return_value=True)
         mock_current_slew.slewstart = 900.0
         mock_current_slew.slewtime = 200.0
+        mock_current_slew.endra = 12.0
+        mock_current_slew.enddec = 22.0
+        mock_current_slew.endroll = 32.0
         queue_ditl.acs.last_slew = mock_current_slew
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
 


### PR DESCRIPTION
Closes #142.

The exported plan was carrying slew metadata from queue-time estimates, while ACS later recomputed the executed slew from the actual spacecraft attitude and roll. That let `slewtime` / `slewdist` in the JSON drift from what ACS actually commanded. A full Tamalpais DITL regeneration also showed that when ACS executed more than one science slew in the same timestep, syncing only from `acs.current_slew` could leave an earlier exported entry with its queue-time `begin`.

This PR makes the ACS-executed `Slew` objects the source of truth for science-plan slew metadata:

- copy `slewtime`, `slewdist`, roll, begin time, and slew path from the scheduled `Slew` onto the selected target
- resync exported plan entries from newly executed ACS science slew commands, so multiple same-timestep slews are handled
- keep the active-slew sync path for direct/current ACS slew state
- include executed slew distance in ACS `SLEW` log events
- add regression coverage for command metadata propagation, exported plan-entry resync, same-timestep executed slew sync, rejection handling, and ACS `SLEW` event parity

Validation:
- `pytest`
- `pytest tests/acs tests/scheduler_queue/test_queue_ditl.py`
- `prek run --all-files`
- Full Tamalpais DITL plan generation for 2026-03-01T18:00:00Z to 2026-03-02T18:00:00Z, comparing serialized JSON science entries against executed ACS slew commands and ACS `SLEW` log events: 0 metadata mismatches, 0 event mismatches