### PR TITLE
fix: export GSP tracking attitude metadata

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -887,6 +887,10 @@ class QueueDITL(DITLMixin, DITLStats):
         entry.station = station
         entry.contact_begin = pass_begin
         entry.contact_end = pass_end
+        entry.track_start_ra = gspass.gsstartra
+        entry.track_start_dec = gspass.gsstartdec
+        entry.track_end_ra = gspass.gsendra
+        entry.track_end_dec = gspass.gsenddec
 
         self.plan.append(entry)
         self._planned_gsp_keys.add(key)

--- a/conops/targets/plan_entry.py
+++ b/conops/targets/plan_entry.py
@@ -28,6 +28,10 @@ class PlanEntry:
     station: str | None
     contact_begin: float | None
     contact_end: float | None
+    track_start_ra: float | None
+    track_start_dec: float | None
+    track_end_ra: float | None
+    track_end_dec: float | None
 
     def __init__(
         self,
@@ -57,6 +61,10 @@ class PlanEntry:
         self.station = None
         self.contact_begin = None
         self.contact_end = None
+        self.track_start_ra = None
+        self.track_start_dec = None
+        self.track_end_ra = None
+        self.track_end_dec = None
 
         self.saa = None
         self.merit = 101

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -73,6 +73,10 @@ class PlanEntrySchema(BaseModel):
     station: str | None = None
     contact_begin: float | None = None
     contact_end: float | None = None
+    track_start_ra: float | None = None
+    track_start_dec: float | None = None
+    track_end_ra: float | None = None
+    track_end_dec: float | None = None
 
     @staticmethod
     def _computed_exposure(entry: PlanEntry) -> int:
@@ -123,6 +127,10 @@ class PlanEntrySchema(BaseModel):
                 "station": getattr(data, "station", None),
                 "contact_begin": getattr(data, "contact_begin", None),
                 "contact_end": getattr(data, "contact_end", None),
+                "track_start_ra": getattr(data, "track_start_ra", None),
+                "track_start_dec": getattr(data, "track_start_dec", None),
+                "track_end_ra": getattr(data, "track_end_ra", None),
+                "track_end_dec": getattr(data, "track_end_dec", None),
             }
         return data
 

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -127,7 +127,11 @@ The JSON file contains a metadata envelope followed by the entry list.
          "exposure": 480,
          "station": "SGS",
          "contact_begin": "2025-12-01T00:20:00+00:00",
-         "contact_end": "2025-12-01T00:28:00+00:00"
+         "contact_end": "2025-12-01T00:28:00+00:00",
+         "track_start_ra": 120.0,
+         "track_start_dec": 45.0,
+         "track_end_ra": 231.67,
+         "track_end_dec": -0.38
        }
      ]
    }
@@ -248,6 +252,26 @@ Entry Fields
      - string | null
      - ISO-8601 UTC timestamp of when the ground station contact window ends. Only present
        for ``obstype="GSP"``. Typically matches ``end``.
+   * - ``track_start_ra``
+     - float | null
+     - Ground-station tracking right ascension at ``contact_begin`` in degrees. Only present
+       for ``obstype="GSP"``. For GSP entries, ``ra`` uses the same pass-start convention.
+   * - ``track_start_dec``
+     - float | null
+     - Ground-station tracking declination at ``contact_begin`` in degrees. Only present
+       for ``obstype="GSP"``. For GSP entries, ``dec`` uses the same pass-start convention.
+   * - ``track_end_ra``
+     - float | null
+     - Ground-station tracking right ascension used by ACS at pass end, in degrees. This is
+       derived from the final tracking sample and matches ``Pass.ra_dec(contact_end)``. Only
+       present for ``obstype="GSP"``. Use this with ``track_end_dec`` when inspecting slews
+       after a pass.
+   * - ``track_end_dec``
+     - float | null
+     - Ground-station tracking declination used by ACS at pass end, in degrees. This is
+       derived from the final tracking sample and matches ``Pass.ra_dec(contact_end)``. Only
+       present for ``obstype="GSP"``. Use this with ``track_end_ra`` when inspecting slews
+       after a pass.
 
 Ground Station Pass (GSP) Entries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -265,6 +289,12 @@ and execution of data downlink passes.
   of the ground station contact.
 * **Metadata fields**: The ``station``, ``contact_begin``, and ``contact_end`` fields are
   only present for GSP entries (``null`` or omitted for other observation types).
+* **Tracking attitude**: GSP entries track the ground station through the contact. The
+  generic ``ra`` and ``dec`` fields are the pass-start pointing, matching
+  ``track_start_ra`` and ``track_start_dec``. Use ``track_end_ra`` and
+  ``track_end_dec`` to inspect the spacecraft pointing at the end of the pass. The end
+  fields are derived from the final tracking sample, matching ACS
+  ``Pass.ra_dec(contact_end)`` behavior.
 * **Deconfliction**: When multiple ground stations are visible simultaneously, COASTSim
   automatically selects the pass with the highest expected data volume (downlink rate × duration).
   Dropped overlapping opportunities are logged but not exported to the plan.
@@ -286,6 +316,10 @@ and execution of data downlink passes.
      "contact_begin": "2025-12-01T12:02:00+00:00",
      "contact_end": "2025-12-01T12:12:00+00:00",
      "end": "2025-12-01T12:12:00+00:00",
+     "track_start_ra": 120.0,
+     "track_start_dec": 45.0,
+     "track_end_ra": 231.67,
+     "track_end_dec": -0.38,
      "slewtime": 120,
      "exptime": 600,
      "obsid": 65535

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -110,6 +110,10 @@ class TestPlanEntrySchema:
                 station="TRO",
                 contact_begin=1_000_120.0,
                 contact_end=1_000_720.0,
+                track_start_ra=12.5,
+                track_start_dec=-4.25,
+                track_end_ra=48.75,
+                track_end_dec=9.5,
             )
         )
 
@@ -117,11 +121,19 @@ class TestPlanEntrySchema:
         assert dumped["station"] == "TRO"
         assert dumped["contact_begin"] == "1970-01-12T13:48:40+00:00"
         assert dumped["contact_end"] == "1970-01-12T13:58:40+00:00"
+        assert dumped["track_start_ra"] == pytest.approx(12.5)
+        assert dumped["track_start_dec"] == pytest.approx(-4.25)
+        assert dumped["track_end_ra"] == pytest.approx(48.75)
+        assert dumped["track_end_dec"] == pytest.approx(9.5)
 
         reloaded = PlanEntrySchema(**dumped)
         assert reloaded.station == "TRO"
         assert reloaded.contact_begin == pytest.approx(1_000_120.0)
         assert reloaded.contact_end == pytest.approx(1_000_720.0)
+        assert reloaded.track_start_ra == pytest.approx(12.5)
+        assert reloaded.track_start_dec == pytest.approx(-4.25)
+        assert reloaded.track_end_ra == pytest.approx(48.75)
+        assert reloaded.track_end_dec == pytest.approx(9.5)
 
 
 # ── PlanSchema ─────────────────────────────────────────────────────────────────
@@ -226,6 +238,10 @@ class TestPlanSchema:
         assert "station" not in entry
         assert "contact_begin" not in entry
         assert "contact_end" not in entry
+        assert "track_start_ra" not in entry
+        assert "track_start_dec" not in entry
+        assert "track_end_ra" not in entry
+        assert "track_end_dec" not in entry
 
     def test_load_existing_example_json(self):
         """Load a plan JSON file produced by a previous version (backward compat)."""

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -2210,8 +2210,13 @@ class TestCheckAndManagePasses:
             length=600.0,
             gsstartra=100.0,
             gsstartdec=50.0,
+            gsendra=115.0,
+            gsenddec=42.0,
             obsid=4242,
         )
+        pass_obj.utime = [pass_obj.begin, pass_obj.end - 60.0]
+        pass_obj.ra = [pass_obj.gsstartra, pass_obj.gsendra]
+        pass_obj.dec = [pass_obj.gsstartdec, pass_obj.gsenddec]
 
         queue_ditl.acs.passrequests.current_pass = Mock(return_value=None)
         queue_ditl.acs.passrequests.next_pass = Mock(return_value=pass_obj)
@@ -2235,14 +2240,28 @@ class TestCheckAndManagePasses:
         assert entry.station == "GS_TEST"
         assert entry.contact_begin == pass_obj.begin
         assert entry.contact_end == pass_obj.end
+        assert entry.ra == pytest.approx(pass_obj.gsstartra)
+        assert entry.dec == pytest.approx(pass_obj.gsstartdec)
+        assert entry.track_start_ra == pytest.approx(pass_obj.gsstartra)
+        assert entry.track_start_dec == pytest.approx(pass_obj.gsstartdec)
+        pass_end_ra, pass_end_dec = pass_obj.ra_dec(pass_obj.end)
+        assert entry.track_end_ra == pytest.approx(pass_end_ra)
+        assert entry.track_end_dec == pytest.approx(pass_end_dec)
 
         schema = PlanSchema.from_plan(queue_ditl.plan)
         assert schema.entries[0].obstype == ObsType.GSP
         assert schema.entries[0].station == "GS_TEST"
         assert schema.entries[0].contact_begin == pass_obj.begin
+        assert schema.entries[0].track_start_ra == pytest.approx(pass_obj.gsstartra)
+        assert schema.entries[0].track_start_dec == pytest.approx(pass_obj.gsstartdec)
+        assert schema.entries[0].track_end_ra == pytest.approx(pass_end_ra)
+        assert schema.entries[0].track_end_dec == pytest.approx(pass_end_dec)
         saved_path = schema.save(tmp_path / "plan.json")
-        assert '"obstype": "GSP"' in saved_path.read_text()
-        assert '"station": "GS_TEST"' in saved_path.read_text()
+        saved_json = saved_path.read_text()
+        assert '"obstype": "GSP"' in saved_json
+        assert '"station": "GS_TEST"' in saved_json
+        assert '"track_start_ra": 100.0' in saved_json
+        assert '"track_end_ra": 115.0' in saved_json
 
     def test_check_and_manage_passes_records_gsp_after_pass_slew_command_enqueue(
         self, queue_ditl


### PR DESCRIPTION
Closes #143.

GSP plan entries currently expose `ra` / `dec` as a single static pointing even though ACS tracks the ground station through the contact. This PR makes the pass-start/pass-end tracking attitude explicit in the exported plan.

Changes:
- add `track_start_ra`, `track_start_dec`, `track_end_ra`, and `track_end_dec` to `PlanEntry` / `PlanEntrySchema`
- populate those fields from the accepted `Pass` when QueueDITL records a GSP plan entry
- document that `ra` / `dec` on GSP entries are the pass-start pointing convention
- add schema and QueueDITL regression coverage

Validation:
- `pytest`
- `pytest tests/plan/test_plan_schema.py tests/scheduler_queue/test_queue_ditl.py -k 'gsp or GSP or plan_entry_for_pass_slew'`\n- `prek run --all-files`\n- Full Tamalpais DITL export for 2026-03-01T18:00:00Z to 2026-03-02T18:00:00Z: 3 GSP entries, 0 missing tracking fields, 0 `ra` / `dec` start-convention mismatches, 3 entries with non-static tracking.