### PR TITLE
fix: validate exported plan entries against ACS execution

### DIFF
--- a/conops/__init__.py
+++ b/conops/__init__.py
@@ -45,6 +45,7 @@ from .ditl import (
     DITLMixin,
     DITLs,
     DITLStats,
+    PlanExecutionMismatchError,
     QueueDITL,
     TOORequest,
 )
@@ -118,6 +119,7 @@ __all__ = [
     "PassTimes",
     "Plan",
     "PlanEntry",
+    "PlanExecutionMismatchError",
     "plot_ditl_timeline",
     "plot_fault_management_timeline",
     "plot_fault_management_timeline_plotly",

--- a/conops/ditl/__init__.py
+++ b/conops/ditl/__init__.py
@@ -4,7 +4,7 @@ from .ditl_log import DITLLog
 from .ditl_log_store import DITLLogStore
 from .ditl_mixin import DITLMixin
 from .ditl_stats import DITLStats
-from .queue_ditl import QueueDITL, TOORequest
+from .queue_ditl import PlanExecutionMismatchError, QueueDITL, TOORequest
 from .telemetry import Housekeeping, PayloadData, Telemetry
 
 __all__ = [
@@ -16,6 +16,7 @@ __all__ = [
     "DITLMixin",
     "DITLStats",
     "QueueDITL",
+    "PlanExecutionMismatchError",
     "TOORequest",
     "Housekeeping",
     "PayloadData",

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -608,6 +608,11 @@ class QueueDITL(DITLMixin, DITLStats):
     def _science_start_time(self, entry: PlanEntry) -> float:
         return float(entry.begin) + max(0.0, float(getattr(entry, "slewtime", 0.0)))
 
+    def _window_indices(self, start: float, end: float) -> range:
+        lo = max(0, int(self.ephem.index(dtutcfromtimestamp(start))))
+        hi = int(self.ephem.index(dtutcfromtimestamp(end)))
+        return range(lo, hi)
+
     def _execution_mismatch(
         self,
         utime: float,
@@ -675,10 +680,8 @@ class QueueDITL(DITLMixin, DITLStats):
 
         samples = 0
         science_samples = 0
-        for i, utime in enumerate(self.utime):
-            if not (start <= utime < end):
-                continue
-
+        for i in self._window_indices(start, end):
+            utime = self.utime[i]
             samples += 1
             mode = self._mode_at_index(i)
             if mode == ACSMode.SAA:
@@ -767,10 +770,8 @@ class QueueDITL(DITLMixin, DITLStats):
                 )
             )
 
-        for i, utime in enumerate(self.utime):
-            if not (start <= utime < end):
-                continue
-
+        for i in self._window_indices(start, end):
+            utime = self.utime[i]
             mode = self._mode_at_index(i)
             if mode != ACSMode.PASS:
                 mismatches.append(

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1,5 +1,6 @@
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import rust_ephem
@@ -52,6 +53,22 @@ class TOORequest(BaseModel):
     name: str
     submit_time: float = 0.0
     executed: bool = False
+
+
+class PlanExecutionMismatchError(RuntimeError):
+    """Raised when an exported plan entry does not match executed ACS telemetry."""
+
+
+@dataclass(frozen=True)
+class PlanExecutionMismatch:
+    """A single mismatch between an exported plan entry and ACS telemetry."""
+
+    utime: float
+    message: str
+    obsid: int | None = None
+
+    def __str__(self) -> str:
+        return self.message
 
 
 class QueueDITL(DITLMixin, DITLStats):
@@ -453,6 +470,8 @@ class QueueDITL(DITLMixin, DITLStats):
         if self.plan:
             self._close_last_plan_entry(utime)
 
+        self._assert_plan_matches_execution()
+
         return True
 
     def _handle_data_management(self, utime: float, mode: ACSMode) -> None:
@@ -544,6 +563,283 @@ class QueueDITL(DITLMixin, DITLStats):
         if collection_time is None:
             return False
         return collection_time < max(0.0, float(entry.ss_min))
+
+    def _entry_obstype(self, entry: PlanEntry) -> ObsType | None:
+        obstype = getattr(entry, "obstype", None)
+        if isinstance(obstype, ObsType):
+            return obstype
+        try:
+            return ObsType(obstype)
+        except (TypeError, ValueError):
+            return None
+
+    def _mode_at_index(self, index: int) -> ACSMode | None:
+        mode = self.mode[index]
+        if isinstance(mode, ACSMode):
+            return mode
+        try:
+            return ACSMode(mode)
+        except (TypeError, ValueError):
+            return None
+
+    def _plan_execution_tolerance_deg(self) -> float:
+        acs_config = self.config.spacecraft_bus.attitude_control
+        try:
+            tolerance = float(acs_config.slew_accuracy)
+        except (TypeError, ValueError):
+            tolerance = 0.01
+        return tolerance if tolerance > 0 else 0.01
+
+    def _telemetry_length_mismatch(self) -> PlanExecutionMismatch | None:
+        lengths = {
+            "utime": len(self.utime),
+            "ra": len(self.ra),
+            "dec": len(self.dec),
+            "obsid": len(self.obsid),
+            "mode": len(self.mode),
+        }
+        if len(set(lengths.values())) == 1:
+            return None
+        return PlanExecutionMismatch(
+            utime=self.uend or self.ustart,
+            message=f"telemetry_length_mismatch: {lengths}",
+        )
+
+    def _science_start_time(self, entry: PlanEntry) -> float:
+        return float(entry.begin) + max(0.0, float(getattr(entry, "slewtime", 0.0)))
+
+    def _execution_mismatch(
+        self,
+        utime: float,
+        interval: str,
+        mismatch_type: str,
+        detail: str,
+        obsid: int | None = None,
+    ) -> PlanExecutionMismatch:
+        return PlanExecutionMismatch(
+            utime=utime,
+            message=f"{unixtime2date(utime)} {interval} {mismatch_type}: {detail}",
+            obsid=obsid,
+        )
+
+    def _mode_mismatch(
+        self,
+        entry: PlanEntry,
+        utime: float,
+        actual_mode: ACSMode | None,
+        expected_mode: ACSMode,
+        interval: str,
+    ) -> PlanExecutionMismatch:
+        return self._execution_mismatch(
+            utime,
+            interval,
+            "mode_mismatch",
+            f"obsid {entry.obsid} expected {expected_mode} got {actual_mode}",
+            obsid=int(entry.obsid),
+        )
+
+    def _obsid_mismatch(
+        self, entry: PlanEntry, utime: float, actual_obsid: int, interval: str
+    ) -> PlanExecutionMismatch:
+        return self._execution_mismatch(
+            utime,
+            interval,
+            "obsid_mismatch",
+            f"expected {int(entry.obsid)} got {int(actual_obsid)}",
+            obsid=int(entry.obsid),
+        )
+
+    def _pointing_mismatch(
+        self,
+        entry: PlanEntry,
+        utime: float,
+        error_deg: float,
+        interval: str,
+    ) -> PlanExecutionMismatch:
+        return self._execution_mismatch(
+            utime,
+            interval,
+            "pointing_mismatch",
+            f"obsid {int(entry.obsid)} error {error_deg:.3f} deg",
+            obsid=int(entry.obsid),
+        )
+
+    def _validate_science_entry_execution(
+        self, entry: PlanEntry, tolerance_deg: float
+    ) -> list[PlanExecutionMismatch]:
+        start = self._science_start_time(entry)
+        end = float(entry.end)
+        mismatches: list[PlanExecutionMismatch] = []
+        if end <= start:
+            return mismatches
+
+        samples = 0
+        science_samples = 0
+        for i, utime in enumerate(self.utime):
+            if not (start <= utime < end):
+                continue
+
+            samples += 1
+            mode = self._mode_at_index(i)
+            if mode == ACSMode.SAA:
+                continue
+            if mode != ACSMode.SCIENCE:
+                mismatches.append(
+                    self._mode_mismatch(entry, utime, mode, ACSMode.SCIENCE, "science")
+                )
+                continue
+
+            science_samples += 1
+            if int(self.obsid[i]) != int(entry.obsid):
+                mismatches.append(
+                    self._obsid_mismatch(entry, utime, self.obsid[i], "science")
+                )
+
+            error_deg = angular_separation(
+                float(self.ra[i]), float(self.dec[i]), float(entry.ra), float(entry.dec)
+            )
+            if error_deg > tolerance_deg:
+                mismatches.append(
+                    self._pointing_mismatch(entry, utime, error_deg, "science")
+                )
+
+        if samples > 0 and science_samples == 0:
+            mismatches.append(
+                self._execution_mismatch(
+                    start,
+                    "science",
+                    "no_science_execution",
+                    f"obsid {int(entry.obsid)}",
+                    obsid=int(entry.obsid),
+                )
+            )
+        return mismatches
+
+    def _matching_pass_for_entry(self, entry: PlanEntry) -> Pass | None:
+        passrequests = getattr(self.acs, "passrequests", None)
+        passes = getattr(passrequests, "passes", None)
+        if not isinstance(passes, list):
+            return None
+
+        station = getattr(entry, "station", None)
+        contact_begin = getattr(entry, "contact_begin", None)
+        contact_end = getattr(entry, "contact_end", None)
+        for gspass in passes:
+            if station is not None and gspass.station != station:
+                continue
+            begin_matches = (
+                contact_begin is None
+                or abs(float(gspass.begin) - float(contact_begin)) <= 1e-6
+            )
+            end_matches = (
+                contact_end is None
+                or abs(float(gspass.end) - float(contact_end)) <= 1e-6
+            )
+            if begin_matches and end_matches:
+                return cast(Pass, gspass)
+        return None
+
+    def _validate_gsp_entry_execution(
+        self, entry: PlanEntry, tolerance_deg: float
+    ) -> list[PlanExecutionMismatch]:
+        contact_begin = getattr(entry, "contact_begin", None)
+        contact_end = getattr(entry, "contact_end", None)
+        start = (
+            float(contact_begin)
+            if contact_begin is not None
+            else self._science_start_time(entry)
+        )
+        end = float(contact_end) if contact_end is not None else float(entry.end)
+        mismatches: list[PlanExecutionMismatch] = []
+        if end <= start:
+            return mismatches
+
+        gspass = self._matching_pass_for_entry(entry)
+        missing_profile = gspass is None or not gspass.ra or not gspass.dec
+        if missing_profile:
+            mismatches.append(
+                self._execution_mismatch(
+                    start,
+                    "contact",
+                    "pass_profile_missing",
+                    f"obsid {int(entry.obsid)} station {getattr(entry, 'station', None)}",
+                    obsid=int(entry.obsid),
+                )
+            )
+
+        for i, utime in enumerate(self.utime):
+            if not (start <= utime < end):
+                continue
+
+            mode = self._mode_at_index(i)
+            if mode != ACSMode.PASS:
+                mismatches.append(
+                    self._mode_mismatch(entry, utime, mode, ACSMode.PASS, "contact")
+                )
+
+            if int(self.obsid[i]) != int(entry.obsid):
+                mismatches.append(
+                    self._obsid_mismatch(entry, utime, self.obsid[i], "contact")
+                )
+
+            if missing_profile:
+                continue
+            assert gspass is not None
+            expected_ra, expected_dec = gspass.ra_dec(utime)
+            if expected_ra is None or expected_dec is None:
+                continue
+
+            error_deg = angular_separation(
+                float(self.ra[i]),
+                float(self.dec[i]),
+                float(expected_ra),
+                float(expected_dec),
+            )
+            if error_deg > tolerance_deg:
+                mismatches.append(
+                    self._pointing_mismatch(entry, utime, error_deg, "contact")
+                )
+        return mismatches
+
+    def validate_plan_matches_execution(self) -> list[PlanExecutionMismatch]:
+        """Return plan/ACS mismatches over exported science and contact intervals."""
+        mismatch = self._telemetry_length_mismatch()
+        if mismatch is not None:
+            return [mismatch]
+
+        tolerance_deg = self._plan_execution_tolerance_deg()
+        mismatches: list[PlanExecutionMismatch] = []
+        for entry in self.plan:
+            obstype = self._entry_obstype(entry)
+            if obstype in (ObsType.AT, ObsType.TOO):
+                mismatches.extend(
+                    self._validate_science_entry_execution(entry, tolerance_deg)
+                )
+            elif obstype == ObsType.GSP:
+                mismatches.extend(
+                    self._validate_gsp_entry_execution(entry, tolerance_deg)
+                )
+        return mismatches
+
+    def _assert_plan_matches_execution(self) -> None:
+        mismatches = self.validate_plan_matches_execution()
+        if not mismatches:
+            return
+
+        examples = "; ".join(str(mismatch) for mismatch in mismatches[:5])
+        message = (
+            f"Plan execution validation failed with {len(mismatches)} mismatch(es): "
+            f"{examples}"
+        )
+        first = mismatches[0]
+        self.log.log_event(
+            utime=first.utime,
+            event_type="ERROR",
+            description=message,
+            obsid=first.obsid,
+            acs_mode=self.acs.acsmode,
+        )
+        raise PlanExecutionMismatchError(message)
 
     def _close_last_plan_entry(self, end_time: float) -> None:
         """Close the last plan entry in the timeline by setting its end time.
@@ -1053,6 +1349,7 @@ class QueueDITL(DITLMixin, DITLStats):
             slew.endra = next_pass.gsstartra
             slew.enddec = next_pass.gsstartdec
             slew.obstype = ObsType.GSP  # Ground Station Pass slew
+            slew.obsid = next_pass.obsid
             command = ACSCommand(
                 command_type=ACSCommandType.SLEW_TO_TARGET,
                 execution_time=utime,

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -564,6 +564,8 @@ class ACS:
         self._check_constraints(utime)
 
         # Return current pointing
+        if self.current_pass is not None:
+            return self.ra, self.dec, self.roll, self.current_pass.obsid
         if self.last_slew is not None:
             return self.ra, self.dec, self.roll, self.last_slew.obsid
         else:

--- a/tests/acs/test_acs_comprehensive.py
+++ b/tests/acs/test_acs_comprehensive.py
@@ -387,6 +387,31 @@ class TestPointing:
         assert dec == 30.0
 
     @patch("conops.optimum_roll")
+    def test_pointing_current_pass_reports_pass_obsid(self, mock_roll, acs) -> None:
+        """Active pass tracking should report the pass obsid, not stale science."""
+        mock_roll.return_value = 0.0
+
+        current_pass = Mock(spec=Pass)
+        current_pass.in_pass = Mock(return_value=True)
+        current_pass.ra_dec = Mock(return_value=(50.0, 35.0))
+        current_pass.obsid = 0xFFFF
+
+        stale_science = Mock()
+        stale_science.obsid = 101
+        stale_science.ra_dec = Mock(return_value=(10.0, 20.0))
+        stale_science.obstype = "PPT"
+        stale_science.is_slewing = Mock(return_value=False)
+
+        acs.current_pass = current_pass
+        acs.last_slew = stale_science
+
+        ra, dec, _, obsid = acs.pointing(1514765000.0)
+
+        assert obsid == 0xFFFF
+        assert ra == 50.0
+        assert dec == 35.0
+
+    @patch("conops.optimum_roll")
     def test_pointing_with_constraint_violation(
         self, mock_roll, acs, mock_constraint
     ) -> None:

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -1,13 +1,20 @@
 """Unit tests for QueueDITL class."""
 
+from datetime import datetime
 from typing import cast
 from unittest.mock import Mock, patch
 
 import pytest
 
-from conops import ACS, ACSCommand, ACSCommandType, ACSMode, Pass, QueueDITL, Slew
 from conops import (
+    ACS,
+    ACSCommand,
+    ACSCommandType,
+    ACSMode,
+    Pass,
     PlanExecutionMismatchError,
+    QueueDITL,
+    Slew,
 )
 from conops.common.enums import ObsType
 from conops.config.config import MissionConfig
@@ -1306,6 +1313,18 @@ class TestRecordSpacecraftState:
 class TestPlanExecutionValidation:
     """Plan entries must match executed ACS telemetry before export."""
 
+    def _index_telemetry_by_time(self, queue_ditl: QueueDITL) -> None:
+        utimes = [float(utime) for utime in queue_ditl.utime]
+
+        def index(time: datetime) -> int:
+            timestamp = time.timestamp()
+            return min(
+                range(len(utimes)),
+                key=lambda i: abs(utimes[i] - timestamp),
+            )
+
+        queue_ditl.ephem.index = index
+
     def _science_entry(self, queue_ditl: QueueDITL) -> PlanEntry:
         entry = PlanEntry(config=queue_ditl.config)
         entry.obstype = ObsType.AT
@@ -1323,17 +1342,19 @@ class TestPlanExecutionValidation:
     ) -> None:
         entry = self._science_entry(queue_ditl)
         queue_ditl.plan.append(entry)
-        queue_ditl.utime = [1000.0, 1060.0, 1120.0, 1180.0, 1240.0]
+        queue_ditl.utime = [1000.0, 1060.0, 1120.0, 1180.0, 1240.0, 1300.0]
         queue_ditl.mode = [
             ACSMode.SLEWING,
             ACSMode.SCIENCE,
             ACSMode.SCIENCE,
             ACSMode.SCIENCE,
             ACSMode.SCIENCE,
+            ACSMode.SCIENCE,
         ]
-        queue_ditl.obsid = [0, 42, 42, 42, 42]
-        queue_ditl.ra = [0.0, 10.0, 10.0, 10.0, 10.0]
-        queue_ditl.dec = [0.0, 20.0, 20.0, 20.0, 20.0]
+        queue_ditl.obsid = [0, 42, 42, 42, 42, 42]
+        queue_ditl.ra = [0.0, 10.0, 10.0, 10.0, 10.0, 10.0]
+        queue_ditl.dec = [0.0, 20.0, 20.0, 20.0, 20.0, 20.0]
+        self._index_telemetry_by_time(queue_ditl)
 
         assert queue_ditl.validate_plan_matches_execution() == []
 
@@ -1342,11 +1363,17 @@ class TestPlanExecutionValidation:
     ) -> None:
         entry = self._science_entry(queue_ditl)
         queue_ditl.plan.append(entry)
-        queue_ditl.utime = [1000.0, 1060.0, 1120.0]
-        queue_ditl.mode = [ACSMode.SLEWING, ACSMode.SCIENCE, ACSMode.SCIENCE]
-        queue_ditl.obsid = [0, 10454, 10454]
-        queue_ditl.ra = [0.0, 10.0, 10.0]
-        queue_ditl.dec = [0.0, 20.0, 20.0]
+        queue_ditl.utime = [1000.0, 1060.0, 1120.0, 1300.0]
+        queue_ditl.mode = [
+            ACSMode.SLEWING,
+            ACSMode.SCIENCE,
+            ACSMode.SCIENCE,
+            ACSMode.SCIENCE,
+        ]
+        queue_ditl.obsid = [0, 10454, 10454, 10454]
+        queue_ditl.ra = [0.0, 10.0, 10.0, 10.0]
+        queue_ditl.dec = [0.0, 20.0, 20.0, 20.0]
+        self._index_telemetry_by_time(queue_ditl)
 
         with pytest.raises(PlanExecutionMismatchError, match="obsid_mismatch"):
             queue_ditl._assert_plan_matches_execution()
@@ -1356,11 +1383,17 @@ class TestPlanExecutionValidation:
     ) -> None:
         entry = self._science_entry(queue_ditl)
         queue_ditl.plan.append(entry)
-        queue_ditl.utime = [1000.0, 1060.0, 1120.0]
-        queue_ditl.mode = [ACSMode.SLEWING, ACSMode.SCIENCE, ACSMode.SCIENCE]
-        queue_ditl.obsid = [0, 42, 42]
-        queue_ditl.ra = [0.0, 40.0, 40.0]
-        queue_ditl.dec = [0.0, 20.0, 20.0]
+        queue_ditl.utime = [1000.0, 1060.0, 1120.0, 1300.0]
+        queue_ditl.mode = [
+            ACSMode.SLEWING,
+            ACSMode.SCIENCE,
+            ACSMode.SCIENCE,
+            ACSMode.SCIENCE,
+        ]
+        queue_ditl.obsid = [0, 42, 42, 42]
+        queue_ditl.ra = [0.0, 40.0, 40.0, 40.0]
+        queue_ditl.dec = [0.0, 20.0, 20.0, 20.0]
+        self._index_telemetry_by_time(queue_ditl)
 
         with pytest.raises(PlanExecutionMismatchError, match="pointing_mismatch"):
             queue_ditl._assert_plan_matches_execution()
@@ -1378,16 +1411,18 @@ class TestPlanExecutionValidation:
         entry.contact_end = 1180.0
         entry.end = 1180.0
         queue_ditl.plan.append(entry)
-        queue_ditl.utime = [900.0, 1000.0, 1060.0, 1120.0]
+        queue_ditl.utime = [900.0, 1000.0, 1060.0, 1120.0, 1180.0]
         queue_ditl.mode = [
             ACSMode.SLEWING,
             ACSMode.PASS,
             ACSMode.SCIENCE,
             ACSMode.PASS,
+            ACSMode.PASS,
         ]
-        queue_ditl.obsid = [0, 0xFFFF, 0xFFFF, 0xFFFF]
-        queue_ditl.ra = [0.0, 10.0, 10.0, 10.0]
-        queue_ditl.dec = [0.0, 20.0, 20.0, 20.0]
+        queue_ditl.obsid = [0, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF]
+        queue_ditl.ra = [0.0, 10.0, 10.0, 10.0, 10.0]
+        queue_ditl.dec = [0.0, 20.0, 20.0, 20.0, 20.0]
+        self._index_telemetry_by_time(queue_ditl)
 
         with pytest.raises(PlanExecutionMismatchError, match="mode_mismatch"):
             queue_ditl._assert_plan_matches_execution()
@@ -1405,11 +1440,12 @@ class TestPlanExecutionValidation:
         entry.contact_end = 1180.0
         entry.end = 1180.0
         queue_ditl.plan.append(entry)
-        queue_ditl.utime = [1000.0, 1060.0, 1120.0]
-        queue_ditl.mode = [ACSMode.PASS, ACSMode.PASS, ACSMode.PASS]
-        queue_ditl.obsid = [0xFFFF, 0xFFFF, 0xFFFF]
-        queue_ditl.ra = [10.0, 10.0, 10.0]
-        queue_ditl.dec = [20.0, 20.0, 20.0]
+        queue_ditl.utime = [1000.0, 1060.0, 1120.0, 1180.0]
+        queue_ditl.mode = [ACSMode.PASS, ACSMode.PASS, ACSMode.PASS, ACSMode.PASS]
+        queue_ditl.obsid = [0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF]
+        queue_ditl.ra = [10.0, 10.0, 10.0, 10.0]
+        queue_ditl.dec = [20.0, 20.0, 20.0, 20.0]
+        self._index_telemetry_by_time(queue_ditl)
 
         with pytest.raises(PlanExecutionMismatchError, match="pass_profile_missing"):
             queue_ditl._assert_plan_matches_execution()
@@ -1432,16 +1468,17 @@ class TestPlanExecutionValidation:
             begin=1000.0,
             length=180.0,
             obsid=0xFFFF,
-            utime=[1000.0, 1060.0, 1120.0],
-            ra=[10.0, 11.0, 12.0],
-            dec=[20.0, 21.0, 22.0],
+            utime=[1000.0, 1060.0, 1120.0, 1180.0],
+            ra=[10.0, 11.0, 12.0, 13.0],
+            dec=[20.0, 21.0, 22.0, 23.0],
         )
         queue_ditl.acs.passrequests.passes = [pass_obj]
-        queue_ditl.utime = [1000.0, 1060.0, 1120.0]
-        queue_ditl.mode = [ACSMode.PASS, ACSMode.PASS, ACSMode.PASS]
-        queue_ditl.obsid = [0xFFFF, 0xFFFF, 0xFFFF]
-        queue_ditl.ra = [10.0, 40.0, 12.0]
-        queue_ditl.dec = [20.0, 21.0, 22.0]
+        queue_ditl.utime = [1000.0, 1060.0, 1120.0, 1180.0]
+        queue_ditl.mode = [ACSMode.PASS, ACSMode.PASS, ACSMode.PASS, ACSMode.PASS]
+        queue_ditl.obsid = [0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF]
+        queue_ditl.ra = [10.0, 40.0, 12.0, 13.0]
+        queue_ditl.dec = [20.0, 21.0, 22.0, 23.0]
+        self._index_telemetry_by_time(queue_ditl)
 
         with pytest.raises(PlanExecutionMismatchError, match="pointing_mismatch"):
             queue_ditl._assert_plan_matches_execution()

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -6,6 +6,9 @@ from unittest.mock import Mock, patch
 import pytest
 
 from conops import ACS, ACSCommand, ACSCommandType, ACSMode, Pass, QueueDITL, Slew
+from conops import (
+    PlanExecutionMismatchError,
+)
 from conops.common.enums import ObsType
 from conops.config.config import MissionConfig
 from conops.ditl.telemetry import Housekeeping
@@ -1300,6 +1303,169 @@ class TestRecordSpacecraftState:
         queue_ditl.battery.charge.assert_called_once_with(100.0, 60)
 
 
+class TestPlanExecutionValidation:
+    """Plan entries must match executed ACS telemetry before export."""
+
+    def _science_entry(self, queue_ditl: QueueDITL) -> PlanEntry:
+        entry = PlanEntry(config=queue_ditl.config)
+        entry.obstype = ObsType.AT
+        entry.obsid = 42
+        entry.ra = 10.0
+        entry.dec = 20.0
+        entry.begin = 1000.0
+        entry.slewtime = 60.0
+        entry.end = 1300.0
+        entry.ss_min = 60.0
+        return entry
+
+    def test_validation_passes_for_matching_science_execution(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = self._science_entry(queue_ditl)
+        queue_ditl.plan.append(entry)
+        queue_ditl.utime = [1000.0, 1060.0, 1120.0, 1180.0, 1240.0]
+        queue_ditl.mode = [
+            ACSMode.SLEWING,
+            ACSMode.SCIENCE,
+            ACSMode.SCIENCE,
+            ACSMode.SCIENCE,
+            ACSMode.SCIENCE,
+        ]
+        queue_ditl.obsid = [0, 42, 42, 42, 42]
+        queue_ditl.ra = [0.0, 10.0, 10.0, 10.0, 10.0]
+        queue_ditl.dec = [0.0, 20.0, 20.0, 20.0, 20.0]
+
+        assert queue_ditl.validate_plan_matches_execution() == []
+
+    def test_validation_fails_for_stale_science_obsid(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = self._science_entry(queue_ditl)
+        queue_ditl.plan.append(entry)
+        queue_ditl.utime = [1000.0, 1060.0, 1120.0]
+        queue_ditl.mode = [ACSMode.SLEWING, ACSMode.SCIENCE, ACSMode.SCIENCE]
+        queue_ditl.obsid = [0, 10454, 10454]
+        queue_ditl.ra = [0.0, 10.0, 10.0]
+        queue_ditl.dec = [0.0, 20.0, 20.0]
+
+        with pytest.raises(PlanExecutionMismatchError, match="obsid_mismatch"):
+            queue_ditl._assert_plan_matches_execution()
+
+    def test_validation_fails_for_science_pointing_mismatch(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = self._science_entry(queue_ditl)
+        queue_ditl.plan.append(entry)
+        queue_ditl.utime = [1000.0, 1060.0, 1120.0]
+        queue_ditl.mode = [ACSMode.SLEWING, ACSMode.SCIENCE, ACSMode.SCIENCE]
+        queue_ditl.obsid = [0, 42, 42]
+        queue_ditl.ra = [0.0, 40.0, 40.0]
+        queue_ditl.dec = [0.0, 20.0, 20.0]
+
+        with pytest.raises(PlanExecutionMismatchError, match="pointing_mismatch"):
+            queue_ditl._assert_plan_matches_execution()
+
+    def test_validation_fails_for_contact_mode_mismatch(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = PlanEntry(config=queue_ditl.config)
+        entry.obstype = ObsType.GSP
+        entry.obsid = 0xFFFF
+        entry.station = "TRO"
+        entry.begin = 900.0
+        entry.slewtime = 100.0
+        entry.contact_begin = 1000.0
+        entry.contact_end = 1180.0
+        entry.end = 1180.0
+        queue_ditl.plan.append(entry)
+        queue_ditl.utime = [900.0, 1000.0, 1060.0, 1120.0]
+        queue_ditl.mode = [
+            ACSMode.SLEWING,
+            ACSMode.PASS,
+            ACSMode.SCIENCE,
+            ACSMode.PASS,
+        ]
+        queue_ditl.obsid = [0, 0xFFFF, 0xFFFF, 0xFFFF]
+        queue_ditl.ra = [0.0, 10.0, 10.0, 10.0]
+        queue_ditl.dec = [0.0, 20.0, 20.0, 20.0]
+
+        with pytest.raises(PlanExecutionMismatchError, match="mode_mismatch"):
+            queue_ditl._assert_plan_matches_execution()
+
+    def test_validation_fails_when_contact_profile_missing(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = PlanEntry(config=queue_ditl.config)
+        entry.obstype = ObsType.GSP
+        entry.obsid = 0xFFFF
+        entry.station = "TRO"
+        entry.begin = 900.0
+        entry.slewtime = 100.0
+        entry.contact_begin = 1000.0
+        entry.contact_end = 1180.0
+        entry.end = 1180.0
+        queue_ditl.plan.append(entry)
+        queue_ditl.utime = [1000.0, 1060.0, 1120.0]
+        queue_ditl.mode = [ACSMode.PASS, ACSMode.PASS, ACSMode.PASS]
+        queue_ditl.obsid = [0xFFFF, 0xFFFF, 0xFFFF]
+        queue_ditl.ra = [10.0, 10.0, 10.0]
+        queue_ditl.dec = [20.0, 20.0, 20.0]
+
+        with pytest.raises(PlanExecutionMismatchError, match="pass_profile_missing"):
+            queue_ditl._assert_plan_matches_execution()
+
+    def test_validation_fails_for_contact_pointing_mismatch(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = PlanEntry(config=queue_ditl.config)
+        entry.obstype = ObsType.GSP
+        entry.obsid = 0xFFFF
+        entry.station = "TRO"
+        entry.begin = 900.0
+        entry.slewtime = 100.0
+        entry.contact_begin = 1000.0
+        entry.contact_end = 1180.0
+        entry.end = 1180.0
+        queue_ditl.plan.append(entry)
+        pass_obj = Pass(
+            station="TRO",
+            begin=1000.0,
+            length=180.0,
+            obsid=0xFFFF,
+            utime=[1000.0, 1060.0, 1120.0],
+            ra=[10.0, 11.0, 12.0],
+            dec=[20.0, 21.0, 22.0],
+        )
+        queue_ditl.acs.passrequests.passes = [pass_obj]
+        queue_ditl.utime = [1000.0, 1060.0, 1120.0]
+        queue_ditl.mode = [ACSMode.PASS, ACSMode.PASS, ACSMode.PASS]
+        queue_ditl.obsid = [0xFFFF, 0xFFFF, 0xFFFF]
+        queue_ditl.ra = [10.0, 40.0, 12.0]
+        queue_ditl.dec = [20.0, 21.0, 22.0]
+
+        with pytest.raises(PlanExecutionMismatchError, match="pointing_mismatch"):
+            queue_ditl._assert_plan_matches_execution()
+
+    def test_calc_validates_plan_before_return(
+        self, queue_ditl: QueueDITL, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called = False
+
+        def assert_plan_matches_execution() -> None:
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(
+            queue_ditl,
+            "_assert_plan_matches_execution",
+            assert_plan_matches_execution,
+        )
+        queue_ditl.step_size = 3600
+
+        assert queue_ditl.calc() is True
+        assert called is True
+
+
 class TestCalcMethod:
     """Test main calc method integration."""
 
@@ -2382,6 +2548,7 @@ class TestCheckAndManagePasses:
         # Verify slew points to the pass start position
         assert command.slew.endra == pass_obj.gsstartra
         assert command.slew.enddec == pass_obj.gsstartdec
+        assert command.slew.obsid == pass_obj.obsid
 
     def test_check_and_manage_passes_exports_gsp_plan_entry_for_pass_slew(
         self, queue_ditl, tmp_path


### PR DESCRIPTION
## Summary
- fail QueueDITL before returning when exported science/contact plan entries do not match recorded ACS telemetry
- validate science obsid/pointing and GSP contact mode/obsid/pass pointing profile
- propagate GSP obsid through ACS pass telemetry so contact validation compares against executed pass state

This prevents a mismatched plan from being produced as valid
