### PR TITLE
fix: drop interrupted science entries during charging

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1088,10 +1088,15 @@ class QueueDITL(DITLMixin, DITLStats):
 
         # If charging PPT created successfully, send command to ACS and replace current PPT
         if self.charging_ppt is not None:
-            if interrupted_ppt is not None and self._is_short_science_entry(
-                interrupted_ppt
-            ):
-                interrupted_ppt.done = False
+            if interrupted_ppt is not None:
+                if (
+                    len(self.plan) > 0
+                    and self._entry_obstype(self.plan[-1]) == ObsType.AT
+                    and int(self.plan[-1].obsid) == int(interrupted_ppt.obsid)
+                ):
+                    self._close_last_plan_entry(utime)
+                if self._is_short_science_entry(interrupted_ppt):
+                    interrupted_ppt.done = False
 
             command = ACSCommand(
                 command_type=ACSCommandType.START_BATTERY_CHARGE,

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -1667,6 +1667,7 @@ class TestCalcMethod:
             return charging_ppt
 
         queue_ditl.ppt = science_ppt
+        queue_ditl.plan = [science_ppt]
         queue_ditl.emergency_charging.initiate_emergency_charging = Mock(
             side_effect=interrupt_for_charging
         )
@@ -1674,6 +1675,7 @@ class TestCalcMethod:
         queue_ditl._initiate_charging(1250.0, 10.0, 20.0)
 
         assert science_ppt.done is False
+        assert science_ppt not in queue_ditl.plan
         assert queue_ditl.ppt is charging_ppt
         queue_ditl.acs.enqueue_command.assert_called_once()
 


### PR DESCRIPTION
Fixes #152.

When emergency charging interrupts active science, QueueDITL now removes the active science plan entry that matches the interrupted target and keeps short science retryable.

Validation:
- pytest tests/scheduler_queue/test_queue_ditl.py -k charging
- pre-commit run --all-files