### PR TITLE
fix: synchronize GSP plan entries with ACS execution

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -20,7 +20,7 @@ from ..common.vector import attitude_to_quat
 from ..config import MissionConfig
 from ..simulation.acs_command import ACSCommand
 from ..simulation.emergency_charging import EmergencyCharging
-from ..simulation.passes import Pass, pass_slew_trigger_buffer
+from ..simulation.passes import GSP_TRACK_ROLL, Pass, pass_slew_trigger_buffer
 from ..simulation.roll import optimum_roll
 from ..simulation.slew import Slew
 from ..targets import Plan, PlanEntry, Pointing, Queue
@@ -436,7 +436,11 @@ class QueueDITL(DITLMixin, DITLStats):
             mode = self.acs.get_mode(utime)
 
             # Check pass timing and manage passes
-            self._check_and_manage_passes(utime, ra, dec)
+            pass_command_due = self._check_and_manage_passes(utime, ra, dec, roll)
+            if pass_command_due:
+                ra, dec, roll, obsid = self.acs.pointing(utime)
+                self._sync_acs_slew_metadata()
+                mode = self.acs.get_mode(utime)
 
             # Handle spacecraft operations based on current mode
             self._handle_mode_operations(mode, utime, ra, dec)
@@ -1257,11 +1261,13 @@ class QueueDITL(DITLMixin, DITLStats):
         )
         return True
 
-    def _check_and_manage_passes(self, utime: float, ra: float, dec: float) -> None:
+    def _check_and_manage_passes(
+        self, utime: float, ra: float, dec: float, roll: float = 0.0
+    ) -> bool:
         """Check pass timing and send appropriate commands to ACS."""
 
         if self.acs.in_safe_mode or self.acs.acsmode == ACSMode.SAFE:
-            return
+            return False
 
         commanded_pass = self.acs.current_pass
         if (
@@ -1280,13 +1286,13 @@ class QueueDITL(DITLMixin, DITLStats):
                 execution_time=utime,
             )
             self.acs.enqueue_command(command)
-            return
+            return True
 
         # Check if we're in a pass, if yes, command ACS to start the pass
         current_pass = self.acs.passrequests.current_pass(utime)
         if current_pass is not None and self.acs.acsmode != ACSMode.PASS:
             if not self._gsp_plan_entry_allowed(current_pass, reserved_begin=utime):
-                return
+                return False
             self.log.log_event(
                 utime=utime,
                 event_type="PASS",
@@ -1299,7 +1305,7 @@ class QueueDITL(DITLMixin, DITLStats):
             )
             self.acs.enqueue_command(command)
             self._record_gsp_plan_entry(current_pass, reserved_begin=utime)
-            return
+            return True
 
         # Check if a pass just ended, if yes, command ACS to end the pass.
         # FIXME: This works but isn't super clean.
@@ -1318,24 +1324,24 @@ class QueueDITL(DITLMixin, DITLStats):
                 execution_time=utime,
             )
             self.acs.enqueue_command(command)
-            return
+            return True
 
         # Check to see if it's time to slew to the next pass
         # Skip if already in PASS or SLEWING mode - can't interrupt a slew mid-motion.
         # Pass-aware scheduling in _fetch_new_ppt prevents conflicts.
         if self.acs.acsmode in (ACSMode.PASS, ACSMode.SLEWING):
-            return
+            return False
 
         next_pass = self.acs.passrequests.next_pass(utime)
 
         # If there's no next pass, nothing to do
         if next_pass is None:
-            return
+            return False
 
         # Check if it's time to start slewing for the next pass
-        if next_pass.time_to_slew(utime=utime, ra=ra, dec=dec):
+        if next_pass.time_to_slew(utime=utime, ra=ra, dec=dec, roll=roll):
             if not self._gsp_plan_entry_allowed(next_pass, reserved_begin=utime):
-                return
+                return False
             # If it's time to slew, enqueue the slew command
             self.log.log_event(
                 utime=utime,
@@ -1351,8 +1357,10 @@ class QueueDITL(DITLMixin, DITLStats):
 
             slew.startra = ra
             slew.startdec = dec
+            slew.startroll = roll
             slew.endra = next_pass.gsstartra
             slew.enddec = next_pass.gsstartdec
+            slew.endroll = GSP_TRACK_ROLL
             slew.obstype = ObsType.GSP  # Ground Station Pass slew
             slew.obsid = next_pass.obsid
             command = ACSCommand(
@@ -1362,7 +1370,9 @@ class QueueDITL(DITLMixin, DITLStats):
             )
             self.acs.enqueue_command(command)
             self._record_gsp_plan_entry(next_pass, reserved_begin=utime)
-            return
+            return True
+
+        return False
 
     def _handle_pass_mode(self, utime: float) -> None:
         """Handle spacecraft behavior during ground station passes."""

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -9,6 +9,10 @@ from ..common.enums import AntennaType
 from ..common.vector import radec2vec, rotvec, separation, vec2radec
 from ..config import Constraint, GroundStationRegistry, MissionConfig
 from ..config.constants import DTOR
+from .slew import Slew
+
+# Current ground-pass model tracks RA/Dec while holding a fixed roll.
+GSP_TRACK_ROLL = 0.0
 
 
 def pass_slew_trigger_buffer(step_size: float) -> float:
@@ -227,7 +231,32 @@ class Pass(BaseModel):
         rate_mbps = self.get_data_rate(band, direction)
         return rate_mbps * self.length  # Mbps * seconds = Megabits
 
-    def time_to_slew(self, utime: float, ra: float, dec: float) -> bool:
+    def _slew_time_to_target(
+        self,
+        utime: float,
+        ra: float,
+        dec: float,
+        roll: float,
+        target_ra: float,
+        target_dec: float,
+    ) -> float:
+        assert self.config is not None, "Config must be set for Pass class"
+        if self.config.spacecraft_bus.attitude_control is None:
+            raise ValueError("ACS config must be set to calculate slew time")
+
+        slew = Slew(config=self.config)
+        slew.startra = ra
+        slew.startdec = dec
+        slew.startroll = roll
+        slew.endra = target_ra
+        slew.enddec = target_dec
+        slew.endroll = GSP_TRACK_ROLL
+        slew.slewstart = utime
+        return slew.calc_slewtime()
+
+    def time_to_slew(
+        self, utime: float, ra: float, dec: float, roll: float = 0.0
+    ) -> bool:
         """Determine whether to begin slewing for this pass.
 
         Calculates the slew time between current RA/Dec and the appropriate pointing of the pass.
@@ -249,17 +278,9 @@ class Pass(BaseModel):
                 return False
             target_ra, target_dec = self.ra[0], self.dec[0]
 
-        # Using ACS config, calculate slew time
-        if self.config.spacecraft_bus.attitude_control is not None:
-            slewdist, _ = self.config.spacecraft_bus.attitude_control.predict_slew(
-                startra=ra,
-                startdec=dec,
-                endra=target_ra,
-                enddec=target_dec,
-            )
-            slewtime = self.config.spacecraft_bus.attitude_control.slew_time(slewdist)
-        else:
-            raise ValueError("ACS config must be set to calculate slew time")
+        slewtime = self._slew_time_to_target(
+            utime, ra, dec, roll, target_ra, target_dec
+        )
         # Determine if we need to start slewing now
         time_until_slew = (self.begin - slewtime) - utime
 

--- a/tests/passes/conftest.py
+++ b/tests/passes/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from rust_ephem import TLEEphemeris
 
 from conops import Constraint, MissionConfig, Pass
+from conops.common.enums import SlewAlgorithm
 from conops.config import (
     AttitudeControlSystem,
     Battery,
@@ -194,6 +195,7 @@ def acs_mock():
     acs = Mock(spec=AttitudeControlSystem)
     acs.predict_slew.return_value = (0.1, None)
     acs.slew_time.return_value = 100.0
+    acs.slew_algorithm = SlewAlgorithm.QUATERNION
     return acs
 
 

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -12,7 +12,7 @@ from conops import (
     PassTimes,
 )
 from conops.config import AttitudeControlSystem, BandCapability, GroundStation
-from conops.simulation.passes import pass_slew_trigger_buffer
+from conops.simulation.passes import GSP_TRACK_ROLL, pass_slew_trigger_buffer
 
 
 class TestPassInitialization:
@@ -269,6 +269,76 @@ class TestPassTimeToSlew:
         # utime same as previous; with slew_time=50 -> time_until_slew = 150 > 120 (buffer)
         result = p.time_to_slew(1514764600.0, ra=0.0, dec=0.0)
         assert result is False
+
+    def test_time_to_slew_includes_roll_distance(
+        self,
+        mock_config,
+        mock_constraint,
+        create_ephem,
+        base_begin,
+    ):
+        begin_dt = datetime(2025, 8, 15, 0, 0, 0, tzinfo=timezone.utc)
+        end_dt = datetime(2025, 8, 15, 0, 15, 0, tzinfo=timezone.utc)
+        ephem = create_ephem(begin_dt, end_dt, step_size=60)
+
+        mock_config.constraint = mock_constraint
+        p = Pass(
+            config=mock_config,
+            ephem=ephem,
+            station="SGS",
+            begin=base_begin,
+            length=600.0,
+        )
+        p.utime = [base_begin, base_begin + 60.0]
+        p.ra = [10.0, 10.0]
+        p.dec = [20.0, 20.0]
+
+        assert p.time_to_slew(base_begin - 600.0, ra=10.0, dec=20.0, roll=0.0) is False
+        assert p.time_to_slew(base_begin - 600.0, ra=10.0, dec=20.0, roll=180.0) is True
+
+    def test_slew_time_to_target_uses_gsp_track_roll(
+        self,
+        mock_config,
+        mock_constraint,
+        create_ephem,
+        base_begin,
+    ):
+        begin_dt = datetime(2025, 8, 15, 0, 0, 0, tzinfo=timezone.utc)
+        end_dt = datetime(2025, 8, 15, 0, 15, 0, tzinfo=timezone.utc)
+        ephem = create_ephem(begin_dt, end_dt, step_size=60)
+
+        mock_config.constraint = mock_constraint
+        p = Pass(
+            config=mock_config,
+            ephem=ephem,
+            station="SGS",
+            begin=base_begin,
+            length=600.0,
+        )
+        captured = {}
+
+        def calc_slewtime(slew):
+            captured["startroll"] = slew.startroll
+            captured["endroll"] = slew.endroll
+            return 123.0
+
+        with patch(
+            "conops.simulation.passes.Slew.calc_slewtime",
+            autospec=True,
+            side_effect=calc_slewtime,
+        ):
+            slewtime = p._slew_time_to_target(
+                base_begin - 600.0,
+                ra=10.0,
+                dec=20.0,
+                roll=42.0,
+                target_ra=30.0,
+                target_dec=40.0,
+            )
+
+        assert slewtime == 123.0
+        assert captured["startroll"] == pytest.approx(42.0)
+        assert captured["endroll"] == pytest.approx(GSP_TRACK_ROLL)
 
     def test_time_to_slew_raises_value_error_when_no_acs_config(
         self, mock_config, mock_constraint, create_ephem, base_begin

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -19,6 +19,7 @@ from conops import (
 from conops.common.enums import ObsType
 from conops.config.config import MissionConfig
 from conops.ditl.telemetry import Housekeeping
+from conops.simulation.passes import GSP_TRACK_ROLL
 from conops.targets import PlanEntry, PlanSchema
 
 
@@ -1584,6 +1585,37 @@ class TestCalcMethod:
         queue_ditl.calc()
         assert ACSMode.PASS in queue_ditl.mode
 
+    def test_calc_processes_due_pass_command_same_step(self, queue_ditl) -> None:
+        queue_ditl.year = 2018
+        queue_ditl.day = 331
+        queue_ditl.length = 1
+        queue_ditl.step_size = 3600
+        queue_ditl.acs.pointing = Mock(
+            side_effect=[
+                (0.0, 0.0, 0.0, 0),
+                (10.0, 20.0, 0.0, 0xFFFF),
+            ]
+            + [(10.0, 20.0, 0.0, 0xFFFF)] * 24
+        )
+        queue_ditl.acs.get_mode = Mock(return_value=ACSMode.PASS)
+        queue_ditl._assert_plan_matches_execution = Mock()
+        pass_checks = 0
+
+        def check_and_manage_passes(
+            utime: float, ra: float, dec: float, roll: float = 0.0
+        ) -> bool:
+            nonlocal pass_checks
+            pass_checks += 1
+            return pass_checks == 1
+
+        queue_ditl._check_and_manage_passes = check_and_manage_passes
+
+        queue_ditl.calc()
+
+        assert queue_ditl.acs.pointing.call_count == 25
+        assert queue_ditl.ra[0] == 10.0
+        assert queue_ditl.obsid[0] == 0xFFFF
+
     def test_calc_handles_emergency_charging_initiates(self, queue_ditl) -> None:
         queue_ditl.year = 2018
         queue_ditl.day = 331
@@ -2550,7 +2582,7 @@ class TestCheckAndManagePasses:
     ) -> None:
         """Test that slew to ground station pass is marked with GSP obstype."""
         utime = 1000.0
-        ra, dec = 10.0, 20.0
+        ra, dec, roll = 10.0, 20.0, 42.0
 
         pass_obj = Pass(
             station="GS_TEST",
@@ -2567,7 +2599,7 @@ class TestCheckAndManagePasses:
 
         # Call the method
         with patch.object(Pass, "time_to_slew", return_value=True):
-            queue_ditl._check_and_manage_passes(utime, ra, dec)
+            queue_ditl._check_and_manage_passes(utime, ra, dec, roll)
 
         # Verify a slew command was enqueued
         queue_ditl.acs.enqueue_command.assert_called_once()
@@ -2583,6 +2615,8 @@ class TestCheckAndManagePasses:
         assert command.slew.obstype == "GSP"
 
         # Verify slew points to the pass start position
+        assert command.slew.startroll == roll
+        assert command.slew.endroll == GSP_TRACK_ROLL
         assert command.slew.endra == pass_obj.gsstartra
         assert command.slew.enddec == pass_obj.gsstartdec
         assert command.slew.obsid == pass_obj.obsid


### PR DESCRIPTION
Fixes #150.

GSP entries now line up with ACS execution instead of being exported before ACS has actually processed the pass command. QueueDITL re-reads ACS pointing and mode after a due pass command, and pass pre-slew timing uses the same Slew model ACS executes, including roll.

Validation:
- pytest tests/passes/test_passes.py::TestPassTimeToSlew tests/scheduler_queue/test_queue_ditl.py::TestCalcMethod::test_calc_processes_due_pass_command_same_step
- pre-commit run --all-files