### PR TITLE
fix: use telemetry timestamps for validation windows

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1,3 +1,4 @@
+from bisect import bisect_left
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, cast
@@ -609,8 +610,8 @@ class QueueDITL(DITLMixin, DITLStats):
         return float(entry.begin) + max(0.0, float(getattr(entry, "slewtime", 0.0)))
 
     def _window_indices(self, start: float, end: float) -> range:
-        lo = max(0, int(self.ephem.index(dtutcfromtimestamp(start))))
-        hi = int(self.ephem.index(dtutcfromtimestamp(end)))
+        lo = max(0, bisect_left(self.utime, start))
+        hi = min(len(self.utime), bisect_left(self.utime, end))
         return range(lo, hi)
 
     def _execution_mismatch(

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -1358,6 +1358,23 @@ class TestPlanExecutionValidation:
 
         assert queue_ditl.validate_plan_matches_execution() == []
 
+    def test_validation_uses_samples_inside_scheduled_interval(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = self._science_entry(queue_ditl)
+        entry.begin = 970.0
+        entry.slewtime = 60.0
+        entry.end = 1120.0
+        queue_ditl.plan.append(entry)
+        queue_ditl.utime = [1000.0, 1060.0, 1120.0]
+        queue_ditl.mode = [ACSMode.SCIENCE, ACSMode.SCIENCE, ACSMode.SCIENCE]
+        queue_ditl.obsid = [999, 42, 999]
+        queue_ditl.ra = [99.0, 10.0, 99.0]
+        queue_ditl.dec = [99.0, 20.0, 99.0]
+        self._index_telemetry_by_time(queue_ditl)
+
+        assert queue_ditl.validate_plan_matches_execution() == []
+
     def test_validation_fails_for_stale_science_obsid(
         self, queue_ditl: QueueDITL
     ) -> None:


### PR DESCRIPTION
Fixes #151.

Plan/execution validation now indexes telemetry windows from self.utime with half-open interval bounds. That keeps samples just outside the scheduled interval from being pulled into validation by nearest ephemeris lookup.

Validation:
- pytest tests/scheduler_queue/test_queue_ditl.py::TestPlanExecutionValidation
- pre-commit run --all-files