### PR TITLE
fix: use ObsType for internal obstype fields

### DIFF
--- a/conops/simulation/acs_command.py
+++ b/conops/simulation/acs_command.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict
 
-from ..common import ACSCommandType
+from ..common import ACSCommandType, ObsType
 
 if TYPE_CHECKING:
     from .slew import Slew
@@ -18,7 +18,7 @@ class ACSCommand(BaseModel):
     dec: float | None = None
     roll: float | None = None
     obsid: int | None = None
-    obstype: str = "PPT"
+    obstype: ObsType = ObsType.PPT
     reason: str | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -5,7 +5,7 @@ import rust_ephem
 from pydantic import BaseModel, Field
 
 from ..common import ics_date_conv, unixtime2date
-from ..common.enums import AntennaType
+from ..common.enums import AntennaType, ObsType
 from ..common.vector import radec2vec, rotvec, separation, vec2radec
 from ..config import Constraint, GroundStationRegistry, MissionConfig
 from ..config.constants import DTOR
@@ -34,7 +34,7 @@ class Pass(BaseModel):
     length: float
 
     # What type of observation is this, a Ground Station Pass (GSP)
-    obstype: str = "GSP"
+    obstype: ObsType = ObsType.GSP
 
     # Ground station pointing vectors (start/end of contact)
     gsstartra: float = 0.0

--- a/tests/acs/test_acs.py
+++ b/tests/acs/test_acs.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from conops import ACS, ACSMode
+from conops.common.enums import ObsType
 
 
 class DummyEphemeris:
@@ -38,7 +39,7 @@ class TestACSInitialization:
         assert acs.ra == 180.0  # Earth-opposite nadir pointing
         assert acs.dec == 0.0
         assert acs.roll == 0.0
-        assert acs.obstype == "PPT"
+        assert acs.obstype == ObsType.PPT
         assert acs.last_slew is not None  # Initialized with boundary condition slew
         assert acs.last_ppt is None
         assert acs.acsmode == 0
@@ -63,9 +64,9 @@ class TestACSAttributes:
 
     def test_obstype_attribute(self, acs) -> None:
         """Test obstype attribute."""
-        assert acs.obstype == "PPT"
-        acs.obstype = "GSP"
-        assert acs.obstype == "GSP"
+        assert acs.obstype == ObsType.PPT
+        acs.obstype = ObsType.GSP
+        assert acs.obstype == ObsType.GSP
 
     def test_constraint_attribute(self, acs, mock_constraint) -> None:
         """Test constraint attribute."""

--- a/tests/acs/test_acs_safe_mode.py
+++ b/tests/acs/test_acs_safe_mode.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock
 
 from conops import ACSCommand, ACSCommandType, ACSMode
+from conops.common.enums import ObsType
 
 
 class TestSafeModeInitialization:
@@ -21,6 +22,23 @@ class TestSafeModeInitialization:
     def test_enter_safe_mode_command_exists(self):
         """Test that ENTER_SAFE_MODE command type exists."""
         assert hasattr(ACSCommandType, "ENTER_SAFE_MODE")
+
+    def test_acs_command_obstype_uses_obstype(self):
+        command = ACSCommand(
+            command_type=ACSCommandType.SLEW_TO_TARGET,
+            execution_time=1000.0,
+        )
+
+        assert command.obstype is ObsType.PPT
+
+    def test_acs_command_obstype_accepts_serialized_value(self):
+        command = ACSCommand(
+            command_type=ACSCommandType.SLEW_TO_TARGET,
+            execution_time=1000.0,
+            obstype="GSP",
+        )
+
+        assert command.obstype is ObsType.GSP
 
 
 class TestSafeModeRequest:

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -11,6 +11,7 @@ from conops import (
     Pass,
     PassTimes,
 )
+from conops.common.enums import ObsType
 from conops.config import AttitudeControlSystem, BandCapability, GroundStation
 from conops.simulation.passes import pass_slew_trigger_buffer
 
@@ -35,6 +36,22 @@ class TestPassInitialization:
         assert p.begin == base_begin
         assert p.length == 480.0
         assert p.obsid == 0xFFFF
+        assert p.obstype is ObsType.GSP
+
+    def test_pass_obstype_accepts_serialized_value(
+        self, mock_config, mock_acs_config, base_begin
+    ):
+        mock_config.spacecraft_bus.attitude_control = mock_acs_config
+        p = Pass(
+            config=mock_config,
+            ephem=None,
+            station="SGS",
+            begin=base_begin,
+            length=480.0,
+            obstype="GSP",
+        )
+
+        assert p.obstype is ObsType.GSP
 
     def test_pass_creation_full(
         self,

--- a/tests/plan_entry/test_plan_entry.py
+++ b/tests/plan_entry/test_plan_entry.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from conops import PlanEntry
+from conops.common.enums import ObsType
 
 
 class MockSAA:
@@ -56,7 +57,7 @@ class TestPlanEntryInit:
         assert pe.obsid == 0
         assert pe.merit == 101
         assert pe.windows == []
-        assert pe.obstype == "PPT"
+        assert pe.obstype == ObsType.PPT
         assert pe.slewpath == ([], [])
         assert pe.slewdist == 0.0
 

--- a/tests/pointing/test_pointing.py
+++ b/tests/pointing/test_pointing.py
@@ -1,4 +1,5 @@
 from conops import Pointing
+from conops.common.enums import ObsType
 
 from .conftest import DummyConstraint
 
@@ -91,7 +92,7 @@ class TestPointing:
         assert pointing.constraint is constraint
 
     def test_obstype_at(self, pointing: Pointing) -> None:
-        assert pointing.obstype == "AT"
+        assert pointing.obstype == ObsType.AT
 
     def test_ra_zero(self, pointing: Pointing) -> None:
         assert pointing.ra == 0.0

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -2580,7 +2580,7 @@ class TestCheckAndManagePasses:
         assert command.command_type == ACSCommandType.SLEW_TO_TARGET
 
         # Verify the slew has GSP obstype marker
-        assert command.slew.obstype == "GSP"
+        assert command.slew.obstype == ObsType.GSP
 
         # Verify slew points to the pass start position
         assert command.slew.endra == pass_obj.gsstartra


### PR DESCRIPTION
Fixes #157.

Make internal obstype fields use ObsType instead of raw strings:
- Pass.obstype now defaults to ObsType.GSP
- ACSCommand.obstype now defaults to ObsType.PPT
- tests that asserted the old internal string contract now assert ObsType values

String values are still accepted at serialization/config boundaries through pydantic enum coercion.

Scope note: this PR intentionally does not mass-edit every test mock that assigns string obstypes. Those mocks still work because ObsType is a str enum, and changing all of them would be broad churn. The production/internal model fields are the contract this PR fixes.

Validation:
- pytest tests/passes/test_passes.py::TestPassInitialization tests/acs/test_acs_safe_mode.py::TestSafeModeInitialization tests/acs/test_acs.py::TestACSInitialization::test_acs_initialization tests/acs/test_acs.py::TestACSAttributes::test_obstype_attribute tests/plan_entry/test_plan_entry.py::TestPlanEntryInit::test_init_with_constraint_and_acs tests/pointing/test_pointing.py::TestPointing::test_obstype_at tests/scheduler_queue/test_queue_ditl.py::TestCheckAndManagePasses::test_check_and_manage_passes_slew_to_pass_has_gsp_obstype
- pre-commit run --all-files