### PR TITLE
fix: export executed GSP slew metadata

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -169,6 +169,7 @@ class QueueDITL(DITLMixin, DITLStats):
         # successful dispatch; None during a pass (spacecraft is occupied).
         self._ppt_unavailable: bool | None = None
         self._planned_gsp_keys: set[tuple[str, float, float]] = set()
+        self._gsp_slew_plan_entries: dict[Slew, PlanEntry] = {}
         self._synced_executed_slew_count = 0
 
     def get_acs_queue_status(self) -> dict[str, Any]:
@@ -1001,18 +1002,29 @@ class QueueDITL(DITLMixin, DITLStats):
             entry.end = int(slew.slewstart + slew.slewtime + entry.ss_max)
 
     @staticmethod
-    def _entry_matches_slew(entry: PlanEntry, slew: Slew) -> bool:
+    def _entry_matches_science_slew(entry: PlanEntry, slew: Slew) -> bool:
         return entry.obstype == ObsType.AT and entry.obsid == slew.obsid
 
+    def _sync_gsp_slew_metadata(self, slew: Slew) -> None:
+        entry = self._gsp_slew_plan_entries.get(slew)
+        if entry is not None:
+            entry.begin = int(slew.slewstart)
+            entry.slewtime = int(round(slew.slewtime))
+            entry.slewdist = float(slew.slewdist)
+
     def _sync_slew_metadata(self, slew: Slew) -> None:
+        if slew.obstype == ObsType.GSP:
+            self._sync_gsp_slew_metadata(slew)
+            return
+
         if slew.obstype != ObsType.PPT:
             return
 
-        if self.ppt is not None and self._entry_matches_slew(self.ppt, slew):
+        if self.ppt is not None and self._entry_matches_science_slew(self.ppt, slew):
             self._apply_slew_metadata(self.ppt, slew, update_end=True)
 
         for entry in reversed(list(self.plan)):
-            if self._entry_matches_slew(entry, slew):
+            if self._entry_matches_science_slew(entry, slew):
                 update_end = entry.end >= entry.begin + 86400
                 self._apply_slew_metadata(entry, slew, update_end=update_end)
                 return
@@ -1215,7 +1227,9 @@ class QueueDITL(DITLMixin, DITLStats):
 
         return True
 
-    def _record_gsp_plan_entry(self, gspass: Pass, reserved_begin: float) -> bool:
+    def _record_gsp_plan_entry(
+        self, gspass: Pass, reserved_begin: float, slew: Slew | None = None
+    ) -> bool:
         """Record an accepted ground-station pass command in the exported plan."""
         key = self._ground_pass_key(gspass)
         if key in self._planned_gsp_keys:
@@ -1236,13 +1250,17 @@ class QueueDITL(DITLMixin, DITLStats):
         entry.dec = gspass.gsstartdec
         entry.begin = reserved_begin
         entry.end = pass_end
-        entry.slewtime = max(0, int(round(pass_begin - reserved_begin)))
+        entry.slewtime = (
+            int(round(slew.slewtime))
+            if slew is not None
+            else max(0, int(round(pass_begin - reserved_begin)))
+        )
+        if slew is not None:
+            entry.slewdist = float(slew.slewdist)
         entry.obsid = gspass.obsid
         entry.obstype = ObsType.GSP
         entry.ss_min = 0
-        contact_duration = max(
-            0, int(round(pass_end - reserved_begin - entry.slewtime))
-        )
+        contact_duration = max(0, int(round(pass_end - max(pass_begin, entry.begin))))
         entry.ss_max = contact_duration
         entry.exptime = contact_duration
         entry.station = station
@@ -1254,6 +1272,8 @@ class QueueDITL(DITLMixin, DITLStats):
         entry.track_end_dec = gspass.gsenddec
 
         self.plan.append(entry)
+        if slew is not None:
+            self._gsp_slew_plan_entries[slew] = entry
         self._planned_gsp_keys.add(key)
         self.log.log_event(
             utime=reserved_begin,
@@ -1364,18 +1384,20 @@ class QueueDITL(DITLMixin, DITLStats):
             slew.startra = ra
             slew.startdec = dec
             slew.startroll = roll
+            slew.slewstart = utime
             slew.endra = next_pass.gsstartra
             slew.enddec = next_pass.gsstartdec
             slew.endroll = GSP_TRACK_ROLL
             slew.obstype = ObsType.GSP  # Ground Station Pass slew
             slew.obsid = next_pass.obsid
+            slew.calc_slewtime()
             command = ACSCommand(
                 command_type=ACSCommandType.SLEW_TO_TARGET,
                 execution_time=utime,
                 slew=slew,
             )
             self.acs.enqueue_command(command)
-            self._record_gsp_plan_entry(next_pass, reserved_begin=utime)
+            self._record_gsp_plan_entry(next_pass, reserved_begin=utime, slew=slew)
             return True
 
         return False

--- a/conops/targets/plan_entry.py
+++ b/conops/targets/plan_entry.py
@@ -98,6 +98,13 @@ class PlanEntry:
 
     @property
     def exposure(self) -> int:  # (),excludesaa=False):
+        if (
+            self.obstype == ObsType.GSP
+            and self.contact_begin is not None
+            and self.contact_end is not None
+        ):
+            contact_start = max(float(self.contact_begin), float(self.begin))
+            return max(0, int(self.contact_end - contact_start))
         self.insaa = 0
         exposure = self.end - self.begin - self.slewtime - self.insaa
         return max(0, int(exposure))  # always an integer number of seconds

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -80,6 +80,13 @@ class PlanEntrySchema(BaseModel):
 
     @staticmethod
     def _computed_exposure(entry: PlanEntry) -> int:
+        if (
+            entry.obstype == ObsType.GSP
+            and entry.contact_begin is not None
+            and entry.contact_end is not None
+        ):
+            contact_start = max(float(entry.contact_begin), float(entry.begin))
+            return max(0, int(entry.contact_end - contact_start))
         exposure = entry.end - entry.begin - entry.slewtime - entry.insaa
         return max(0, int(exposure))
 

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from conops.common.enums import ObsType
 from conops.targets import PlanEntrySchema, PlanSchema
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -367,3 +368,29 @@ class TestPlanSchema:
         schema.save(dest)
         raw = json.loads(dest.read_text())
         assert raw["entries"][0]["exposure"] == 0
+
+    def test_from_plan_computes_exposure_without_mutating_entry(self) -> None:
+        """Serialising a plan should not modify the source PlanEntry."""
+        from conops.targets.plan import Plan
+        from conops.targets.plan_entry import PlanEntry
+
+        config = Mock()
+        config.constraint = Mock()
+        config.constraint.ephem = Mock()
+        config.spacecraft_bus = Mock()
+        config.spacecraft_bus.attitude_control = Mock()
+
+        entry = PlanEntry(config=config)
+        entry.obstype = ObsType.AT
+        entry.begin = 1000.0
+        entry.end = 1200.0
+        entry.slewtime = 50
+        entry.insaa = 30
+
+        plan = Plan()
+        plan.append(entry)
+
+        schema = PlanSchema.from_plan(plan)
+
+        assert schema.entries[0].exposure == 120
+        assert entry.insaa == 30

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -2605,7 +2605,7 @@ class TestCheckAndManagePasses:
 
         pass_obj = Pass(
             station="GS_TEST",
-            begin=1100.0,
+            begin=1200.0,
             length=600.0,
             gsstartra=100.0,
             gsstartdec=50.0,
@@ -2649,7 +2649,7 @@ class TestCheckAndManagePasses:
 
         pass_obj = Pass(
             station="GS_TEST",
-            begin=1100.0,
+            begin=1200.0,
             length=600.0,
             gsstartra=100.0,
             gsstartdec=50.0,
@@ -2674,9 +2674,14 @@ class TestCheckAndManagePasses:
         ]
         assert len(gsp_entries) == 1
         entry = gsp_entries[0]
+        command = queue_ditl.acs.enqueue_command.call_args[0][0]
         assert entry.name == "GS_TEST_PASS"
         assert entry.begin == utime
         assert entry.slewtime == 100
+        assert command.slew.slewdist == pytest.approx(entry.slewdist)
+        assert command.slew.slewtime == pytest.approx(entry.slewtime)
+        assert entry.slewdist > 0
+        assert entry.contact_begin - entry.begin - entry.slewtime == 100
         assert entry.end == pass_obj.end
         assert entry.exposure == 600
         assert entry.exptime == 600
@@ -2693,6 +2698,9 @@ class TestCheckAndManagePasses:
 
         schema = PlanSchema.from_plan(queue_ditl.plan)
         assert schema.entries[0].obstype == ObsType.GSP
+        assert schema.entries[0].slewtime == entry.slewtime
+        assert schema.entries[0].slewdist == pytest.approx(entry.slewdist)
+        assert schema.entries[0].exposure == 600
         assert schema.entries[0].station == "GS_TEST"
         assert schema.entries[0].contact_begin == pass_obj.begin
         assert schema.entries[0].track_start_ra == pytest.approx(pass_obj.gsstartra)
@@ -2738,6 +2746,43 @@ class TestCheckAndManagePasses:
             entry for entry in queue_ditl.plan if entry.obstype == ObsType.GSP
         ]
         assert len(gsp_entries) == 1
+
+    def test_executed_gsp_slew_updates_exported_slew_metadata(self, queue_ditl) -> None:
+        """GSP plan slew metadata should follow the ACS-executed slew."""
+        pass_obj = Pass(
+            station="GS_TEST",
+            begin=1100.0,
+            length=600.0,
+            gsstartra=100.0,
+            gsstartdec=50.0,
+            obsid=4242,
+        )
+        pass_obj.utime = [pass_obj.begin, pass_obj.end - 60.0]
+        pass_obj.ra = [pass_obj.gsstartra, pass_obj.gsendra]
+        pass_obj.dec = [pass_obj.gsstartdec, pass_obj.gsenddec]
+        queue_ditl.acs.passrequests.current_pass = Mock(return_value=None)
+        queue_ditl.acs.passrequests.next_pass = Mock(return_value=pass_obj)
+        queue_ditl.acs.acsmode = ACSMode.SCIENCE
+
+        with patch.object(Pass, "time_to_slew", return_value=True):
+            queue_ditl._check_and_manage_passes(1000.0, 10.0, 20.0)
+
+        entry = next(entry for entry in queue_ditl.plan if entry.obstype == ObsType.GSP)
+        command = queue_ditl.acs.enqueue_command.call_args[0][0]
+        executed_begin = entry.begin + 10.0
+        executed_duration = entry.slewtime + 7.0
+        executed_distance = entry.slewdist + 5.0
+        command.slew.slewstart = executed_begin
+        command.slew.slewtime = executed_duration
+        command.slew.slewdist = executed_distance
+        queue_ditl.acs.executed_commands = [command]
+
+        queue_ditl._sync_acs_slew_metadata()
+
+        assert entry.begin == int(executed_begin)
+        assert entry.slewtime == int(round(executed_duration))
+        assert entry.slewdist == pytest.approx(executed_distance)
+        assert entry.exposure == 600
 
     def test_check_and_manage_passes_safe_mode_does_not_export_gsp(
         self, queue_ditl
@@ -2898,6 +2943,7 @@ class TestCheckAndManagePasses:
         assert entry.name == "GS_ACTIVE_PASS"
         assert entry.begin == utime
         assert entry.slewtime == 0
+        assert entry.slewdist == 0.0
         assert entry.end == pass_obj.end
         assert entry.exposure == 550
         assert entry.exptime == 550


### PR DESCRIPTION
Fixes #159.

GSP plan entries were exporting the reserved pre-contact window as slewtime and leaving slewdist at 0.0. That made downstream plan stats and visualization show contacts as zero-distance maneuvers and could label pre-contact buffer as slew.

This changes GSP export so:
- the queued GSP entry gets physical slewtime/slewdist from the pre-pass slew command
- after ACS executes and recomputes the maneuver from current attitude, the GSP plan entry is synced to the executed slew start, slewtime, and slewdist
- GSP exposure/contact duration stays tied to the contact window, not to the activity window minus slewtime

The slew distance is the maneuver to the ground-station pass start pointing. It is not the angular distance swept while tracking during the contact.

Validation:
- pytest tests/scheduler_queue/test_queue_ditl.py::TestCheckAndManagePasses tests/scheduler_queue/test_queue_ditl.py::TestFetchNewPPT tests/plan/test_plan_schema.py tests/plan_entry/test_plan_entry.py
- ruff check conops/ditl/queue_ditl.py conops/targets/plan_entry.py conops/targets/plan_schema.py tests/scheduler_queue/test_queue_ditl.py
- pre-commit run --all-files