### PR TITLE
feat: Export linked attitude timeseries with plans

### DIFF
--- a/conops/__init__.py
+++ b/conops/__init__.py
@@ -65,6 +65,8 @@ from .simulation import (
     optimum_roll_sidemount,
 )
 from .targets import (
+    AttitudeSampleSchema,
+    AttitudeTimeseriesSchema,
     Plan,
     PlanEntry,
     Pointing,
@@ -86,6 +88,8 @@ __all__ = [
     "ACSCommand",
     "ACSCommandType",
     "ACSMode",
+    "AttitudeSampleSchema",
+    "AttitudeTimeseriesSchema",
     "AttitudeControlSystem",
     "Battery",
     "ChargeState",

--- a/conops/ditl/ditl.py
+++ b/conops/ditl/ditl.py
@@ -341,6 +341,7 @@ class DITL(DITLMixin, DITLStats):
                 )
                 self.telemetry.data.append(pd)
 
+        self._attach_attitude_timeseries_to_plan()
         return True
 
     def _compute_sun_angle(self, utime: float, ra: float, dec: float) -> float | None:

--- a/conops/ditl/ditl_mixin.py
+++ b/conops/ditl/ditl_mixin.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import matplotlib.pyplot as plt
 import rust_ephem
@@ -136,6 +136,45 @@ class DITLMixin:
         self.spacecraft_bus = self.config.spacecraft_bus
         self.payload = self.config.payload
         self.recorder = self.config.recorder
+
+    @staticmethod
+    def _attitude_mode_name(mode: ACSMode | int | None) -> str | None:
+        if mode is None:
+            return None
+        if isinstance(mode, ACSMode):
+            return mode.name
+        try:
+            return ACSMode(int(mode)).name
+        except (TypeError, ValueError):
+            return str(mode)
+
+    def _attach_attitude_timeseries_to_plan(self) -> None:
+        """Attach the executed attitude timeline to the current plan for export."""
+        from ..targets import AttitudeSampleSchema, AttitudeTimeseriesSchema
+
+        samples = []
+        for hk in self.telemetry.housekeeping:
+            if hk.timestamp.tzinfo is None:
+                timestamp = hk.timestamp.replace(tzinfo=timezone.utc)
+            else:
+                timestamp = hk.timestamp.astimezone(timezone.utc)
+            samples.append(
+                AttitudeSampleSchema(
+                    utime=timestamp.timestamp(),
+                    timestamp=timestamp.isoformat(),
+                    ra=hk.ra,
+                    dec=hk.dec,
+                    roll=hk.roll,
+                    mode=self._attitude_mode_name(hk.acs_mode),
+                    obsid=hk.obsid,
+                    quat_w=hk.quat_w,
+                    quat_x=hk.quat_x,
+                    quat_y=hk.quat_y,
+                    quat_z=hk.quat_z,
+                )
+            )
+
+        self.plan.attitude_timeseries = AttitudeTimeseriesSchema(samples=samples)
 
     def plot(self) -> None:
         """Plot DITL timeline.

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -477,6 +477,7 @@ class QueueDITL(DITLMixin, DITLStats):
             self._close_last_plan_entry(utime)
 
         self._assert_plan_matches_execution()
+        self._attach_attitude_timeseries_to_plan()
 
         return True
 

--- a/conops/targets/__init__.py
+++ b/conops/targets/__init__.py
@@ -1,6 +1,11 @@
 from .plan import Plan, TargetList
 from .plan_entry import PlanEntry
-from .plan_schema import PlanEntrySchema, PlanSchema
+from .plan_schema import (
+    AttitudeSampleSchema,
+    AttitudeTimeseriesSchema,
+    PlanEntrySchema,
+    PlanSchema,
+)
 from .pointing import Pointing
 from .target_queue import Queue, TargetQueue
 
@@ -8,6 +13,8 @@ __all__ = [
     "PlanEntry",
     "PlanEntrySchema",
     "PlanSchema",
+    "AttitudeSampleSchema",
+    "AttitudeTimeseriesSchema",
     "Pointing",
     "Plan",
     "TargetList",

--- a/conops/targets/plan.py
+++ b/conops/targets/plan.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from .plan_entry import PlanEntry
 
 if TYPE_CHECKING:
-    from .plan_schema import PlanSchema
+    from .plan_schema import AttitudeTimeseriesSchema, PlanSchema
 
 
 class TargetList:
@@ -38,6 +38,7 @@ class Plan:
 
     def __init__(self) -> None:
         self.entries = list()
+        self.attitude_timeseries: AttitudeTimeseriesSchema | None = None
 
     def __getitem__(self, number: int) -> PlanEntry:
         return self.entries[number]

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -142,6 +142,58 @@ class PlanEntrySchema(BaseModel):
         return data
 
 
+class AttitudeSampleSchema(BaseModel):
+    """A single executed spacecraft attitude sample for plan inspection."""
+
+    utime: float
+    timestamp: str
+    ra: float | None = None
+    dec: float | None = None
+    roll: float | None = None
+    mode: str | None = None
+    obsid: int | None = None
+    quat_w: float | None = None
+    quat_x: float | None = None
+    quat_y: float | None = None
+    quat_z: float | None = None
+
+
+class AttitudeTimeseriesSchema(BaseModel):
+    """Continuous executed spacecraft attitude timeline tied to a plan file."""
+
+    version: int = 0
+    coast_sim_version: str = Field(default_factory=lambda: __version__)
+    created_at: str = Field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    plan_file: str | None = None
+    plan_version: int | None = None
+    plan_start: float | None = None
+    plan_end: float | None = None
+    num_samples: int = 0
+    samples: list[AttitudeSampleSchema] = Field(default_factory=list)
+
+    @field_validator("plan_start", "plan_end", mode="before")
+    @classmethod
+    def _coerce_optional_time(cls, v: Any) -> float | None:
+        if v is None:
+            return None
+        if isinstance(v, str):
+            return datetime.fromisoformat(v).timestamp()
+        return float(v)
+
+    @field_serializer("plan_start", "plan_end")
+    def _serialize_optional_time(self, v: float | None) -> str | None:
+        if v is None:
+            return None
+        return datetime.fromtimestamp(v, tz=timezone.utc).isoformat()
+
+    @model_validator(mode="after")
+    def _reconcile_metadata(self) -> AttitudeTimeseriesSchema:
+        self.num_samples = len(self.samples)
+        return self
+
+
 class PlanSchema(BaseModel):
     """Top-level schema for a serialised :class:`~conops.targets.Plan`.
 
@@ -167,6 +219,9 @@ class PlanSchema(BaseModel):
         Total number of plan entries.
     entries:
         The serialised plan entries.
+    attitude_timeseries_file:
+        Optional sibling JSON file containing the executed attitude samples
+        associated with this exact plan export.
     """
 
     model_config = ConfigDict(from_attributes=True)
@@ -179,7 +234,11 @@ class PlanSchema(BaseModel):
     start: float = 0.0
     end: float = 0.0
     num_entries: int = 0
+    attitude_timeseries_file: str | None = None
     entries: list[PlanEntrySchema] = Field(default_factory=list)
+    attitude_timeseries: AttitudeTimeseriesSchema | None = Field(
+        default=None, exclude=True
+    )
 
     @field_validator("start", "end", mode="before")
     @classmethod
@@ -221,6 +280,7 @@ class PlanSchema(BaseModel):
                 "end": entries[-1].end if entries else 0.0,
                 "num_entries": len(entries),
                 "entries": entries,
+                "attitude_timeseries": getattr(data, "attitude_timeseries", None),
             }
         return data
 
@@ -292,6 +352,10 @@ class PlanSchema(BaseModel):
         ]
         return max(versions) + 1 if versions else 0
 
+    @staticmethod
+    def _attitude_timeseries_path(plan_path: Path) -> Path:
+        return plan_path.with_name(f"{plan_path.stem}_attitude_timeseries.json")
+
     def save(self, path: str | Path, *, indent: int = 2) -> Path:
         """Serialise the plan to a JSON file.
 
@@ -321,8 +385,31 @@ class PlanSchema(BaseModel):
         else:
             schema = self
             dest.parent.mkdir(parents=True, exist_ok=True)
+
+        attitude_timeseries = schema.attitude_timeseries
+        if attitude_timeseries is not None:
+            attitude_path = self._attitude_timeseries_path(dest)
+            schema = schema.model_copy(
+                update={"attitude_timeseries_file": attitude_path.name}
+            )
+            attitude_timeseries = attitude_timeseries.model_copy(
+                update={
+                    "plan_file": dest.name,
+                    "plan_version": schema.version,
+                    "plan_start": schema.start,
+                    "plan_end": schema.end,
+                }
+            )
+            attitude_payload = attitude_timeseries.model_dump(
+                mode="json", exclude_none=True
+            )
+            attitude_path.write_text(
+                json.dumps(attitude_payload, indent=indent), encoding="utf-8"
+            )
+
         payload = schema.model_dump(mode="json", exclude_none=True)
         dest.write_text(json.dumps(payload, indent=indent), encoding="utf-8")
+
         return dest.resolve()
 
     @classmethod

--- a/tests/plan/test_plan.py
+++ b/tests/plan/test_plan.py
@@ -8,6 +8,7 @@ import pytest
 
 from conops import Plan, PlanEntry
 from conops.common.enums import ObsType
+from conops.targets import AttitudeSampleSchema, AttitudeTimeseriesSchema
 
 
 def _make_plan_entry(obsid: int, begin: float, end: float) -> PlanEntry:
@@ -219,6 +220,33 @@ class TestPlanSaveLoad:
         assert "end" in raw
         assert raw["num_entries"] == 2
         assert len(raw["entries"]) == 2
+
+    def test_save_writes_attitude_timeseries_companion(self, tmp_path):
+        """Plan.save() writes the attached executed-attitude companion file."""
+        plan = _make_plan(1)
+        plan.attitude_timeseries = AttitudeTimeseriesSchema(
+            samples=[
+                AttitudeSampleSchema(
+                    utime=1_000_000.0,
+                    timestamp="1970-01-12T13:46:40+00:00",
+                    ra=11.0,
+                    dec=-19.0,
+                    roll=0.0,
+                    mode="SCIENCE",
+                    obsid=0,
+                )
+            ]
+        )
+        dest = tmp_path / "plan.json"
+
+        plan.save(dest)
+
+        raw = json.loads(dest.read_text())
+        attitude_path = tmp_path / raw["attitude_timeseries_file"]
+        assert attitude_path.exists()
+        attitude_raw = json.loads(attitude_path.read_text())
+        assert attitude_raw["plan_file"] == "plan.json"
+        assert attitude_raw["samples"][0]["obsid"] == 0
 
     def test_save_times_are_iso_strings(self, tmp_path):
         """start, end, and entry begin/end are serialised as ISO-8601 strings."""

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -7,7 +7,12 @@ from unittest.mock import Mock
 import pytest
 
 from conops.common.enums import ObsType
-from conops.targets import PlanEntrySchema, PlanSchema
+from conops.targets import (
+    AttitudeSampleSchema,
+    AttitudeTimeseriesSchema,
+    PlanEntrySchema,
+    PlanSchema,
+)
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -204,6 +209,42 @@ class TestPlanSchema:
         assert "T" in raw["start"]  # sanity-check ISO format
         assert isinstance(raw["entries"], list)
         assert len(raw["entries"]) == 1
+
+    def test_save_writes_linked_attitude_timeseries(self, tmp_path):
+        schema = _make_schema(1)
+        schema.attitude_timeseries = AttitudeTimeseriesSchema(
+            samples=[
+                AttitudeSampleSchema(
+                    utime=1_000_000.0,
+                    timestamp="1970-01-12T13:46:40+00:00",
+                    ra=12.0,
+                    dec=-4.0,
+                    roll=30.0,
+                    mode="SCIENCE",
+                    obsid=99,
+                    quat_w=1.0,
+                    quat_x=0.0,
+                    quat_y=0.0,
+                    quat_z=0.0,
+                )
+            ]
+        )
+        dest = tmp_path / "plan.json"
+
+        schema.save(dest)
+
+        raw = json.loads(dest.read_text())
+        assert raw["attitude_timeseries_file"] == "plan_attitude_timeseries.json"
+        assert "attitude_timeseries" not in raw
+
+        attitude_path = tmp_path / raw["attitude_timeseries_file"]
+        attitude_raw = json.loads(attitude_path.read_text())
+        assert attitude_raw["plan_file"] == "plan.json"
+        assert attitude_raw["plan_version"] == raw["version"]
+        assert attitude_raw["plan_start"] == raw["start"]
+        assert attitude_raw["plan_end"] == raw["end"]
+        assert attitude_raw["num_samples"] == 1
+        assert attitude_raw["samples"][0]["mode"] == "SCIENCE"
 
     def test_entry_fields_in_json(self, tmp_path):
         schema = _make_schema(1)

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -1,6 +1,7 @@
 """Unit tests for QueueDITL class."""
 
-from datetime import datetime
+import json
+from datetime import datetime, timezone
 from typing import cast
 from unittest.mock import Mock, patch
 
@@ -35,6 +36,39 @@ class TestQueueDITLInitialization:
             ditl = QueueDITL(config=mock_config)
             assert ditl.ppt is None
             assert ditl.charging_ppt is None
+
+    def test_attach_attitude_timeseries_to_plan(
+        self, queue_ditl: QueueDITL, tmp_path
+    ) -> None:
+        queue_ditl.telemetry.housekeeping.append(
+            Housekeeping(
+                timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                ra=12.0,
+                dec=-4.0,
+                roll=30.0,
+                acs_mode=ACSMode.SLEWING,
+                obsid=4242,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            )
+        )
+
+        queue_ditl._attach_attitude_timeseries_to_plan()
+
+        attitude = queue_ditl.plan.attitude_timeseries
+        assert attitude is not None
+        assert attitude.num_samples == 1
+        sample = attitude.samples[0]
+        assert sample.mode == "SLEWING"
+        assert sample.obsid == 4242
+        assert sample.ra == pytest.approx(12.0)
+
+        plan_path = queue_ditl.plan.save(tmp_path / "plan.json")
+        raw = json.loads(plan_path.read_text())
+        assert raw["attitude_timeseries_file"] == "plan_attitude_timeseries.json"
+        assert (tmp_path / "plan_attitude_timeseries.json").exists()
 
     def test_initialization_pointing_lists_empty(
         self, mock_config: MissionConfig


### PR DESCRIPTION
Adds a companion executed-attitude export for generated plan JSON files.

What changes:
- DITL and QueueDITL attach the executed attitude timeline to their Plan after simulation.
- Plan/PlanSchema save writes a sibling *_attitude_timeseries.json file when attitude samples are present.
- The plan JSON includes attitude_timeseries_file, and the companion file points back to the exact plan filename, version, and plan window.
- The companion samples include utime, timestamp, RA, Dec, roll, mode, obsid, and attitude quaternion components.

This keeps dense trajectory data out of the operational plan JSON while making inspection and verification artifacts available alongside every DITL-generated plan save.

Dependency / merge-order note:
This PR is the export layer only.
With #153, #154, #155, #156, and this PR applied together, the representative Tamalpais generation passes with zero plan/execution mismatches and writes both plan.json and plan_attitude_timeseries.json.

Validation:
- pytest tests/plan/test_plan_schema.py tests/plan/test_plan.py tests/scheduler_queue/test_queue_ditl.py::TestQueueDITLInitialization
- pre-commit run --all-files
- Local combined-PR Tamalpais check with #153/#154/#155/#156/#161: calc_ok=True, mismatches_after_calc=0, linked plan + attitude timeseries written to /tmp/tamalpais_attitude_export_combined_prs