### PR TITLE
refactor: clean up plan_schema.py

### DIFF
--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -30,6 +30,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    computed_field,
     field_serializer,
     field_validator,
     model_validator,
@@ -170,8 +171,12 @@ class AttitudeTimeseriesSchema(BaseModel):
     plan_version: int | None = None
     plan_start: float | None = None
     plan_end: float | None = None
-    num_samples: int = 0
     samples: list[AttitudeSampleSchema] = Field(default_factory=list)
+
+    @computed_field  # type:ignore[prop-decorator]
+    @property
+    def num_samples(self) -> int:
+        return len(self.samples)
 
     @field_validator("plan_start", "plan_end", mode="before")
     @classmethod
@@ -187,11 +192,6 @@ class AttitudeTimeseriesSchema(BaseModel):
         if v is None:
             return None
         return datetime.fromtimestamp(v, tz=timezone.utc).isoformat()
-
-    @model_validator(mode="after")
-    def _reconcile_metadata(self) -> AttitudeTimeseriesSchema:
-        self.num_samples = len(self.samples)
-        return self
 
 
 class PlanSchema(BaseModel):
@@ -233,12 +233,16 @@ class PlanSchema(BaseModel):
     )
     start: float = 0.0
     end: float = 0.0
-    num_entries: int = 0
     attitude_timeseries_file: str | None = None
     entries: list[PlanEntrySchema] = Field(default_factory=list)
     attitude_timeseries: AttitudeTimeseriesSchema | None = Field(
         default=None, exclude=True
     )
+
+    @computed_field  # type:ignore[prop-decorator]
+    @property
+    def num_entries(self) -> int:
+        return len(self.entries)
 
     @field_validator("start", "end", mode="before")
     @classmethod
@@ -285,21 +289,13 @@ class PlanSchema(BaseModel):
         return data
 
     @model_validator(mode="after")
-    def _reconcile_metadata(self) -> PlanSchema:
-        """Keep num_entries, start, and end consistent with the entries list.
-
-        This corrects metadata that may be missing or stale in legacy JSON
-        files (e.g. files written before ``num_entries`` / ``start`` / ``end``
-        were stored, or files whose entry list was modified after creation).
-        """
-        self.num_entries = len(self.entries)
+    def _correct_legacy_bounds(self) -> PlanSchema:
+        """Fill start/end from entries when absent in legacy JSON files."""
         if self.entries:
-            computed_start = self.entries[0].begin
-            computed_end = self.entries[-1].end
             if self.start == 0.0:
-                self.start = computed_start
+                self.start = self.entries[0].begin
             if self.end == 0.0:
-                self.end = computed_end
+                self.end = self.entries[-1].end
         return self
 
     # ── Convenience constructors ───────────────────────────────────────────────


### PR DESCRIPTION
This pull request refactors the way metadata fields are handled in the `AttitudeTimeseriesSchema` and `PlanSchema` classes to improve data consistency and reduce manual bookkeeping. The main change is to compute `num_samples` and `num_entries` dynamically from their respective lists, rather than storing and updating them manually. Additionally, the logic for correcting legacy metadata has been simplified.

Key changes:

**Dynamic Computed Fields:**
* Replaced the stored `num_samples` and `num_entries` integer fields in `AttitudeTimeseriesSchema` and `PlanSchema` with computed properties that automatically return the length of the `samples` and `entries` lists, respectively. This ensures that these counts are always accurate and up to date. [[1]](diffhunk://#diff-30eec4d8aaeb66d37ed45dcaa0a464c60de689b76175daba86445f1fb503749bL173-R180) [[2]](diffhunk://#diff-30eec4d8aaeb66d37ed45dcaa0a464c60de689b76175daba86445f1fb503749bL236-R246)

**Simplified Legacy Metadata Correction:**
* Removed the model validators that previously reconciled metadata fields like `num_samples` and `num_entries` after model creation. The new approach only updates `start` and `end` fields if they are missing (i.e., set to `0.0`), using the first and last entry times, making the logic simpler and more robust for legacy JSON file support. [[1]](diffhunk://#diff-30eec4d8aaeb66d37ed45dcaa0a464c60de689b76175daba86445f1fb503749bL191-L195) [[2]](diffhunk://#diff-30eec4d8aaeb66d37ed45dcaa0a464c60de689b76175daba86445f1fb503749bL288-R298)

**Imports:**
* Added import for `computed_field` to support the new computed property decorators.