### PR TITLE
fix: make plan scheduling deterministic

### DIFF
--- a/conops/config/config.py
+++ b/conops/config/config.py
@@ -26,6 +26,10 @@ class MissionConfig(ConfigModel):
     """
 
     name: str = Field(default="Default Config", description="Mission name/identifier")
+    random_seed: int | None = Field(
+        default=None,
+        description="Optional seed for stochastic planning decisions.",
+    )
     spacecraft_bus: SpacecraftBus = Field(
         default_factory=SpacecraftBus,
         description="Spacecraft Bus Configuration. Defines the main spacecraft platform including power, attitude control, and communications",

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -1,4 +1,6 @@
 import time
+from numbers import Integral
+from typing import Protocol
 
 import numpy as np
 import rust_ephem
@@ -18,6 +20,17 @@ GSP_TRACK_ROLL = 0.0
 def pass_slew_trigger_buffer(step_size: float) -> float:
     """Return how early pass handling can trigger a slew, in seconds."""
     return max(0.0, 2.0 * float(step_size))
+
+
+def _config_random_seed(config: MissionConfig) -> int | None:
+    seed = getattr(config, "random_seed", None)
+    if seed is None or isinstance(seed, bool) or not isinstance(seed, Integral):
+        return None
+    return int(seed)
+
+
+class RandomSource(Protocol):
+    def random(self) -> float: ...
 
 
 class Pass(BaseModel):
@@ -302,6 +315,7 @@ class PassTimes:
     def __init__(
         self,
         config: MissionConfig,
+        rng: RandomSource | None = None,
     ):
         self.constraint = config.constraint
         assert self.constraint is not None, "Constraint must be set for PassTimes class"
@@ -311,6 +325,11 @@ class PassTimes:
         self.ephem = self.constraint.ephem
 
         self.config = config
+        self.rng = (
+            rng
+            if rng is not None
+            else np.random.default_rng(_config_random_seed(config))
+        )
         self.passes = []
         self.dropped_overlapping_passes: list[tuple[Pass, Pass]] = []
         self.length = 1
@@ -325,6 +344,9 @@ class PassTimes:
         self.minelev = 10.0
         self.minlen = 8 * 60  # 10 mins
         self.schedule_chance = 1.0  # base chance of getting a pass
+
+    def _random(self) -> float:
+        return float(self.rng.random())
 
     def __getitem__(self, number: int) -> Pass:
         return self.passes[number]
@@ -351,7 +373,9 @@ class PassTimes:
         sched = list()
         last = 0.0
         for gspass in self.passes:
-            if gspass.begin - last > mean_between and np.random.random() < gsprob:
+            if gspass.begin - last <= mean_between:
+                continue
+            if gsprob >= 1.0 or (gsprob > 0.0 and self._random() < gsprob):
                 sched.extend([gspass])
                 last = sched[-1].begin
         return sched
@@ -495,8 +519,10 @@ class PassTimes:
                     combined_prob = self.schedule_chance * getattr(
                         station, "schedule_probability", 1.0
                     )
-                    rand_val = np.random.random()
-                    if rand_val <= combined_prob:
+                    should_schedule = combined_prob >= 1.0 or (
+                        combined_prob > 0.0 and self._random() <= combined_prob
+                    )
+                    if should_schedule:
                         # Schedule this pass if the dice roll allows it
                         gspass = Pass(
                             config=self.config,

--- a/conops/targets/target_queue.py
+++ b/conops/targets/target_queue.py
@@ -112,11 +112,8 @@ class TargetQueue:
                 target.merit = -900
                 continue
 
-        # Add randomness to break ties
-        for target in self.targets:
-            target.merit += np.random.random()
-
-        # Sort by merit (highest first)
+        # Sort by merit (highest first). Python's sort is stable, so equal-merit
+        # targets keep the checked-in queue order instead of using random noise.
         self.targets.sort(key=lambda x: x.merit, reverse=True)
 
     def get(

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -483,29 +483,43 @@ class TestPassTimes:
 
     def test_request_passes(self, mock_constraint, mock_config):
         """Test request_passes returns passes at requested rate."""
-        pt = PassTimes(config=mock_config)
+        pt = PassTimes(config=mock_config, rng=Mock(random=Mock(return_value=0.5)))
         # Create passes every ~4 hours
         for i in range(6):
             p = Mock()
             p.begin = i * 14400.0  # Every 4 hours
             pt.passes.append(p)
 
-        with patch("numpy.random.random", return_value=0.5):
-            scheduled = pt.request_passes(req_gsnum=6, gsprob=0.9)
-            assert len(scheduled) > 0
+        scheduled = pt.request_passes(req_gsnum=6, gsprob=0.9)
+        assert len(scheduled) > 0
 
     def test_request_passes_probability(self, mock_constraint, mock_config):
         """Test request_passes respects probability."""
-        pt = PassTimes(config=mock_config)
+        pt = PassTimes(config=mock_config, rng=Mock(random=Mock(return_value=0.95)))
         for i in range(10):
             p = Mock()
             p.begin = i * 20000.0
             pt.passes.append(p)
 
         # All random values > 0.9, should not schedule any
-        with patch("numpy.random.random", return_value=0.95):
-            scheduled = pt.request_passes(req_gsnum=10, gsprob=0.9)
-            assert len(scheduled) == 0
+        scheduled = pt.request_passes(req_gsnum=10, gsprob=0.9)
+        assert len(scheduled) == 0
+
+    def test_request_passes_seeded_rng_is_repeatable(
+        self, mock_constraint, mock_config
+    ):
+        """A configured seed should make probability-based pass requests repeatable."""
+        mock_config.random_seed = 42
+
+        def scheduled_begins() -> list[float]:
+            pt = PassTimes(config=mock_config)
+            for i in range(10):
+                p = Mock()
+                p.begin = i * 20000.0
+                pt.passes.append(p)
+            return [p.begin for p in pt.request_passes(req_gsnum=10, gsprob=0.5)]
+
+        assert scheduled_begins() == scheduled_begins()
 
     def test_deconflict_overlapping_passes_prefers_more_data_volume(
         self, mock_constraint, mock_config

--- a/tests/target_queue/test_target_queue.py
+++ b/tests/target_queue/test_target_queue.py
@@ -62,20 +62,16 @@ class TestQueueBasicOps:
 
 
 class TestMeritsort:
-    @patch("numpy.random.random", side_effect=[0.1, 0.2, 0.3, 0.4, 0.5])
-    def test_meritsort_invisible_target_merit(
-        self, mock_random, queue_instance
-    ) -> None:
-        """The invisible target should get -900 + random penalty as merit."""
+    def test_meritsort_invisible_target_merit(self, queue_instance) -> None:
+        """The invisible target should get the hidden-target merit."""
         invisible_target = queue_instance.targets[1]
         invisible_target.visible.return_value = False
 
         queue_instance.meritsort()
 
-        assert invisible_target.merit == -900 + 0.2
+        assert invisible_target.merit == -900
 
-    @patch("numpy.random.random", side_effect=[0.1, 0.2, 0.3, 0.4, 0.5])
-    def test_meritsort_sorted_descending(self, mock_random, queue_instance):
+    def test_meritsort_sorted_descending(self, queue_instance):
         """Check that the targets are sorted by merit descending."""
         queue_instance.meritsort()
         for i in range(len(queue_instance.targets) - 1):
@@ -83,8 +79,7 @@ class TestMeritsort:
                 queue_instance.targets[i].merit >= queue_instance.targets[i + 1].merit
             )
 
-    @patch("numpy.random.random", side_effect=[0.1, 0.2, 0.3, 0.4, 0.5])
-    def test_meritsort_invisible_target_last(self, mock_random, queue_instance):
+    def test_meritsort_invisible_target_last(self, queue_instance):
         """Invisible target should be last after sort (lowest merit)."""
         invisible_target = queue_instance.targets[1]
         invisible_target.visible.return_value = False
@@ -92,6 +87,16 @@ class TestMeritsort:
         queue_instance.meritsort()
 
         assert queue_instance.targets[-1] is invisible_target
+
+    def test_meritsort_keeps_equal_merit_order(self, queue_instance):
+        """Equal-merit targets should be deterministic."""
+        for target in queue_instance.targets:
+            target.fom = 100
+
+        expected = list(queue_instance.targets)
+        queue_instance.meritsort()
+
+        assert queue_instance.targets == expected
 
 
 class TestGetTarget:


### PR DESCRIPTION
Closes #163.

Identical inputs were not guaranteed to produce identical schedules because target merit ties and ground-station pass probabilities used process-global NumPy randomness.

This PR:

- removes random target merit tie-breaking; equal-merit targets now keep queue order
- adds `MissionConfig.random_seed`
- makes `PassTimes` use a seeded/injected RNG for probabilistic pass selection
- avoids consuming RNG when pass probability is 0 or 1
- adds tests for deterministic ordering and seeded pass requests

Validated:

- `pytest tests/target_queue/test_target_queue.py tests/passes/test_passes.py`