### PR TITLE
fix: prevent stale plan entry slew sync

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -676,6 +676,45 @@ class QueueDITL(DITLMixin, DITLStats):
             obsid=int(entry.obsid),
         )
 
+    def _validate_plan_entry_structure(self) -> list[PlanExecutionMismatch]:
+        mismatches: list[PlanExecutionMismatch] = []
+        previous_begin: float | None = None
+        for index, entry in enumerate(self.plan):
+            obstype = self._entry_obstype(entry)
+            if obstype is None or obstype == ObsType.PPT:
+                continue
+            begin = float(entry.begin)
+            end = float(entry.end)
+            obsid = int(entry.obsid) if entry.obsid is not None else None
+            if end < begin:
+                mismatches.append(
+                    self._execution_mismatch(
+                        begin,
+                        "plan",
+                        "invalid_interval",
+                        (
+                            f"entry {index} obsid {obsid} ends before it begins "
+                            f"({end:.0f} < {begin:.0f})"
+                        ),
+                        obsid=obsid,
+                    )
+                )
+            if previous_begin is not None and begin < previous_begin:
+                mismatches.append(
+                    self._execution_mismatch(
+                        begin,
+                        "plan",
+                        "non_monotonic_begin",
+                        (
+                            f"entry {index} obsid {obsid} begins before previous "
+                            f"entry ({begin:.0f} < {previous_begin:.0f})"
+                        ),
+                        obsid=obsid,
+                    )
+                )
+            previous_begin = begin
+        return mismatches
+
     def _validate_science_entry_execution(
         self, entry: PlanEntry, tolerance_deg: float
     ) -> list[PlanExecutionMismatch]:
@@ -816,7 +855,10 @@ class QueueDITL(DITLMixin, DITLStats):
             return [mismatch]
 
         tolerance_deg = self._plan_execution_tolerance_deg()
-        mismatches: list[PlanExecutionMismatch] = []
+        mismatches = self._validate_plan_entry_structure()
+        if mismatches:
+            return mismatches
+
         for entry in self.plan:
             obstype = self._entry_obstype(entry)
             if obstype in (ObsType.AT, ObsType.TOO):
@@ -1004,7 +1046,15 @@ class QueueDITL(DITLMixin, DITLStats):
 
     @staticmethod
     def _entry_matches_science_slew(entry: PlanEntry, slew: Slew) -> bool:
-        return entry.obstype == ObsType.AT and entry.obsid == slew.obsid
+        if entry.obstype != ObsType.AT or entry.obsid != slew.obsid:
+            return False
+
+        entry_begin = float(entry.begin)
+        entry_end = float(entry.end)
+        slew_start = float(slew.slewstart)
+        has_placeholder_end = entry_end >= entry_begin + 86400
+        matches_slew_start = abs(entry_begin - slew_start) <= 1e-6
+        return has_placeholder_end or matches_slew_start
 
     def _sync_gsp_slew_metadata(self, slew: Slew) -> None:
         entry = self._gsp_slew_plan_entries.get(slew)

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -18,7 +18,7 @@ from ..common import (
 )
 from ..common.enums import ACSCommandType
 from ..common.vector import attitude_to_quat
-from ..config import MissionConfig
+from ..config import DAY_SECONDS, MissionConfig
 from ..simulation.acs_command import ACSCommand
 from ..simulation.emergency_charging import EmergencyCharging
 from ..simulation.passes import GSP_TRACK_ROLL, Pass, pass_slew_trigger_buffer
@@ -686,15 +686,15 @@ class QueueDITL(DITLMixin, DITLStats):
             begin = float(entry.begin)
             end = float(entry.end)
             obsid = int(entry.obsid) if entry.obsid is not None else None
-            if end < begin:
+            if end <= begin:
                 mismatches.append(
                     self._execution_mismatch(
                         begin,
                         "plan",
                         "invalid_interval",
                         (
-                            f"entry {index} obsid {obsid} ends before it begins "
-                            f"({end:.0f} < {begin:.0f})"
+                            f"entry {index} obsid {obsid} ends at or before it begins "
+                            f"({end:.0f} <= {begin:.0f})"
                         ),
                         obsid=obsid,
                     )
@@ -1011,9 +1011,9 @@ class QueueDITL(DITLMixin, DITLStats):
             # Before adding new PPT, close the previous one if it has placeholder end time
             if len(self.plan) > 0:
                 last_entry = self.plan[-1]
-                # Check if end time looks like a placeholder (>= 86400 seconds from begin)
-                # Charging PPTs use exactly 86400, science obs use larger values
-                if last_entry.end >= last_entry.begin + 86400:
+                # Check if end time looks like a placeholder (>= one day from begin).
+                # Charging PPTs use exactly one day, science obs use larger values.
+                if last_entry.end >= last_entry.begin + DAY_SECONDS:
                     # Set end to the begin time of new PPT (no gap between entries)
                     self._close_last_plan_entry(self.ppt.begin)
 
@@ -1027,9 +1027,9 @@ class QueueDITL(DITLMixin, DITLStats):
         """
         if self.ppt is None and len(self.plan) > 0:
             last_entry = self.plan[-1]
-            # Check if end time looks like a placeholder (>= 86400 seconds from begin)
-            # Charging PPTs use exactly 86400, science obs use larger values
-            if last_entry.end >= last_entry.begin + 86400:
+            # Check if end time looks like a placeholder (>= one day from begin).
+            # Charging PPTs use exactly one day, science obs use larger values.
+            if last_entry.end >= last_entry.begin + DAY_SECONDS:
                 self._close_last_plan_entry(utime)
 
     @staticmethod
@@ -1052,7 +1052,7 @@ class QueueDITL(DITLMixin, DITLStats):
         entry_begin = float(entry.begin)
         entry_end = float(entry.end)
         slew_start = float(slew.slewstart)
-        has_placeholder_end = entry_end >= entry_begin + 86400
+        has_placeholder_end = entry_end >= entry_begin + DAY_SECONDS
         matches_slew_start = abs(entry_begin - slew_start) <= 1e-6
         return has_placeholder_end or matches_slew_start
 
@@ -1076,7 +1076,7 @@ class QueueDITL(DITLMixin, DITLStats):
 
         for entry in reversed(list(self.plan)):
             if self._entry_matches_science_slew(entry, slew):
-                update_end = entry.end >= entry.begin + 86400
+                update_end = entry.end >= entry.begin + DAY_SECONDS
                 self._apply_slew_metadata(entry, slew, update_end=update_end)
                 return
 

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -1470,6 +1470,18 @@ class TestPlanExecutionValidation:
 
         assert any("invalid_interval" in str(m) for m in mismatches)
 
+    def test_validation_fails_for_zero_duration_entry(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = self._science_entry(queue_ditl)
+        entry.begin = 1200.0
+        entry.end = 1200.0
+        queue_ditl.plan.append(entry)
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any("invalid_interval" in str(m) for m in mismatches)
+
     def test_validation_fails_for_non_monotonic_plan_entries(
         self, queue_ditl: QueueDITL
     ) -> None:

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -768,6 +768,34 @@ class TestFetchNewPPT:
             assert entry.slewdist == pytest.approx(slew.slewdist)
             assert entry.roll == pytest.approx(slew.endroll)
 
+    def test_sync_slew_metadata_does_not_rewrite_closed_duplicate_obsid(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = PlanEntry(config=queue_ditl.config)
+        entry.obstype = ObsType.AT
+        entry.obsid = 1001
+        entry.begin = 1000.0
+        entry.end = 1300.0
+        entry.slewtime = 60
+        entry.slewdist = 10.0
+        queue_ditl.plan.append(entry)
+
+        slew = Slew(config=queue_ditl.config)
+        slew.obstype = ObsType.PPT
+        slew.obsid = entry.obsid
+        slew.slewstart = 5000.0
+        slew.slewtime = 120.0
+        slew.slewdist = 50.0
+        slew.endroll = 40.0
+        queue_ditl.acs.current_slew = slew
+
+        queue_ditl._sync_acs_slew_metadata()
+
+        assert entry.begin == 1000.0
+        assert entry.end == 1300.0
+        assert entry.slewtime == 60
+        assert entry.slewdist == 10.0
+
     def test_rejected_ppt_keeps_queue_estimate_metadata(self, queue_ditl) -> None:
         mock_ppt = Mock()
         mock_ppt.ra = 45.0
@@ -1429,6 +1457,32 @@ class TestPlanExecutionValidation:
 
         with pytest.raises(PlanExecutionMismatchError, match="obsid_mismatch"):
             queue_ditl._assert_plan_matches_execution()
+
+    def test_validation_fails_for_entry_end_before_begin(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = self._science_entry(queue_ditl)
+        entry.begin = 1300.0
+        entry.end = 1200.0
+        queue_ditl.plan.append(entry)
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any("invalid_interval" in str(m) for m in mismatches)
+
+    def test_validation_fails_for_non_monotonic_plan_entries(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        first = self._science_entry(queue_ditl)
+        second = self._science_entry(queue_ditl)
+        second.obsid = 43
+        second.begin = first.begin - 60.0
+        second.end = first.end + 60.0
+        queue_ditl.plan.extend([first, second])
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any("non_monotonic_begin" in str(m) for m in mismatches)
 
     def test_validation_fails_for_science_pointing_mismatch(
         self, queue_ditl: QueueDITL


### PR DESCRIPTION
Closes #165.

A target can be retried with the same obsid after an earlier constrained or under-collected attempt. The exported plan metadata sync was matching science slew metadata by obsid only, so a later retry could rewrite an older closed plan entry with the later slew start while leaving the old end time in place.

This PR:

- only syncs science slew metadata into the active/open entry for that slew
- validates exported plan structure before export so invalid intervals or non-monotonic entries fail inside COAST
- adds regression tests for duplicate-obsid stale sync and structural plan validation

Validated:

- `pytest tests/scheduler_queue/test_queue_ditl.py`

I also validated this fix with Tamalpais full generation locally; JSON, FlightJAS, orbit visualizer payload, timelines, event logs, and manifest all complete when local `fjplan` and `orbit_visualizer` packages are on `PYTHONPATH`.