### PR TITLE
fix: validate executed science/contact activity before export

### DIFF
--- a/conops/common/enums.py
+++ b/conops/common/enums.py
@@ -10,6 +10,7 @@ class ACSMode(int, Enum):
     PASS = 3
     CHARGING = 4
     SAFE = 5
+    IDLE = 6
 
 
 class ChargeState(int, Enum):

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -676,6 +676,17 @@ class QueueDITL(DITLMixin, DITLStats):
             obsid=int(entry.obsid),
         )
 
+    def _constraint_mismatch(
+        self, entry: PlanEntry, utime: float, constraint_name: str
+    ) -> PlanExecutionMismatch:
+        return self._execution_mismatch(
+            utime,
+            "science",
+            "constraint_violation",
+            f"obsid {int(entry.obsid)} violates {constraint_name}",
+            obsid=int(entry.obsid),
+        )
+
     def _validate_plan_entry_structure(self) -> list[PlanExecutionMismatch]:
         mismatches: list[PlanExecutionMismatch] = []
         previous_begin: float | None = None
@@ -752,6 +763,29 @@ class QueueDITL(DITLMixin, DITLStats):
                     self._pointing_mismatch(entry, utime, error_deg, "science")
                 )
 
+            roll = (
+                float(self.roll[i])
+                if i < len(self.roll)
+                else float(getattr(entry, "roll", 0.0))
+            )
+            if self.constraint.in_constraint(
+                float(self.ra[i]),
+                float(self.dec[i]),
+                utime,
+                target_roll=roll,
+                acs_mode=ACSMode.SCIENCE,
+            ):
+                constraint_name = self._get_constraint_name(
+                    float(self.ra[i]),
+                    float(self.dec[i]),
+                    utime,
+                    roll=roll,
+                    mode=ACSMode.SCIENCE,
+                )
+                mismatches.append(
+                    self._constraint_mismatch(entry, utime, constraint_name)
+                )
+
         if samples > 0 and science_samples == 0:
             mismatches.append(
                 self._execution_mismatch(
@@ -762,6 +796,59 @@ class QueueDITL(DITLMixin, DITLStats):
                     obsid=int(entry.obsid),
                 )
             )
+        return mismatches
+
+    def _science_entry_covering_sample(
+        self, utime: float, obsid: int
+    ) -> PlanEntry | None:
+        for entry in self.plan:
+            obstype = self._entry_obstype(entry)
+            if obstype not in (ObsType.AT, ObsType.TOO):
+                continue
+            if int(entry.obsid) != int(obsid):
+                continue
+            if float(entry.begin) <= utime < float(entry.end):
+                return entry
+        return None
+
+    def _gsp_entry_covering_sample(self, utime: float, obsid: int) -> PlanEntry | None:
+        for entry in self.plan:
+            if self._entry_obstype(entry) != ObsType.GSP:
+                continue
+            if int(entry.obsid) != int(obsid):
+                continue
+            if float(entry.begin) <= utime <= float(entry.end):
+                return entry
+        return None
+
+    def _validate_execution_is_planned(self) -> list[PlanExecutionMismatch]:
+        mismatches: list[PlanExecutionMismatch] = []
+        for i, utime in enumerate(self.utime):
+            mode = self._mode_at_index(i)
+            if mode == ACSMode.SCIENCE:
+                obsid = int(self.obsid[i])
+                if self._science_entry_covering_sample(utime, obsid) is None:
+                    mismatches.append(
+                        self._execution_mismatch(
+                            utime,
+                            "execution",
+                            "unplanned_science",
+                            f"obsid {obsid} has no matching exported science entry",
+                            obsid=obsid,
+                        )
+                    )
+            elif mode == ACSMode.PASS:
+                obsid = int(self.obsid[i])
+                if self._gsp_entry_covering_sample(utime, obsid) is None:
+                    mismatches.append(
+                        self._execution_mismatch(
+                            utime,
+                            "execution",
+                            "unplanned_contact",
+                            f"obsid {obsid} has no matching exported GSP entry",
+                            obsid=obsid,
+                        )
+                    )
         return mismatches
 
     def _matching_pass_for_entry(self, entry: PlanEntry) -> Pass | None:
@@ -869,6 +956,7 @@ class QueueDITL(DITLMixin, DITLStats):
                 mismatches.extend(
                     self._validate_gsp_entry_execution(entry, tolerance_deg)
                 )
+        mismatches.extend(self._validate_execution_is_planned())
         return mismatches
 
     def _assert_plan_matches_execution(self) -> None:
@@ -1592,6 +1680,7 @@ class QueueDITL(DITLMixin, DITLStats):
             self.ppt.done = True
 
         self.ppt = None
+        self.acs.end_science_observation()
         # Do NOT clear last_slew here. The spacecraft is physically still pointing
         # at the science target; clearing last_slew would cause pointing() to call
         # optimum_roll() and jump the roll on the next tick. Roll stays locked to

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -23,6 +23,9 @@ if TYPE_CHECKING:
     from ..targets import Pointing
 
 
+IDLE_OBSID = 0
+
+
 class ACS:
     """
     Queue-driven state machine for spacecraft Attitude Control System (ACS).
@@ -54,6 +57,7 @@ class ACS:
     radiator_sun_exposure: float
     radiator_earth_exposure: float
     radiator_heat_dissipation_w: float
+    science_observation_active: bool
 
     def __init__(self, config: MissionConfig, log: "DITLLog | None" = None) -> None:
         """Initialize the Attitude Control System.
@@ -88,7 +92,8 @@ class ACS:
         # Current state
         self.roll = 0.0
         self.obstype = ObsType.PPT
-        self.acsmode = ACSMode.SCIENCE  # Start in science/pointing mode
+        self.acsmode = ACSMode.IDLE
+        self.science_observation_active = False
         self.in_eclipse = False  # Initialize eclipse state
         self.in_safe_mode = False  # Safe mode flag - once True, cannot be exited
 
@@ -276,7 +281,7 @@ class ACS:
     def _end_pass(self, utime: float) -> None:
         """Handle the END_PASS command to command the end of a groundstation pass."""
         self.current_pass = None
-        self.acsmode = ACSMode.SCIENCE
+        self.acsmode = ACSMode.IDLE
 
         # Clear any stale slew that was issued during the pass. Such slews have
         # start positions from pass tracking that don't reflect where the
@@ -368,11 +373,18 @@ class ACS:
 
         # Update last_ppt if this is a science pointing
         if self._is_science_pointing(slew):
+            self.science_observation_active = True
             self.last_ppt = slew
+        else:
+            self.science_observation_active = False
 
     def _is_science_pointing(self, slew: Slew) -> bool:
         """Check if slew represents a science pointing (not a pass)."""
         return slew.obstype == ObsType.PPT and isinstance(slew, Slew)
+
+    def end_science_observation(self) -> None:
+        """Mark the current held attitude as no longer collecting science."""
+        self.science_observation_active = False
 
     def _enqueue_slew(
         self,
@@ -567,9 +579,16 @@ class ACS:
         if self.current_pass is not None:
             return self.ra, self.dec, self.roll, self.current_pass.obsid
         if self.last_slew is not None:
+            if self._is_science_pointing(self.last_slew):
+                obsid = (
+                    self.last_slew.obsid
+                    if self.science_observation_active
+                    else IDLE_OBSID
+                )
+                return self.ra, self.dec, self.roll, obsid
             return self.ra, self.dec, self.roll, self.last_slew.obsid
         else:
-            return self.ra, self.dec, self.roll, 1
+            return self.ra, self.dec, self.roll, IDLE_OBSID
 
     def get_mode(self, utime: float) -> ACSMode:
         """Determine current spacecraft mode based on ACS state and external factors.
@@ -610,7 +629,14 @@ class ACS:
         if self.saa is not None and self.saa.insaa(utime):
             return ACSMode.SAA
 
-        return ACSMode.SCIENCE
+        if self.last_slew is not None:
+            if self._is_science_pointing(self.last_slew):
+                return (
+                    ACSMode.SCIENCE if self.science_observation_active else ACSMode.IDLE
+                )
+            return ACSMode.IDLE
+
+        return ACSMode.SCIENCE if self.science_observation_active else ACSMode.IDLE
 
     def _is_actively_slewing(self, utime: float) -> bool:
         """Check if spacecraft is currently executing a slew."""
@@ -724,8 +750,6 @@ class ACS:
                         " ".join(true_constraints),
                     ),
                 )
-            # Note: acsmode remains SCIENCE - the DITL will decide if charging is needed
-
         # Check star tracker constraints
         self._check_star_tracker_constraints(utime)
         self._check_radiator_constraints(utime)
@@ -1061,6 +1085,7 @@ class ACS:
         # This prevents staying in CHARGING mode while slewing back to science
         if self.last_slew is not None and self.last_slew.obstype == ObsType.CHARGE:
             self.last_slew = None
+        self.science_observation_active = False
 
         # Queue-driven scheduling owns the next science target. Returning to the
         # previous PPT here can resurrect a closed observation after charging.

--- a/tests/acs/test_acs.py
+++ b/tests/acs/test_acs.py
@@ -42,7 +42,7 @@ class TestACSInitialization:
         assert acs.obstype == ObsType.PPT
         assert acs.last_slew is not None  # Initialized with boundary condition slew
         assert acs.last_ppt is None
-        assert acs.acsmode == 0
+        assert acs.acsmode == ACSMode.IDLE
         assert acs.current_pass is None
         assert acs.slew_dists == []
 
@@ -101,8 +101,8 @@ class TestACSStateManagement:
     """Test ACS state management."""
 
     def test_acsmode_initial(self, acs) -> None:
-        """Test default acsmode is SCIENCE."""
-        assert acs.acsmode == ACSMode.SCIENCE
+        """Test default acsmode is IDLE."""
+        assert acs.acsmode == ACSMode.IDLE
 
     def test_acsmode_set_slewing(self, acs) -> None:
         """Test setting acsmode to SLEWING."""

--- a/tests/acs/test_acs_comprehensive.py
+++ b/tests/acs/test_acs_comprehensive.py
@@ -435,6 +435,7 @@ class TestPointing:
         mock_slew.at.roll = 0.0
 
         acs.last_slew = mock_slew
+        acs.science_observation_active = True
         acs.constraint.in_constraint = Mock(return_value=True)
 
         ra, dec, roll, obsid = acs.pointing(1514764800.0)
@@ -485,7 +486,7 @@ class TestPointing:
         # After pass ends
         ra, dec, roll, obsid = acs.pointing(1514765500.0)
 
-        assert acs.acsmode == ACSMode.SCIENCE
+        assert acs.acsmode == ACSMode.IDLE
 
 
 class TestRequestPass:

--- a/tests/acs/test_acs_coverage.py
+++ b/tests/acs/test_acs_coverage.py
@@ -20,9 +20,9 @@ class TestExecuteCommandCoverage:
 
         # Directly call _end_pass
         acs._end_pass(1514764800.0)
-        # Verify currentpass is cleared and mode is set to SCIENCE
+        # Verify currentpass is cleared and mode is set to IDLE
         assert acs.current_pass is None
-        assert acs.acsmode == ACSMode.SCIENCE
+        assert acs.acsmode == ACSMode.IDLE
 
     def test_end_pass_clears_currentpass(self, acs) -> None:
         mock_ppt = Mock(spec=Slew)
@@ -35,9 +35,9 @@ class TestExecuteCommandCoverage:
 
         acs._end_pass(1514764800.0)
         assert acs.current_pass is None
-        assert acs.acsmode == ACSMode.SCIENCE
+        assert acs.acsmode == ACSMode.IDLE
 
-    def test_end_pass_sets_mode_science(self, acs) -> None:
+    def test_end_pass_sets_mode_idle(self, acs) -> None:
         mock_ppt = Mock(spec=Slew)
         mock_ppt.endra = 45.0
         mock_ppt.enddec = 30.0
@@ -47,7 +47,7 @@ class TestExecuteCommandCoverage:
         acs.acsmode = ACSMode.PASS
 
         acs._end_pass(1514764800.0)
-        assert acs.acsmode == ACSMode.SCIENCE
+        assert acs.acsmode == ACSMode.IDLE
 
     def test_end_pass_no_last_ppt_clears_currentpass(self, acs) -> None:
         acs.last_ppt = None
@@ -57,13 +57,13 @@ class TestExecuteCommandCoverage:
         acs._end_pass(1514764800.0)
         assert acs.current_pass is None
 
-    def test_end_pass_no_last_ppt_sets_mode_science(self, acs) -> None:
+    def test_end_pass_no_last_ppt_sets_mode_idle(self, acs) -> None:
         acs.last_ppt = None
         acs.current_pass = Mock(spec=Pass)
         acs.acsmode = ACSMode.PASS
 
         acs._end_pass(1514764800.0)
-        assert acs.acsmode == ACSMode.SCIENCE
+        assert acs.acsmode == ACSMode.IDLE
 
     def test_execute_null_slew_does_not_start(self, acs) -> None:
         command = ACSCommand(
@@ -428,7 +428,7 @@ class TestEndPassCoverage:
             acs._end_pass(1514764800.0)
             assert acs.current_pass is None
 
-    def test_end_pass_sets_mode_science_on_end(self, acs) -> None:
+    def test_end_pass_sets_mode_idle_on_end(self, acs) -> None:
         mock_ppt = Mock(spec=Slew)
         mock_ppt.endra = 45.0
         mock_ppt.enddec = 30.0
@@ -440,7 +440,7 @@ class TestEndPassCoverage:
 
         with patch.object(acs, "enqueue_command", return_value=True):
             acs._end_pass(1514764800.0)
-            assert acs.acsmode == ACSMode.SCIENCE
+            assert acs.acsmode == ACSMode.IDLE
 
     def test_end_pass_with_no_last_ppt_clears_currentpass(self, acs) -> None:
         acs.last_ppt = None
@@ -450,13 +450,13 @@ class TestEndPassCoverage:
         acs._end_pass(1514764800.0)
         assert acs.current_pass is None
 
-    def test_end_pass_with_no_last_ppt_sets_mode_science(self, acs) -> None:
+    def test_end_pass_with_no_last_ppt_sets_mode_idle(self, acs) -> None:
         acs.last_ppt = None
         acs.current_pass = Mock(spec=Pass)
         acs.acsmode = ACSMode.PASS
 
         acs._end_pass(1514764800.0)
-        assert acs.acsmode == ACSMode.SCIENCE
+        assert acs.acsmode == ACSMode.IDLE
 
     def test_end_pass_no_last_ppt_does_not_enqueue_slew(self, acs) -> None:
         acs.last_ppt = None
@@ -486,8 +486,8 @@ class TestEndPassCoverage:
         assert acs.last_slew is None
         # Pass should be cleared
         assert acs.current_pass is None
-        # Mode should be SCIENCE
-        assert acs.acsmode == ACSMode.SCIENCE
+        # Mode should be IDLE
+        assert acs.acsmode == ACSMode.IDLE
 
     def test_end_pass_preserves_fresh_slew(self, acs) -> None:
         """Test that _end_pass preserves slews that start in the future (fresh slews)."""
@@ -509,8 +509,8 @@ class TestEndPassCoverage:
         assert acs.last_slew is mock_slew
         # Pass should still be cleared
         assert acs.current_pass is None
-        # Mode should be SCIENCE
-        assert acs.acsmode == ACSMode.SCIENCE
+        # Mode should be IDLE
+        assert acs.acsmode == ACSMode.IDLE
 
     def test_end_pass_handles_no_slew(self, acs) -> None:
         """Test that _end_pass works correctly when there's no last_slew."""
@@ -527,7 +527,7 @@ class TestEndPassCoverage:
         # Everything should work as expected
         assert acs.last_slew is None
         assert acs.current_pass is None
-        assert acs.acsmode == ACSMode.SCIENCE
+        assert acs.acsmode == ACSMode.IDLE
 
     def test_end_pass_clears_slew_starting_exactly_at_current_time(self, acs) -> None:
         """Test edge case where slew starts exactly at current time."""

--- a/tests/acs/test_acs_safe_mode.py
+++ b/tests/acs/test_acs_safe_mode.py
@@ -12,7 +12,7 @@ class TestSafeModeInitialization:
     def test_acs_initializes_not_in_safe_mode(self, acs):
         """Test that ACS initializes with safe mode flag set to False."""
         assert acs.in_safe_mode is False
-        assert acs.acsmode == ACSMode.SCIENCE
+        assert acs.acsmode == ACSMode.IDLE
 
     def test_safe_mode_enum_exists(self):
         """Test that SAFE mode exists in ACSMode enum."""

--- a/tests/scheduler_queue/conftest.py
+++ b/tests/scheduler_queue/conftest.py
@@ -157,8 +157,8 @@ def queue_ditl(mock_config: Mock, mock_ephem: DummyEphemeris) -> QueueDITL:
         # Set acsmode to a real ACSMode enum value for logging
         from conops import ACSMode
 
-        mock_acs.acsmode = ACSMode.SCIENCE
-        mock_acs.get_mode = Mock(return_value=ACSMode.SCIENCE)
+        mock_acs.acsmode = ACSMode.IDLE
+        mock_acs.get_mode = Mock(return_value=ACSMode.IDLE)
         mock_acs.in_safe_mode = False
         mock_acs.in_eclipse = False
         # Add star tracker attributes for Housekeeping telemetry
@@ -589,8 +589,8 @@ def queue_ditl_no_queue_log(
         # Set acsmode to a real ACSMode enum value for logging
         from conops import ACSMode
 
-        mock_acs.acsmode = ACSMode.SCIENCE
-        mock_acs.get_mode = Mock(return_value=ACSMode.SCIENCE)
+        mock_acs.acsmode = ACSMode.IDLE
+        mock_acs.get_mode = Mock(return_value=ACSMode.IDLE)
         mock_acs.in_safe_mode = False
         mock_acs.in_eclipse = False
         # Add star tracker attributes for Housekeeping telemetry
@@ -665,8 +665,8 @@ def queue_ditl_acs_no_ephem(
         # Set acsmode to a real ACSMode enum value for logging
         from conops import ACSMode
 
-        mock_acs.acsmode = ACSMode.SCIENCE
-        mock_acs.get_mode = Mock(return_value=ACSMode.SCIENCE)
+        mock_acs.acsmode = ACSMode.IDLE
+        mock_acs.get_mode = Mock(return_value=ACSMode.IDLE)
         mock_acs.in_safe_mode = False
         mock_acs.in_eclipse = False
         # Add star tracker attributes for Housekeeping telemetry

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -20,6 +20,7 @@ from conops import (
 from conops.common.enums import ObsType
 from conops.config.config import MissionConfig
 from conops.ditl.telemetry import Housekeeping
+from conops.simulation.acs import IDLE_OBSID
 from conops.simulation.passes import GSP_TRACK_ROLL
 from conops.targets import PlanEntry, PlanSchema
 
@@ -313,7 +314,21 @@ class TestDetermineMode:
         acs.saa = None
 
         mode = acs.get_mode(1000.0)
+        assert mode == ACSMode.IDLE
+
+        science_slew = Slew(config=mock_config)
+        science_slew.obstype = ObsType.PPT
+        science_slew.obsid = 42
+        science_slew.slewstart = 0.0
+        science_slew.slewend = 0.0
+        acs.last_slew = science_slew
+        acs.science_observation_active = True
+        mode = acs.get_mode(2000.0)
         assert mode == ACSMode.SCIENCE
+
+        acs.end_science_observation()
+        mode = acs.get_mode(1000.0)
+        assert mode == ACSMode.IDLE
 
 
 class TestHandlePassMode:
@@ -1463,7 +1478,7 @@ class TestPlanExecutionValidation:
             ACSMode.SCIENCE,
             ACSMode.SCIENCE,
             ACSMode.SCIENCE,
-            ACSMode.SCIENCE,
+            ACSMode.IDLE,
         ]
         queue_ditl.obsid = [0, 42, 42, 42, 42, 42]
         queue_ditl.ra = [0.0, 10.0, 10.0, 10.0, 10.0, 10.0]
@@ -1481,13 +1496,102 @@ class TestPlanExecutionValidation:
         entry.end = 1120.0
         queue_ditl.plan.append(entry)
         queue_ditl.utime = [1000.0, 1060.0, 1120.0]
-        queue_ditl.mode = [ACSMode.SCIENCE, ACSMode.SCIENCE, ACSMode.SCIENCE]
+        queue_ditl.mode = [ACSMode.IDLE, ACSMode.SCIENCE, ACSMode.IDLE]
         queue_ditl.obsid = [999, 42, 999]
         queue_ditl.ra = [99.0, 10.0, 99.0]
         queue_ditl.dec = [99.0, 20.0, 99.0]
         self._index_telemetry_by_time(queue_ditl)
 
         assert queue_ditl.validate_plan_matches_execution() == []
+
+    def test_terminating_ppt_marks_held_attitude_idle(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = self._science_entry(queue_ditl)
+        queue_ditl.ppt = entry
+
+        real_acs = ACS(config=queue_ditl.config)
+        queue_ditl.acs = real_acs
+        science_slew = Slew(config=queue_ditl.config)
+        science_slew.obstype = ObsType.PPT
+        science_slew.obsid = entry.obsid
+        science_slew.slewstart = 1000.0
+        science_slew.slewend = 1100.0
+        science_slew.slewtime = 100.0
+        science_slew.startra = 0.0
+        science_slew.startdec = 0.0
+        science_slew.endra = entry.ra
+        science_slew.enddec = entry.dec
+        real_acs.last_slew = science_slew
+        real_acs.science_observation_active = True
+
+        queue_ditl._terminate_ppt(1300.0, reason="Target constrained")
+
+        assert queue_ditl.ppt is None
+        assert real_acs.science_observation_active is False
+        assert real_acs.get_mode(1300.0) == ACSMode.IDLE
+        real_acs._check_constraints = Mock()
+        real_acs._check_star_tracker_constraints = Mock()
+        real_acs._check_radiator_constraints = Mock()
+        assert real_acs.pointing(1300.0)[3] == IDLE_OBSID
+
+    def test_validation_fails_for_unplanned_science_execution(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = self._science_entry(queue_ditl)
+        queue_ditl.plan.append(entry)
+        queue_ditl.utime = [1060.0, 1120.0, 1300.0, 1360.0]
+        queue_ditl.mode = [
+            ACSMode.SCIENCE,
+            ACSMode.SCIENCE,
+            ACSMode.IDLE,
+            ACSMode.SCIENCE,
+        ]
+        queue_ditl.obsid = [42, 42, 1, 42]
+        queue_ditl.ra = [10.0, 10.0, 10.0, 10.0]
+        queue_ditl.dec = [20.0, 20.0, 20.0, 20.0]
+        self._index_telemetry_by_time(queue_ditl)
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any("unplanned_science" in str(m) for m in mismatches)
+
+    def test_validation_fails_for_science_constraint_violation(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = self._science_entry(queue_ditl)
+        queue_ditl.plan.append(entry)
+        queue_ditl.utime = [1060.0, 1120.0]
+        queue_ditl.mode = [ACSMode.SCIENCE, ACSMode.SCIENCE]
+        queue_ditl.obsid = [42, 42]
+        queue_ditl.ra = [10.0, 10.0]
+        queue_ditl.dec = [20.0, 20.0]
+        queue_ditl.constraint.in_constraint = Mock(side_effect=[False, True])
+        queue_ditl._get_constraint_name = Mock(return_value="Earth Limb")  # type: ignore[method-assign]
+        self._index_telemetry_by_time(queue_ditl)
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any("constraint_violation" in str(m) for m in mismatches)
+
+    def test_execution_coverage_uses_full_gsp_entry_window(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = PlanEntry(config=queue_ditl.config)
+        entry.obstype = ObsType.GSP
+        entry.obsid = 0xFFFF
+        entry.station = "TRO"
+        entry.begin = 900.0
+        entry.slewtime = 100.0
+        entry.contact_begin = 1000.0
+        entry.contact_end = 1180.0
+        entry.end = 1180.0
+        queue_ditl.plan.append(entry)
+        queue_ditl.utime = [900.0, 960.0, 1180.0]
+        queue_ditl.mode = [ACSMode.PASS, ACSMode.PASS, ACSMode.PASS]
+        queue_ditl.obsid = [0xFFFF, 0xFFFF, 0xFFFF]
+
+        assert queue_ditl._validate_execution_is_planned() == []
 
     def test_validation_fails_for_stale_science_obsid(
         self, queue_ditl: QueueDITL
@@ -1741,6 +1845,7 @@ class TestCalcMethod:
         queue_ditl.length = 1
         queue_ditl.step_size = 3600
         queue_ditl.acs.get_mode = Mock(return_value=ACSMode.PASS)
+        queue_ditl._assert_plan_matches_execution = Mock()
         result = queue_ditl.calc()
         assert result is True
 
@@ -1750,6 +1855,7 @@ class TestCalcMethod:
         queue_ditl.length = 1
         queue_ditl.step_size = 3600
         queue_ditl.acs.get_mode = Mock(return_value=ACSMode.PASS)
+        queue_ditl._assert_plan_matches_execution = Mock()
         queue_ditl.calc()
         assert ACSMode.PASS in queue_ditl.mode
 
@@ -1895,6 +2001,7 @@ class TestCalcMethod:
         queue_ditl.battery.battery_alert = True
         queue_ditl.acs.get_mode = Mock(return_value=ACSMode.SCIENCE)
         queue_ditl.acs.pointing = Mock(return_value=(10.0, 20.0, 0.0, 1001))
+        queue_ditl._assert_plan_matches_execution = Mock()
 
         science_entry = Mock()
         science_entry.obstype = "AT"

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -1524,15 +1524,15 @@ class TestPlanExecutionValidation:
         science_slew.enddec = entry.dec
         real_acs.last_slew = science_slew
         real_acs.science_observation_active = True
+        real_acs._check_constraints = Mock()
+        real_acs._check_star_tracker_constraints = Mock()
+        real_acs._check_radiator_constraints = Mock()
 
         queue_ditl._terminate_ppt(1300.0, reason="Target constrained")
 
         assert queue_ditl.ppt is None
         assert real_acs.science_observation_active is False
         assert real_acs.get_mode(1300.0) == ACSMode.IDLE
-        real_acs._check_constraints = Mock()
-        real_acs._check_star_tracker_constraints = Mock()
-        real_acs._check_radiator_constraints = Mock()
         assert real_acs.pointing(1300.0)[3] == IDLE_OBSID
 
     def test_validation_fails_for_unplanned_science_execution(


### PR DESCRIPTION
## Summary
- reject generated plans when executed SCIENCE samples violate the applicable science constraints
- require executed SCIENCE/PASS telemetry to be covered by the exported AT/TOO/GSP entries so activity telemetry cannot drift away from the plan
- make ACS report held post-activity attitudes as IDLE instead of continuing to report stale SCIENCE obsids after the activity is closed

This PR fixes the immediate bug where a plan can look valid while executed science/contact telemetry does not match the exported activity windows. It validates activity-scoped executed telemetry before attitude export. It does not yet run every attitude sample in every ACS mode through a full mode-specific constraint policy; that is follow-up work.

Closes #167.

## Validation
- `pytest`
- `prek run --all-files`
- Tamalpais integration with #164 + #166 + this branch now fails before export on #168, which is the intended behavior until dropped under-collected retries are fixed.