### PR TITLE
fix: validate full attitude constraint timeline

### DIFF
--- a/conops/__init__.py
+++ b/conops/__init__.py
@@ -18,6 +18,7 @@ from .common import (
 from .config import (
     DAY_SECONDS,
     DTOR,
+    AttitudeConstraintPolicy,
     AttitudeControlSystem,
     Battery,
     Constraint,
@@ -91,6 +92,7 @@ __all__ = [
     "AttitudeSampleSchema",
     "AttitudeTimeseriesSchema",
     "AttitudeControlSystem",
+    "AttitudeConstraintPolicy",
     "Battery",
     "ChargeState",
     "MissionConfig",

--- a/conops/config/__init__.py
+++ b/conops/config/__init__.py
@@ -5,7 +5,7 @@ from .communications import (
     BandCapability,
     CommunicationsSystem,
 )
-from .config import MissionConfig
+from .config import AttitudeConstraintPolicy, MissionConfig
 from .constants import DAY_SECONDS, DTOR
 from .constraint import Constraint, DefaultConstraint
 from .data_generator import DataGeneration
@@ -44,6 +44,7 @@ from .visualization import VisualizationConfig
 __all__ = [
     "AntennaPointing",
     "AttitudeControlSystem",
+    "AttitudeConstraintPolicy",
     "BandCapability",
     "Battery",
     "CommunicationsSystem",

--- a/conops/config/config.py
+++ b/conops/config/config.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any
 
 import yaml
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 from rust_ephem.constraints import ConstraintConfig
 
+from ..common.enums import ACSMode
 from ._base import ConfigModel
 from .battery import Battery
 from .constraint import Constraint, DefaultConstraint
@@ -20,6 +22,48 @@ from .targets import TargetConfig
 from .visualization import VisualizationConfig
 
 
+class AttitudeConstraintPolicy(str, Enum):
+    """Constraint validation policy applied to executed attitude samples."""
+
+    FULL_MISSION = "full_mission"
+    HARD_KEEPOUT = "hard_keepout"
+    NONE = "none"
+
+
+def _default_attitude_constraint_policy() -> dict[str, AttitudeConstraintPolicy]:
+    return {
+        ACSMode.SCIENCE.name: AttitudeConstraintPolicy.FULL_MISSION,
+        ACSMode.CHARGING.name: AttitudeConstraintPolicy.FULL_MISSION,
+        ACSMode.SLEWING.name: AttitudeConstraintPolicy.HARD_KEEPOUT,
+        ACSMode.PASS.name: AttitudeConstraintPolicy.HARD_KEEPOUT,
+        ACSMode.SAA.name: AttitudeConstraintPolicy.HARD_KEEPOUT,
+        ACSMode.SAFE.name: AttitudeConstraintPolicy.HARD_KEEPOUT,
+        ACSMode.IDLE.name: AttitudeConstraintPolicy.HARD_KEEPOUT,
+    }
+
+
+def _mode_name(mode: ACSMode | int | str) -> str:
+    if isinstance(mode, ACSMode):
+        return mode.name
+    if isinstance(mode, int):
+        return ACSMode(mode).name
+    raw = mode.strip().upper()
+    if raw in ACSMode.__members__:
+        return raw
+    return ACSMode(int(raw)).name
+
+
+def _normalize_attitude_constraint_policy(
+    value: dict[ACSMode | int | str, AttitudeConstraintPolicy | str] | None,
+) -> dict[str, AttitudeConstraintPolicy]:
+    policies = _default_attitude_constraint_policy()
+    if value is None:
+        return policies
+    for mode, policy in value.items():
+        policies[_mode_name(mode)] = AttitudeConstraintPolicy(policy)
+    return policies
+
+
 class MissionConfig(ConfigModel):
     """
     Configuration class for the spacecraft and its subsystems.
@@ -29,6 +73,14 @@ class MissionConfig(ConfigModel):
     random_seed: int | None = Field(
         default=None,
         description="Optional seed for stochastic planning decisions.",
+    )
+    attitude_constraint_policy: dict[str, AttitudeConstraintPolicy] = Field(
+        default_factory=_default_attitude_constraint_policy,
+        description=(
+            "Constraint validation policy by ACS mode for executed attitude samples. "
+            "Values are 'full_mission', 'hard_keepout', or 'none'. Omitted modes "
+            "use the default policy."
+        ),
     )
     spacecraft_bus: SpacecraftBus = Field(
         default_factory=SpacecraftBus,
@@ -75,6 +127,21 @@ class MissionConfig(ConfigModel):
         default_factory=TargetConfig,
         description="Target Configuration. Defines observational targets and scheduling parameters",
     )
+
+    @field_validator("attitude_constraint_policy", mode="before")
+    @classmethod
+    def _validate_attitude_constraint_policy(
+        cls,
+        value: dict[ACSMode | int | str, AttitudeConstraintPolicy | str] | None,
+    ) -> dict[str, AttitudeConstraintPolicy]:
+        return _normalize_attitude_constraint_policy(value)
+
+    def attitude_constraint_policy_for_mode(
+        self, mode: ACSMode | int
+    ) -> AttitudeConstraintPolicy:
+        return self.attitude_constraint_policy.get(
+            _mode_name(mode), AttitudeConstraintPolicy.NONE
+        )
 
     @model_validator(mode="after")
     def init_fault_management_defaults(self) -> MissionConfig:

--- a/conops/config/constraint.py
+++ b/conops/config/constraint.py
@@ -154,7 +154,6 @@ class Constraint(ConfigModel):
         default=None,
         description="Telescope boresight-offset hard exclusion constraint",
     )
-
     ephem: rust_ephem.Ephemeris | None = Field(
         default=None,
         exclude=True,

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -18,7 +18,7 @@ from ..common import (
 )
 from ..common.enums import ACSCommandType
 from ..common.vector import attitude_to_quat
-from ..config import DAY_SECONDS, MissionConfig
+from ..config import DAY_SECONDS, AttitudeConstraintPolicy, MissionConfig
 from ..simulation.acs_command import ACSCommand
 from ..simulation.emergency_charging import EmergencyCharging
 from ..simulation.passes import GSP_TRACK_ROLL, Pass, pass_slew_trigger_buffer
@@ -602,6 +602,7 @@ class QueueDITL(DITLMixin, DITLStats):
             "utime": len(self.utime),
             "ra": len(self.ra),
             "dec": len(self.dec),
+            "roll": len(self.roll),
             "obsid": len(self.obsid),
             "mode": len(self.mode),
         }
@@ -676,15 +677,32 @@ class QueueDITL(DITLMixin, DITLStats):
             obsid=int(entry.obsid),
         )
 
-    def _constraint_mismatch(
-        self, entry: PlanEntry, utime: float, constraint_name: str
+    def _attitude_constraint_mismatch(
+        self, index: int, constraint_name: str, policy: str
     ) -> PlanExecutionMismatch:
+        mode = self._mode_at_index(index)
+        obsid = int(self.obsid[index])
         return self._execution_mismatch(
-            utime,
-            "science",
+            self.utime[index],
+            "attitude",
             "constraint_violation",
-            f"obsid {int(entry.obsid)} violates {constraint_name}",
-            obsid=int(entry.obsid),
+            (
+                f"mode {mode.name if mode is not None else self.mode[index]} "
+                f"obsid {obsid} violates {constraint_name} ({policy}); "
+                f"ra={float(self.ra[index]):.3f} "
+                f"dec={float(self.dec[index]):.3f} "
+                f"roll={float(self.roll[index]):.3f}"
+            ),
+            obsid=obsid,
+        )
+
+    def _unknown_mode_mismatch(self, index: int) -> PlanExecutionMismatch:
+        return self._execution_mismatch(
+            self.utime[index],
+            "attitude",
+            "unknown_mode",
+            f"cannot apply constraint policy for mode {self.mode[index]}",
+            obsid=int(self.obsid[index]),
         )
 
     def _validate_plan_entry_structure(self) -> list[PlanExecutionMismatch]:
@@ -763,29 +781,6 @@ class QueueDITL(DITLMixin, DITLStats):
                     self._pointing_mismatch(entry, utime, error_deg, "science")
                 )
 
-            roll = (
-                float(self.roll[i])
-                if i < len(self.roll)
-                else float(getattr(entry, "roll", 0.0))
-            )
-            if self.constraint.in_constraint(
-                float(self.ra[i]),
-                float(self.dec[i]),
-                utime,
-                target_roll=roll,
-                acs_mode=ACSMode.SCIENCE,
-            ):
-                constraint_name = self._get_constraint_name(
-                    float(self.ra[i]),
-                    float(self.dec[i]),
-                    utime,
-                    roll=roll,
-                    mode=ACSMode.SCIENCE,
-                )
-                mismatches.append(
-                    self._constraint_mismatch(entry, utime, constraint_name)
-                )
-
         if samples > 0 and science_samples == 0:
             mismatches.append(
                 self._execution_mismatch(
@@ -849,6 +844,68 @@ class QueueDITL(DITLMixin, DITLStats):
                             obsid=obsid,
                         )
                     )
+        return mismatches
+
+    def _hard_attitude_constraint_name(
+        self,
+        ra: float,
+        dec: float,
+        utime: float,
+        roll: float,
+        mode: ACSMode,
+    ) -> str | None:
+        if self.constraint.in_star_tracker_hard(
+            ra, dec, utime, target_roll=roll, acs_mode=mode
+        ):
+            return "ST Hard"
+        if self.constraint.in_radiator_hard(ra, dec, utime, target_roll=roll):
+            return "Radiator Hard"
+        if self.constraint.in_telescope_hard(ra, dec, utime, target_roll=roll):
+            return "Telescope Hard"
+        return None
+
+    def _attitude_constraint_name_for_sample(
+        self, index: int, mode: ACSMode
+    ) -> tuple[str, str] | None:
+        """Return the violated constraint name and policy for one attitude sample."""
+        ra = float(self.ra[index])
+        dec = float(self.dec[index])
+        roll = float(self.roll[index])
+        utime = self.utime[index]
+        policy = self.config.attitude_constraint_policy_for_mode(mode)
+        if policy == AttitudeConstraintPolicy.NONE:
+            return None
+        if policy == AttitudeConstraintPolicy.FULL_MISSION:
+            if self.constraint.in_constraint(
+                ra, dec, utime, target_roll=roll, acs_mode=mode
+            ):
+                return (
+                    self._get_constraint_name(ra, dec, utime, roll=roll, mode=mode),
+                    policy.value,
+                )
+            return None
+        if policy == AttitudeConstraintPolicy.HARD_KEEPOUT:
+            name = self._hard_attitude_constraint_name(ra, dec, utime, roll, mode)
+            if name is not None:
+                return name, policy.value
+        return None
+
+    def _validate_attitude_constraints(self) -> list[PlanExecutionMismatch]:
+        mismatches: list[PlanExecutionMismatch] = []
+        for i in range(len(self.utime)):
+            mode = self._mode_at_index(i)
+            if mode is None:
+                mismatches.append(self._unknown_mode_mismatch(i))
+                continue
+
+            violation = self._attitude_constraint_name_for_sample(i, mode)
+            if violation is None:
+                continue
+
+            constraint_name, policy = violation
+            mismatches.append(
+                self._attitude_constraint_mismatch(i, constraint_name, policy)
+            )
         return mismatches
 
     def _matching_pass_for_entry(self, entry: PlanEntry) -> Pass | None:
@@ -956,6 +1013,7 @@ class QueueDITL(DITLMixin, DITLStats):
                 mismatches.extend(
                     self._validate_gsp_entry_execution(entry, tolerance_deg)
                 )
+        mismatches.extend(self._validate_attitude_constraints())
         mismatches.extend(self._validate_execution_is_planned())
         return mismatches
 
@@ -1720,6 +1778,10 @@ class QueueDITL(DITLMixin, DITLStats):
             ra, dec, utime, target_roll=roll, acs_mode=mode
         ):
             return "ST Soft"
+        elif self.constraint.in_radiator_hard(ra, dec, utime, target_roll=roll):
+            return "Radiator Hard"
+        elif self.constraint.in_telescope_hard(ra, dec, utime, target_roll=roll):
+            return "Telescope Hard"
         return "Unknown"
 
     def _simulation_end_deadline(self) -> float:

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -9,6 +9,8 @@ import rust_ephem
 import yaml
 
 from conops import (
+    ACSMode,
+    AttitudeConstraintPolicy,
     Battery,
     Constraint,
     FaultManagement,
@@ -64,6 +66,37 @@ class TestConfig:
         assert (
             minimal_config["config"].ground_stations
             == minimal_config["ground_stations"]
+        )
+
+    def test_attitude_constraint_policy_defaults_by_mode(self) -> None:
+        """Test executed attitude validation policy defaults."""
+        config = MissionConfig()
+        assert (
+            config.attitude_constraint_policy_for_mode(ACSMode.SCIENCE)
+            == AttitudeConstraintPolicy.FULL_MISSION
+        )
+        assert (
+            config.attitude_constraint_policy_for_mode(ACSMode.PASS)
+            == AttitudeConstraintPolicy.HARD_KEEPOUT
+        )
+
+    def test_attitude_constraint_policy_accepts_mode_name_overrides(self) -> None:
+        """Test mission config can override one ACS mode by name."""
+        config = MissionConfig(
+            attitude_constraint_policy={"PASS": "full_mission", "CHARGING": "none"}
+        )
+
+        assert (
+            config.attitude_constraint_policy_for_mode(ACSMode.PASS)
+            == AttitudeConstraintPolicy.FULL_MISSION
+        )
+        assert (
+            config.attitude_constraint_policy_for_mode(ACSMode.CHARGING)
+            == AttitudeConstraintPolicy.NONE
+        )
+        assert (
+            config.attitude_constraint_policy_for_mode(ACSMode.SCIENCE)
+            == AttitudeConstraintPolicy.FULL_MISSION
         )
 
     def test_config_default_name(self) -> None:

--- a/tests/scheduler_queue/conftest.py
+++ b/tests/scheduler_queue/conftest.py
@@ -9,7 +9,13 @@ import numpy as np
 import pytest
 from astropy.time import Time  # type: ignore[import-untyped]
 
-from conops import DAY_SECONDS, DumbQueueScheduler, QueueDITL
+from conops import (
+    DAY_SECONDS,
+    ACSMode,
+    AttitudeConstraintPolicy,
+    DumbQueueScheduler,
+    QueueDITL,
+)
 from conops.targets.plan import Plan
 
 
@@ -67,7 +73,23 @@ def mock_config() -> Mock:
     config.constraint.panel_constraint.solar_panel = Mock()
     config.constraint.orbit_constraint = None
     config.constraint.in_constraint = Mock(return_value=False)
+    config.constraint.in_sun = Mock(return_value=False)
+    config.constraint.in_earth = Mock(return_value=False)
+    config.constraint.in_panel = Mock(return_value=False)
+    config.constraint.in_moon = Mock(return_value=False)
+    config.constraint.in_anti_sun = Mock(return_value=False)
     config.constraint.in_orbit = Mock(return_value=False)
+    config.constraint.in_star_tracker_hard = Mock(return_value=False)
+    config.constraint.in_star_tracker_soft = Mock(return_value=False)
+    config.constraint.in_radiator_hard = Mock(return_value=False)
+    config.constraint.in_telescope_hard = Mock(return_value=False)
+    config.attitude_constraint_policy_for_mode = Mock(
+        side_effect=lambda mode: (
+            AttitudeConstraintPolicy.FULL_MISSION
+            if ACSMode(int(mode)) in (ACSMode.SCIENCE, ACSMode.CHARGING)
+            else AttitudeConstraintPolicy.HARD_KEEPOUT
+        )
+    )
     config.constraint.instantaneous_field_of_regard = Mock(return_value=1.234)
 
     # Mock battery

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -12,6 +12,7 @@ from conops import (
     ACSCommand,
     ACSCommandType,
     ACSMode,
+    AttitudeConstraintPolicy,
     Pass,
     PlanExecutionMismatchError,
     QueueDITL,
@@ -1444,6 +1445,8 @@ class TestPlanExecutionValidation:
 
     def _index_telemetry_by_time(self, queue_ditl: QueueDITL) -> None:
         utimes = [float(utime) for utime in queue_ditl.utime]
+        if not queue_ditl.roll:
+            queue_ditl.roll = [0.0] * len(utimes)
 
         def index(time: datetime) -> int:
             timestamp = time.timestamp()
@@ -1573,6 +1576,206 @@ class TestPlanExecutionValidation:
         mismatches = queue_ditl.validate_plan_matches_execution()
 
         assert any("constraint_violation" in str(m) for m in mismatches)
+
+    def test_validation_fails_for_charging_constraint_violation(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.utime = [1060.0]
+        queue_ditl.mode = [ACSMode.CHARGING]
+        queue_ditl.obsid = [999001]
+        queue_ditl.ra = [40.0]
+        queue_ditl.dec = [10.0]
+        queue_ditl.roll = [5.0]
+        queue_ditl.constraint.in_constraint = Mock(return_value=True)
+        queue_ditl.constraint.in_sun = Mock(return_value=True)
+        self._index_telemetry_by_time(queue_ditl)
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any("mode CHARGING" in str(m) for m in mismatches)
+        assert any("Sun" in str(m) for m in mismatches)
+        queue_ditl.constraint.in_constraint.assert_called_once_with(
+            40.0, 10.0, 1060.0, target_roll=5.0, acs_mode=ACSMode.CHARGING
+        )
+
+    def test_validation_uses_hard_constraints_only_for_pass(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = PlanEntry(config=queue_ditl.config)
+        entry.obstype = ObsType.GSP
+        entry.obsid = 0xFFFF
+        entry.station = "TRO"
+        entry.begin = 1000.0
+        entry.contact_begin = 1000.0
+        entry.contact_end = 1120.0
+        entry.end = 1120.0
+        queue_ditl.plan.append(entry)
+        queue_ditl.acs.passrequests.passes = [
+            Pass(
+                station="TRO",
+                begin=1000.0,
+                length=120.0,
+                obsid=0xFFFF,
+                utime=[1000.0, 1060.0],
+                ra=[10.0, 11.0],
+                dec=[20.0, 21.0],
+            )
+        ]
+        queue_ditl.utime = [1000.0, 1060.0]
+        queue_ditl.mode = [ACSMode.PASS, ACSMode.PASS]
+        queue_ditl.obsid = [0xFFFF, 0xFFFF]
+        queue_ditl.ra = [10.0, 11.0]
+        queue_ditl.dec = [20.0, 21.0]
+        queue_ditl.roll = [0.0, 10.0]
+        queue_ditl.constraint.in_constraint = Mock(return_value=True)
+        self._index_telemetry_by_time(queue_ditl)
+
+        assert queue_ditl.validate_plan_matches_execution() == []
+        queue_ditl.constraint.in_constraint.assert_not_called()
+
+    def test_validation_uses_configured_full_constraint_policy_for_pass(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = PlanEntry(config=queue_ditl.config)
+        entry.obstype = ObsType.GSP
+        entry.obsid = 0xFFFF
+        entry.station = "TRO"
+        entry.begin = 1000.0
+        entry.contact_begin = 1000.0
+        entry.contact_end = 1060.0
+        entry.end = 1060.0
+        queue_ditl.plan.append(entry)
+        queue_ditl.acs.passrequests.passes = [
+            Pass(
+                station="TRO",
+                begin=1000.0,
+                length=60.0,
+                obsid=0xFFFF,
+                utime=[1000.0],
+                ra=[10.0],
+                dec=[20.0],
+            )
+        ]
+        queue_ditl.utime = [1000.0]
+        queue_ditl.mode = [ACSMode.PASS]
+        queue_ditl.obsid = [0xFFFF]
+        queue_ditl.ra = [10.0]
+        queue_ditl.dec = [20.0]
+        queue_ditl.roll = [15.0]
+        queue_ditl.config.attitude_constraint_policy_for_mode = Mock(
+            return_value=AttitudeConstraintPolicy.FULL_MISSION
+        )
+        queue_ditl.constraint.in_constraint = Mock(return_value=True)
+        queue_ditl.constraint.in_sun = Mock(return_value=True)
+        self._index_telemetry_by_time(queue_ditl)
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any("mode PASS" in str(m) for m in mismatches)
+        assert any("Sun" in str(m) for m in mismatches)
+        assert any("full_mission" in str(m) for m in mismatches)
+        queue_ditl.constraint.in_constraint.assert_called_once_with(
+            10.0, 20.0, 1000.0, target_roll=15.0, acs_mode=ACSMode.PASS
+        )
+
+    def test_validation_fails_for_pass_hard_constraint_violation(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        entry = PlanEntry(config=queue_ditl.config)
+        entry.obstype = ObsType.GSP
+        entry.obsid = 0xFFFF
+        entry.station = "TRO"
+        entry.begin = 1000.0
+        entry.contact_begin = 1000.0
+        entry.contact_end = 1060.0
+        entry.end = 1060.0
+        queue_ditl.plan.append(entry)
+        queue_ditl.acs.passrequests.passes = [
+            Pass(
+                station="TRO",
+                begin=1000.0,
+                length=60.0,
+                obsid=0xFFFF,
+                utime=[1000.0],
+                ra=[10.0],
+                dec=[20.0],
+            )
+        ]
+        queue_ditl.utime = [1000.0]
+        queue_ditl.mode = [ACSMode.PASS]
+        queue_ditl.obsid = [0xFFFF]
+        queue_ditl.ra = [10.0]
+        queue_ditl.dec = [20.0]
+        queue_ditl.roll = [15.0]
+        queue_ditl.constraint.in_star_tracker_hard = Mock(return_value=True)
+        self._index_telemetry_by_time(queue_ditl)
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any("mode PASS" in str(m) for m in mismatches)
+        assert any("ST Hard" in str(m) for m in mismatches)
+        queue_ditl.constraint.in_star_tracker_hard.assert_called_once_with(
+            10.0, 20.0, 1000.0, target_roll=15.0, acs_mode=ACSMode.PASS
+        )
+
+    def test_validation_uses_configured_hard_policy_for_charging(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.utime = [1060.0]
+        queue_ditl.mode = [ACSMode.CHARGING]
+        queue_ditl.obsid = [999001]
+        queue_ditl.ra = [40.0]
+        queue_ditl.dec = [10.0]
+        queue_ditl.roll = [5.0]
+        queue_ditl.config.attitude_constraint_policy_for_mode = Mock(
+            return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+        )
+        queue_ditl.constraint.in_constraint = Mock(return_value=True)
+        queue_ditl.constraint.in_radiator_hard = Mock(return_value=True)
+        self._index_telemetry_by_time(queue_ditl)
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any("mode CHARGING" in str(m) for m in mismatches)
+        assert any("Radiator Hard" in str(m) for m in mismatches)
+        assert any("hard_keepout" in str(m) for m in mismatches)
+        queue_ditl.constraint.in_constraint.assert_not_called()
+
+    def test_validation_fails_for_unknown_attitude_mode(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.utime = [1000.0]
+        queue_ditl.mode = [999]
+        queue_ditl.obsid = [IDLE_OBSID]
+        queue_ditl.ra = [10.0]
+        queue_ditl.dec = [20.0]
+        queue_ditl.roll = [30.0]
+        self._index_telemetry_by_time(queue_ditl)
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any("unknown_mode" in str(m) for m in mismatches)
+        assert any("mode 999" in str(m) for m in mismatches)
+
+    @pytest.mark.parametrize(
+        "mode", [ACSMode.SLEWING, ACSMode.SAA, ACSMode.SAFE, ACSMode.IDLE]
+    )
+    def test_validation_fails_for_hard_constraint_violation_in_non_activity_modes(
+        self, queue_ditl: QueueDITL, mode: ACSMode
+    ) -> None:
+        queue_ditl.utime = [1000.0]
+        queue_ditl.mode = [mode]
+        queue_ditl.obsid = [IDLE_OBSID]
+        queue_ditl.ra = [10.0]
+        queue_ditl.dec = [20.0]
+        queue_ditl.roll = [30.0]
+        queue_ditl.constraint.in_radiator_hard = Mock(return_value=True)
+        self._index_telemetry_by_time(queue_ditl)
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any(f"mode {mode.name}" in str(m) for m in mismatches)
+        assert any("Radiator Hard" in str(m) for m in mismatches)
 
     def test_execution_coverage_uses_full_gsp_entry_window(
         self, queue_ditl: QueueDITL


### PR DESCRIPTION
## Summary
- add a pre-export validation pass over the complete executed attitude telemetry timeline
- apply the full mission constraint set in SCIENCE and CHARGING modes
- apply hard keepout constraints in PASS, SLEWING, IDLE, SAFE, and SAA so ground contacts do not inherit science Earth-limb rules
- report timestamp, mode, obsid, RA/Dec, roll, policy, and violated constraint when validation fails

The actual constraint geometry and thresholds remain config-driven. This PR only defines which constraint policy is applied to each ACS mode during export validation.

Stacked on #169. Closes #170.

## Validation
- `pytest`
- `prek run --all-files`