### PR TITLE
fix: retry equal-merit target selection

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1805,15 +1805,11 @@ class QueueDITL(DITLMixin, DITLStats):
                         target_dec=self.ppt.dec,
                     )
                     if not _valid_ranges:
-                        obsid = self.ppt.obsid
                         self.log.log_event(
                             utime=utime,
                             event_type="QUEUE",
-                            description=(
-                                f"Target {obsid} skipped - no valid roll satisfies "
-                                "all constraints at this time"
-                            ),
-                            obsid=obsid,
+                            description=f"Target {self.ppt.obsid} skipped — no valid roll satisfies all constraints at this time",
+                            obsid=self.ppt.obsid,
                             acs_mode=self.acs.acsmode,
                         )
                         self._retry_fetch_without_current_ppt(utime, ra, dec)
@@ -1855,16 +1851,15 @@ class QueueDITL(DITLMixin, DITLStats):
                     target_roll=slew.endroll,
                     acs_mode=ACSMode.SCIENCE,
                 ):
-                    obsid = self.ppt.obsid
                     self.log.log_event(
                         utime=utime,
                         event_type="QUEUE",
                         description=(
-                            f"Target {obsid} skipped - locked roll "
+                            f"Target {self.ppt.obsid} skipped — locked roll "
                             f"{slew.endroll:.1f}° violates constraint "
                             f"within minimum observation window (at t+{t_unix - obs_start_time:.0f}s)"
                         ),
-                        obsid=obsid,
+                        obsid=self.ppt.obsid,
                         acs_mode=self.acs.acsmode,
                     )
                     self._retry_fetch_without_current_ppt(utime, ra, dec)

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1805,15 +1805,18 @@ class QueueDITL(DITLMixin, DITLStats):
                         target_dec=self.ppt.dec,
                     )
                     if not _valid_ranges:
+                        obsid = self.ppt.obsid
                         self.log.log_event(
                             utime=utime,
                             event_type="QUEUE",
-                            description=f"Target {self.ppt.obsid} skipped — no valid roll satisfies all constraints at this time",
-                            obsid=self.ppt.obsid,
+                            description=(
+                                f"Target {obsid} skipped - no valid roll satisfies "
+                                "all constraints at this time"
+                            ),
+                            obsid=obsid,
                             acs_mode=self.acs.acsmode,
                         )
-                        self.ppt = None
-                        self._ppt_unavailable = True
+                        self._retry_fetch_without_current_ppt(utime, ra, dec)
                         return
 
             slew.endroll = optimum_roll(
@@ -1852,19 +1855,19 @@ class QueueDITL(DITLMixin, DITLStats):
                     target_roll=slew.endroll,
                     acs_mode=ACSMode.SCIENCE,
                 ):
+                    obsid = self.ppt.obsid
                     self.log.log_event(
                         utime=utime,
                         event_type="QUEUE",
                         description=(
-                            f"Target {self.ppt.obsid} skipped — locked roll "
+                            f"Target {obsid} skipped - locked roll "
                             f"{slew.endroll:.1f}° violates constraint "
                             f"within minimum observation window (at t+{t_unix - obs_start_time:.0f}s)"
                         ),
-                        obsid=self.ppt.obsid,
+                        obsid=obsid,
                         acs_mode=self.acs.acsmode,
                     )
-                    self.ppt = None
-                    self._ppt_unavailable = True
+                    self._retry_fetch_without_current_ppt(utime, ra, dec)
                     return
 
             # Verify slew won't overlap with a pass - check both start and end

--- a/conops/targets/target_queue.py
+++ b/conops/targets/target_queue.py
@@ -1,3 +1,4 @@
+import hashlib
 from typing import Any, cast
 
 import numpy as np
@@ -20,6 +21,7 @@ class TargetQueue:
     constraint: Constraint | None
     acs_config: AttitudeControlSystem | None
     config: MissionConfig | None
+    random_seed: int
 
     def __init__(
         self,
@@ -45,6 +47,7 @@ class TargetQueue:
         self.radiator_earth_exposure_weight = (
             config.targets.radiator_earth_exposure_weight
         )
+        self.random_seed = config.random_seed if config.random_seed is not None else 0
 
     def __getitem__(self, number: int) -> Pointing:
         return self.targets[number]
@@ -112,9 +115,21 @@ class TargetQueue:
                 target.merit = -900
                 continue
 
-        # Sort by merit (highest first). Python's sort is stable, so equal-merit
-        # targets keep the checked-in queue order instead of using random noise.
-        self.targets.sort(key=lambda x: x.merit, reverse=True)
+        self.targets.sort(
+            key=lambda target: (target.merit, self._target_tie_breaker(target)),
+            reverse=True,
+        )
+
+    def _target_tie_breaker(self, target: Pointing) -> int:
+        """Return a deterministic tie-break value for equal-merit targets."""
+        identifier = getattr(target, "obsid", None)
+        if identifier is None:
+            identifier = getattr(target, "targetid", None)
+        if identifier is None:
+            identifier = getattr(target, "name", "")
+        payload = f"{self.random_seed}:{identifier}".encode()
+        digest = hashlib.blake2b(payload, digest_size=8).digest()
+        return int.from_bytes(digest, "big")
 
     def get(
         self,

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -783,6 +783,7 @@ class TestFetchNewPPT:
         mock_ppt.slewtime = 12
         mock_ppt.slewdist = 3.0
         cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
+        queue_ditl.queue.targets = [mock_ppt]
         cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
         cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(return_value=None)
         queue_ditl.constraint.in_constraint = Mock(return_value=True)
@@ -1092,6 +1093,7 @@ class TestFetchNewPPT:
         mock_ppt.ss_min = 300.0
         mock_ppt.windows = [[0.0, 1e12]]
         cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
+        queue_ditl.queue.targets = [mock_ppt]
 
         # No blocking pass
         cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
@@ -1112,6 +1114,55 @@ class TestFetchNewPPT:
         log_text = "\n".join(event.description for event in queue_ditl.log.events)
         assert "locked roll" in log_text
         assert str(mock_ppt.obsid) in log_text
+
+    def test_fetch_ppt_retries_when_locked_roll_rejects_top_target(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Try the next candidate when downstream roll validation rejects the first."""
+        bad_ppt = Mock()
+        bad_ppt.ra = 45.0
+        bad_ppt.dec = 30.0
+        bad_ppt.obsid = 1001
+        bad_ppt.done = False
+        bad_ppt.next_vis = Mock(return_value=1000.0)
+        bad_ppt.ss_max = 3600.0
+        bad_ppt.ss_min = 300.0
+        bad_ppt.windows = [[0.0, 1e12]]
+
+        good_ppt = Mock()
+        good_ppt.ra = 46.0
+        good_ppt.dec = 31.0
+        good_ppt.obsid = 1002
+        good_ppt.done = False
+        good_ppt.next_vis = Mock(return_value=1000.0)
+        good_ppt.ss_max = 3600.0
+        good_ppt.ss_min = 300.0
+        good_ppt.windows = [[0.0, 1e12]]
+
+        targets = [bad_ppt, good_ppt]
+        queue_ditl.queue.targets = targets
+
+        def get_next_not_done(ra: float, dec: float, utime: float) -> Mock | None:
+            return next((target for target in targets if not target.done), None)
+
+        cast(Mock, queue_ditl.queue).get = Mock(side_effect=get_next_not_done)
+        cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
+        cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(return_value=None)
+        queue_ditl.constraint.in_constraint = Mock(
+            side_effect=lambda ra, *args, **kwargs: ra == bad_ppt.ra
+        )
+
+        queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        assert queue_ditl.ppt is good_ppt
+        assert bad_ppt.done is False
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_called_once()
+        command = cast(Mock, queue_ditl.acs.enqueue_command).call_args[0][0]
+        assert command.slew.obsid == good_ppt.obsid
+
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Target 1001 skipped" in log_text
+        assert "locked roll" in log_text
 
     def test_fetch_ppt_accepts_when_locked_roll_satisfies_constraint_in_window(
         self, queue_ditl

--- a/tests/target_queue/test_target_queue.py
+++ b/tests/target_queue/test_target_queue.py
@@ -88,15 +88,19 @@ class TestMeritsort:
 
         assert queue_instance.targets[-1] is invisible_target
 
-    def test_meritsort_keeps_equal_merit_order(self, queue_instance):
-        """Equal-merit targets should be deterministic."""
-        for target in queue_instance.targets:
+    def test_meritsort_uses_deterministic_equal_merit_tie_break(self, queue_instance):
+        """Equal-merit targets should not depend on original queue order."""
+        for index, target in enumerate(queue_instance.targets):
             target.fom = 100
+            target.obsid = 1000 + index
 
-        expected = list(queue_instance.targets)
+        queue_instance.meritsort()
+        expected_obsids = [target.obsid for target in queue_instance.targets]
+
+        queue_instance.targets.reverse()
         queue_instance.meritsort()
 
-        assert queue_instance.targets == expected
+        assert [target.obsid for target in queue_instance.targets] == expected_obsids
 
 
 class TestGetTarget:


### PR DESCRIPTION
## Summary
- add a seeded deterministic tie-break for equal-merit targets so ordering does not collapse to checked-in catalog order
- retry target selection in the same scheduler tick when downstream roll validation rejects the selected PPT
- cover equal-merit ordering and locked-roll retry behavior in tests

Fixes #174.

This is stacked on #164 because the regression is introduced by the deterministic scheduling change; the PR should be retargeted to main after #164 lands, or merged after it.

The repeated-obsid stale plan entry sync exposed during full Tamalpais export is intentionally left to #166.

## Validation
- pytest tests/target_queue/test_target_queue.py tests/scheduler_queue/test_queue_ditl.py -q
- pytest -q
- prek run --all-files
- representative Tamalpais in-memory run before removing the #166-overlap commit: 90 entries (72 AT, 15 CHARGE, 3 GSP), 187 locked-roll skips; full export still requires #166 for repeated-obsid plan-entry sync