### PR TITLE
fix(documentation): catch up on updates to documentation

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -155,6 +155,141 @@ Example:
 
    config = MissionConfig(name="Reproducible Run", random_seed=42)
 
+attitude_constraint_policy
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Controls which constraints are checked against the executed attitude timeline during
+post-run plan validation.
+
+.. code-block:: python
+
+   attitude_constraint_policy: dict[str, AttitudeConstraintPolicy] = <mode-specific defaults>
+
+**Background**
+
+At the end of every :meth:`~conops.ditl.queue_ditl.QueueDITL.run`, COASTSim compares
+the exported plan against the ACS telemetry it actually produced — a step called *plan
+execution validation*.  One part of that validation scans every attitude sample in the
+telemetry and checks whether the spacecraft was pointing somewhere it shouldn't have been.
+
+Not all modes are held to the same standard.  During ``SCIENCE`` mode a pointing
+violation is unambiguously a simulation bug.  During ``SLEWING`` the spacecraft is
+actively rotating between targets and may briefly sweep through a soft-constraint zone
+by design — flagging that as an error would produce false positives.  The
+``attitude_constraint_policy`` map lets you express, per ACS mode, exactly how strict
+you want that check to be.
+
+If any sample fails its policy check, a
+:class:`~conops.ditl.queue_ditl.PlanExecutionMismatch` is recorded and
+:meth:`~conops.ditl.queue_ditl.QueueDITL.run` raises
+:exc:`~conops.ditl.queue_ditl.PlanExecutionMismatchError` before returning.  The error
+message includes the first few violations — mode, obsid, RA/Dec/roll, and the constraint
+name — to aid debugging.
+
+**Hard keep-outs vs. full mission constraints**
+
+COASTSim's constraint system has two tiers:
+
+* **Full mission constraints** — the complete set of keep-outs the spacecraft must
+  respect during normal science operations: minimum Sun angle, Moon and Earth limb
+  avoidance, solar-panel illumination requirement, and the star-tracker, radiator, and
+  telescope hard constraints listed below.  Violating any of these during science would
+  degrade or invalidate the observation.
+
+* **Hard keep-outs** — a strict health-and-safety subset that must never be violated
+  regardless of mode: star tracker hard constraint (sensor blinding risk), radiator hard
+  constraint (thermal damage risk), and telescope hard constraint (structural or optical
+  damage risk).  These are always instrument-protection limits, not science-quality
+  limits.
+
+The ``HARD_KEEPOUT`` policy enforces the second tier only, which is appropriate for
+transient modes (slewing, SAA, safe) where soft science-quality limits legitimately do
+not apply.
+
+**Policy values** (:class:`~conops.config.AttitudeConstraintPolicy`):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Value
+     - Behaviour
+   * - ``"full_mission"``
+     - The complete mission constraint (Sun, Moon, Earth limb, star tracker, radiator,
+       telescope) is evaluated.  Any violation is flagged.
+   * - ``"hard_keepout"``
+     - Only the three hard keep-outs are checked: star tracker hard constraint,
+       radiator hard constraint, and telescope hard constraint.  Science-quality soft
+       constraints (Sun angle, Moon, Earth limb, etc.) are intentionally ignored.
+   * - ``"none"``
+     - No constraint checking is performed for this mode.  Use this when the mode
+       genuinely has no pointing restrictions (rare) or when you need to suppress
+       false positives during development.
+
+**Default policy per ACS mode:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - ACS Mode
+     - Default Policy
+     - Rationale
+   * - ``SCIENCE``
+     - ``full_mission``
+     - Science observations must satisfy all pointing constraints.
+   * - ``CHARGING``
+     - ``full_mission``
+     - Emergency charging still obeys the full mission keep-out.
+   * - ``SLEWING``
+     - ``hard_keepout``
+     - Slews may briefly sweep through soft-constraint zones by design; hard
+       health-and-safety limits are still enforced.
+   * - ``PASS``
+     - ``hard_keepout``
+     - Ground-station tracking may transit soft zones during the arc; hard limits apply.
+   * - ``SAA``
+     - ``hard_keepout``
+     - SAA transits relax science constraints but not instrument-protection limits.
+   * - ``SAFE``
+     - ``hard_keepout``
+     - Safe-mode pointing relaxes science constraints but not instrument-protection limits.
+   * - ``IDLE``
+     - ``hard_keepout``
+     - Idle attitude relaxes science constraints but not instrument-protection limits.
+
+**Overriding the policy for individual modes:**
+
+Pass a partial dict — only the modes you specify are overridden; all others keep their
+defaults.  Keys can be :class:`~conops.common.ACSMode` enum members, their integer
+values, or their string names.
+
+.. code-block:: python
+
+   from conops.config import MissionConfig, AttitudeConstraintPolicy
+   from conops.common import ACSMode
+
+   config = MissionConfig(
+       attitude_constraint_policy={
+           # Relax SLEWING to no check when using a separate, less restrictive
+           # slew constraint already enforced by the ACS slew algorithm.
+           ACSMode.SLEWING: AttitudeConstraintPolicy.NONE,
+           # Promote SAFE mode to full validation for a strict mission context.
+           "SAFE": AttitudeConstraintPolicy.FULL_MISSION,
+       }
+   )
+
+**YAML configuration:**
+
+When loading a config from YAML, use the mode name string as the key and the policy
+string as the value.  Omitted modes retain their defaults.
+
+.. code-block:: yaml
+
+   attitude_constraint_policy:
+     SLEWING: none
+     SAFE: full_mission
+
 spacecraft_bus
 ~~~~~~~~~~~~~~
 
@@ -1211,6 +1346,7 @@ API Reference
 For detailed API documentation, see:
 
 * :class:`~conops.config.MissionConfig`
+* :class:`~conops.config.AttitudeConstraintPolicy`
 * :class:`~conops.config.SpacecraftBus`
 * :class:`~conops.config.SolarPanelSet`
 * :class:`~conops.config.SolarPanel`

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -131,6 +131,30 @@ Example:
 
    config = MissionConfig(name="STROBE-X Observatory")
 
+random_seed
+~~~~~~~~~~~
+
+An optional integer seed for stochastic planning decisions.
+
+.. code-block:: python
+
+   random_seed: int | None = None
+
+When set, COASTSim uses this value to seed the random-number generators that break
+scheduling ties and select ground-station pass opportunities.  Identical seeds produce
+identical plans across runs with the same inputs, making simulation results reproducible
+and regression-testable.
+
+When ``None`` (the default), system-time entropy is used, so each run may produce
+different orderings when targets have equal merit or multiple ground stations are visible
+simultaneously.
+
+Example:
+
+.. code-block:: python
+
+   config = MissionConfig(name="Reproducible Run", random_seed=42)
+
 spacecraft_bus
 ~~~~~~~~~~~~~~
 

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -169,6 +169,11 @@ Metadata Fields
    * - ``num_entries``
      - int
      - Total number of entries in the file.
+   * - ``attitude_timeseries_file``
+     - string | null
+     - Filename (no path) of the sibling attitude-timeseries JSON file written alongside
+       this plan, or ``null`` / absent when no timeseries was exported.
+       See :ref:`attitude-timeseries` for the file format.
 
 Entry Fields
 ~~~~~~~~~~~~
@@ -238,7 +243,9 @@ Entry Fields
      - ``true`` if the observation completed successfully.
    * - ``exposure``
      - int
-     - Net science exposure time: ``end − begin − slewtime − insaa`` (seconds).
+     - Net science exposure time in seconds. For ``AT``/``PPT``/``TOO`` entries:
+       ``end − begin − slewtime − insaa``. For ``GSP`` entries: the actual downlink
+       contact duration, computed as ``contact_end − max(contact_begin, begin)``.
    * - ``station``
      - string | null
      - Ground station code for ``GSP`` (Ground Station Pass) entries. Only present for
@@ -340,6 +347,162 @@ scans the directory for existing files matching
 (or ``0`` if no matching files exist).  Saving to an explicit file path
 leaves ``version`` unchanged.
 
+.. _attitude-timeseries:
+
+Attitude Timeseries
+~~~~~~~~~~~~~~~~~~~
+
+Both :class:`~conops.ditl.ditl.DITL` and :class:`~conops.ditl.queue_ditl.QueueDITL`
+automatically attach the executed spacecraft attitude timeline to the plan at the end of
+``calc()``/``run()``.  When the plan is then saved, this timeseries is written to a sibling
+JSON file alongside the main plan file.
+
+**File naming**: the sibling file is placed in the same directory as the plan and named
+``<plan_stem>_attitude_timeseries.json``.  For example, if the plan is saved as
+``plan_20251201T000000Z_20251201T235900Z_v3.json`` the attitude file is
+``plan_20251201T000000Z_20251201T235900Z_v3_attitude_timeseries.json``.
+
+The plan file records the sibling filename in the ``attitude_timeseries_file`` metadata
+field so that consumers can locate it without scanning the directory.
+
+**Attitude Timeseries File Format**
+
+.. code-block:: json
+
+   {
+     "version": 0,
+     "coast_sim_version": "0.6.1",
+     "created_at": "2025-12-01T00:00:00+00:00",
+     "plan_file": "plan_20251201T000000Z_20251201T235900Z_v3.json",
+     "plan_version": 3,
+     "plan_start": "2025-12-01T00:00:00+00:00",
+     "plan_end": "2025-12-01T23:59:00+00:00",
+     "num_samples": 2,
+     "samples": [
+       {
+         "utime": 1748736000.0,
+         "timestamp": "2025-12-01T00:00:00+00:00",
+         "ra": 83.82,
+         "dec": -5.39,
+         "roll": 0.0,
+         "mode": "SCIENCE",
+         "obsid": 1001,
+         "quat_w": 0.9998,
+         "quat_x": 0.0050,
+         "quat_y": -0.0120,
+         "quat_z": 0.0150
+       },
+       {
+         "utime": 1748736060.0,
+         "timestamp": "2025-12-01T00:01:00+00:00",
+         "ra": 83.82,
+         "dec": -5.39,
+         "roll": 0.0,
+         "mode": "SCIENCE",
+         "obsid": 1001,
+         "quat_w": 0.9998,
+         "quat_x": 0.0051,
+         "quat_y": -0.0121,
+         "quat_z": 0.0151
+       }
+     ]
+   }
+
+**Attitude Timeseries Metadata Fields**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Field
+     - Type
+     - Description
+   * - ``version``
+     - int
+     - Schema format version (currently always ``0``).
+   * - ``coast_sim_version``
+     - string
+     - COASTSim package version that produced the file.
+   * - ``created_at``
+     - string
+     - ISO-8601 UTC timestamp of when the file was created.
+   * - ``plan_file``
+     - string | null
+     - Filename of the associated plan JSON file.
+   * - ``plan_version``
+     - int | null
+     - ``version`` value of the associated plan.
+   * - ``plan_start``
+     - string | null
+     - ISO-8601 UTC timestamp matching the plan's ``start`` field.
+   * - ``plan_end``
+     - string | null
+     - ISO-8601 UTC timestamp matching the plan's ``end`` field.
+   * - ``num_samples``
+     - int
+     - Number of attitude samples in ``samples``.
+
+**Attitude Sample Fields**
+
+Each element of ``samples`` is an :class:`~conops.targets.plan_schema.AttitudeSampleSchema`:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 15 70
+
+   * - Field
+     - Type
+     - Description
+   * - ``utime``
+     - float
+     - Unix timestamp (seconds since epoch, UTC).
+   * - ``timestamp``
+     - string
+     - ISO-8601 UTC timestamp — human-readable form of ``utime``.
+   * - ``ra``
+     - float | null
+     - Right ascension of the spacecraft boresight in degrees (J2000).
+   * - ``dec``
+     - float | null
+     - Declination of the spacecraft boresight in degrees (J2000).
+   * - ``roll``
+     - float | null
+     - Spacecraft roll angle in degrees.
+   * - ``mode``
+     - string | null
+     - ACS mode name at this sample (e.g. ``"SCIENCE"``, ``"SLEWING"``, ``"PASS"``).
+   * - ``obsid``
+     - int | null
+     - Observation ID active at this sample.
+   * - ``quat_w``
+     - float | null
+     - Spacecraft attitude quaternion W component.
+   * - ``quat_x``
+     - float | null
+     - Spacecraft attitude quaternion X component.
+   * - ``quat_y``
+     - float | null
+     - Spacecraft attitude quaternion Y component.
+   * - ``quat_z``
+     - float | null
+     - Spacecraft attitude quaternion Z component.
+
+**Loading the Attitude Timeseries**
+
+.. code-block:: python
+
+   from conops.targets import PlanSchema, AttitudeTimeseriesSchema
+   from pathlib import Path
+
+   schema = PlanSchema.load("plan_20251201T000000Z_20251201T235900Z_v3.json")
+
+   if schema.attitude_timeseries_file:
+       plan_dir = Path("plan_20251201T000000Z_20251201T235900Z_v3.json").parent
+       timeseries_path = plan_dir / schema.attitude_timeseries_file
+       raw = __import__("json").loads(timeseries_path.read_text())
+       timeseries = AttitudeTimeseriesSchema.model_validate(raw)
+       print(f"Loaded {timeseries.num_samples} attitude samples")
+
 Backward Compatibility
 ----------------------
 
@@ -372,6 +535,16 @@ API Reference
    :show-inheritance:
 
 .. autoclass:: conops.targets.plan_schema.PlanSchema
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: conops.targets.plan_schema.AttitudeTimeseriesSchema
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: conops.targets.plan_schema.AttitudeSampleSchema
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -58,6 +58,12 @@ Housekeeping Fields
    - ``ra``: Right ascension in degrees
    - ``dec``: Declination in degrees
    - ``roll``: Roll angle in degrees
+   - ``roll_offset_deg``: Signed offset from the solar-optimal roll in degrees (range
+     [-180, 180)); meaningful only during SCIENCE mode.
+   - ``quat_w``: Attitude quaternion scalar component (w)
+   - ``quat_x``: Attitude quaternion vector component (x)
+   - ``quat_y``: Attitude quaternion vector component (y)
+   - ``quat_z``: Attitude quaternion vector component (z)
 
 **ACS State**
    - ``acs_mode``: Current ACS mode (SCIENCE, SLEWING, SAFE, SAA, etc.)
@@ -87,11 +93,6 @@ Housekeeping Fields
    - ``for_solid_angle_sr``: Instantaneous field-of-regard solid angle in steradians.
      This value is optional and is ``None`` unless FOR calculation is enabled.
    - ``in_eclipse``: Whether spacecraft is in eclipse
-
-**Star Tracker Health**
-   - ``star_tracker_hard_violations``: Number of trackers violating their hard constraint
-   - ``star_tracker_soft_violations``: Whether any tracker is in its soft constraint zone
-   - ``star_tracker_functional_count``: Number of hard-constraint-clear trackers
 
 **Star Tracker and Radiator State**
    - ``star_tracker_hard_violations``: Number of star trackers in hard keep-out zones


### PR DESCRIPTION
This pull request updates the documentation for COASTSim's configuration, plan serialization, and telemetry output. The changes introduce new configuration options for reproducibility and constraint validation, add detailed documentation for the new attitude timeseries file format, clarify plan entry fields, and expand telemetry field descriptions.

The most important changes are:

**Configuration Improvements:**
* Added documentation for the optional `random_seed` parameter in `MissionConfig`, which enables reproducible simulation runs by seeding stochastic planning decisions.
* Introduced and documented the `attitude_constraint_policy` option in `MissionConfig`, allowing users to control constraint enforcement per ACS mode during plan execution validation. Includes policy values, defaults, and YAML usage examples.
* Included `AttitudeConstraintPolicy` in the API reference list for discoverability.

**Plan Serialization Enhancements:**
* Added the `attitude_timeseries_file` metadata field to the plan file, indicating the name of the sibling attitude timeseries JSON file if present.
* Documented the new attitude timeseries file format, including naming conventions, metadata fields, sample structure, and Python loading example.
* Clarified the meaning of the `exposure` field for different plan entry types (`AT`/`PPT`/`TOO` vs. `GSP`).
* Added API documentation for `AttitudeTimeseriesSchema` and `AttitudeSampleSchema` classes.

**Telemetry Documentation Updates:**
* Expanded the list of housekeeping fields to include quaternion components and `roll_offset_deg`.
* Clarified and reorganized the documentation for star tracker and radiator state fields.