### PR TITLE
fix: track GSP contacts with configured antenna vector

### DIFF
--- a/conops/common/__init__.py
+++ b/conops/common/__init__.py
@@ -17,7 +17,10 @@ from .enums import (
 )
 from .vector import (
     angular_separation,
+    attitude_for_body_vector_tracking,
+    attitude_from_body_axes,
     attitude_to_quat,
+    body_vector_to_eci,
     constraint_avoiding_waypoint,
     great_circle,
     quat_slerp,
@@ -39,7 +42,10 @@ __all__ = [
     "Polarization",
     "SlewAlgorithm",
     "angular_separation",
+    "attitude_for_body_vector_tracking",
+    "attitude_from_body_axes",
     "attitude_to_quat",
+    "body_vector_to_eci",
     "constraint_avoiding_waypoint",
     "dtutcfromtimestamp",
     "givename",

--- a/conops/common/vector.py
+++ b/conops/common/vector.py
@@ -194,6 +194,140 @@ def normal_to_euler_deg(
     return 0.0, pitch_deg, yaw_deg
 
 
+def _unit_vector(
+    vector: tuple[float, float, float] | npt.NDArray[np.float64], name: str
+) -> npt.NDArray[np.float64]:
+    arr = np.asarray(vector, dtype=np.float64)
+    norm = float(np.linalg.norm(arr))
+    if norm < 1e-12:
+        raise ValueError(f"{name} must be non-zero")
+    return arr / norm
+
+
+def _perpendicular_reference(
+    axis: npt.NDArray[np.float64],
+    preferred: tuple[float, float, float] | npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    for candidate in (
+        preferred,
+        (0.0, 0.0, 1.0),
+        (0.0, 1.0, 0.0),
+        (1.0, 0.0, 0.0),
+    ):
+        ref = _unit_vector(candidate, "reference vector")
+        projected = ref - float(np.dot(ref, axis)) * axis
+        norm = float(np.linalg.norm(projected))
+        if norm >= 1e-12:
+            return projected / norm
+    raise ValueError("could not find a reference vector perpendicular to axis")
+
+
+def attitude_from_body_axes(
+    body_x_eci: tuple[float, float, float] | npt.NDArray[np.float64],
+    body_z_eci: tuple[float, float, float] | npt.NDArray[np.float64],
+) -> tuple[float, float, float]:
+    """Convert body +X/+Z inertial axes to RA, Dec, and roll in degrees."""
+
+    x_axis = _unit_vector(body_x_eci, "body_x_eci")
+    z_axis_raw = _unit_vector(body_z_eci, "body_z_eci")
+    z_axis = z_axis_raw - float(np.dot(z_axis_raw, x_axis)) * x_axis
+    z_axis = _unit_vector(z_axis, "body_z_eci projected perpendicular to body_x_eci")
+
+    ra_rad, dec_rad = vec2radec(x_axis)
+
+    north = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    n_proj = north - float(np.dot(north, x_axis)) * x_axis
+    n_norm = float(np.linalg.norm(n_proj))
+    if n_norm < 1e-10:
+        north = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+        n_proj = north - float(np.dot(north, x_axis)) * x_axis
+        n_norm = float(np.linalg.norm(n_proj))
+    n_hat = n_proj / n_norm
+    y_hat = np.cross(n_hat, x_axis)
+    roll_rad = float(np.arctan2(np.dot(z_axis, y_hat), np.dot(z_axis, n_hat)))
+    roll_deg = float(np.rad2deg(roll_rad) % 360.0)
+    if abs(roll_deg - 360.0) < 1e-9:
+        roll_deg = 0.0
+
+    return (
+        float(np.rad2deg(ra_rad)),
+        float(np.rad2deg(dec_rad)),
+        roll_deg,
+    )
+
+
+def body_vector_to_eci(
+    ra_deg: float,
+    dec_deg: float,
+    roll_deg: float,
+    body_vector: tuple[float, float, float] | npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    """Return a body-frame vector expressed in ECI for an RA/Dec/roll attitude.
+
+    This is the inverse of the ``scbodyvector`` body-frame transform.
+    """
+
+    x_hat = radec2vec(np.deg2rad(ra_deg), np.deg2rad(dec_deg))
+    ref = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    y0 = np.cross(ref, x_hat)
+    if np.linalg.norm(y0) < 1e-12:
+        y0 = np.cross(np.array([0.0, 1.0, 0.0], dtype=np.float64), x_hat)
+    y0 = vecnorm(y0)
+    z0 = vecnorm(np.cross(x_hat, y0))
+
+    roll_rad = np.deg2rad(roll_deg)
+    c = np.cos(roll_rad)
+    s = np.sin(roll_rad)
+    y_hat = y0 * c - z0 * s
+    z_hat = y0 * s + z0 * c
+
+    body = _unit_vector(body_vector, "body_vector")
+    result: npt.NDArray[np.float64] = np.asarray(
+        body[0] * x_hat + body[1] * y_hat + body[2] * z_hat,
+        dtype=np.float64,
+    )
+    return result
+
+
+def attitude_for_body_vector_tracking(
+    body_vector: tuple[float, float, float] | npt.NDArray[np.float64],
+    target_eci: tuple[float, float, float] | npt.NDArray[np.float64],
+    *,
+    reference_body: tuple[float, float, float] | npt.NDArray[np.float64] = (
+        0.0,
+        0.0,
+        1.0,
+    ),
+    reference_eci: tuple[float, float, float] | npt.NDArray[np.float64] = (
+        0.0,
+        0.0,
+        1.0,
+    ),
+) -> tuple[float, float, float]:
+    """Return RA/Dec/roll that points ``body_vector`` at ``target_eci``.
+
+    The remaining rotation about ``target_eci`` is chosen by keeping
+    ``reference_body`` as close as possible to ``reference_eci`` after both are
+    projected perpendicular to the tracking axis.
+    """
+
+    body_axis = _unit_vector(body_vector, "body_vector")
+    target_axis = _unit_vector(target_eci, "target_eci")
+
+    body_ref = _perpendicular_reference(body_axis, reference_body)
+    eci_ref = _perpendicular_reference(target_axis, reference_eci)
+
+    body_cross = np.cross(body_axis, body_ref)
+    eci_cross = np.cross(target_axis, eci_ref)
+    body_basis = np.column_stack((body_axis, body_ref, body_cross))
+    eci_basis = np.column_stack((target_axis, eci_ref, eci_cross))
+
+    body_to_eci = eci_basis @ body_basis.T
+    body_x_eci = body_to_eci[:, 0]
+    body_z_eci = body_to_eci[:, 2]
+    return attitude_from_body_axes(body_x_eci, body_z_eci)
+
+
 # ---------------------------------------------------------------------------
 # Quaternion utilities
 # ---------------------------------------------------------------------------

--- a/conops/common/vector.py
+++ b/conops/common/vector.py
@@ -194,55 +194,54 @@ def normal_to_euler_deg(
     return 0.0, pitch_deg, yaw_deg
 
 
-def _unit_vector(
-    vector: tuple[float, float, float] | npt.NDArray[np.float64], name: str
-) -> npt.NDArray[np.float64]:
+def _unit_vector_or_none(
+    vector: tuple[float, float, float] | npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64] | None:
     arr = np.asarray(vector, dtype=np.float64)
     norm = float(np.linalg.norm(arr))
     if norm < 1e-12:
-        raise ValueError(f"{name} must be non-zero")
+        return None
     return arr / norm
 
 
 def _perpendicular_reference(
     axis: npt.NDArray[np.float64],
     preferred: tuple[float, float, float] | npt.NDArray[np.float64],
-) -> npt.NDArray[np.float64]:
+) -> npt.NDArray[np.float64] | None:
     for candidate in (
         preferred,
         (0.0, 0.0, 1.0),
         (0.0, 1.0, 0.0),
         (1.0, 0.0, 0.0),
     ):
-        ref = _unit_vector(candidate, "reference vector")
+        ref = _unit_vector_or_none(candidate)
+        if ref is None:
+            continue
         projected = ref - float(np.dot(ref, axis)) * axis
-        norm = float(np.linalg.norm(projected))
-        if norm >= 1e-12:
-            return projected / norm
-    raise ValueError("could not find a reference vector perpendicular to axis")
+        projected_unit = _unit_vector_or_none(projected)
+        if projected_unit is not None:
+            return projected_unit
+    return None
 
 
 def attitude_from_body_axes(
     body_x_eci: tuple[float, float, float] | npt.NDArray[np.float64],
     body_z_eci: tuple[float, float, float] | npt.NDArray[np.float64],
-) -> tuple[float, float, float]:
+) -> tuple[float, float, float] | None:
     """Convert body +X/+Z inertial axes to RA, Dec, and roll in degrees."""
 
-    x_axis = _unit_vector(body_x_eci, "body_x_eci")
-    z_axis_raw = _unit_vector(body_z_eci, "body_z_eci")
-    z_axis = z_axis_raw - float(np.dot(z_axis_raw, x_axis)) * x_axis
-    z_axis = _unit_vector(z_axis, "body_z_eci projected perpendicular to body_x_eci")
+    x_axis = _unit_vector_or_none(body_x_eci)
+    if x_axis is None:
+        return None
+    z_axis = _perpendicular_reference(x_axis, body_z_eci)
+    if z_axis is None:
+        return None
 
     ra_rad, dec_rad = vec2radec(x_axis)
 
-    north = np.array([0.0, 0.0, 1.0], dtype=np.float64)
-    n_proj = north - float(np.dot(north, x_axis)) * x_axis
-    n_norm = float(np.linalg.norm(n_proj))
-    if n_norm < 1e-10:
-        north = np.array([1.0, 0.0, 0.0], dtype=np.float64)
-        n_proj = north - float(np.dot(north, x_axis)) * x_axis
-        n_norm = float(np.linalg.norm(n_proj))
-    n_hat = n_proj / n_norm
+    n_hat = _perpendicular_reference(x_axis, (0.0, 0.0, 1.0))
+    if n_hat is None:
+        return None
     y_hat = np.cross(n_hat, x_axis)
     roll_rad = float(np.arctan2(np.dot(z_axis, y_hat), np.dot(z_axis, n_hat)))
     roll_deg = float(np.rad2deg(roll_rad) % 360.0)
@@ -261,7 +260,7 @@ def body_vector_to_eci(
     dec_deg: float,
     roll_deg: float,
     body_vector: tuple[float, float, float] | npt.NDArray[np.float64],
-) -> npt.NDArray[np.float64]:
+) -> npt.NDArray[np.float64] | None:
     """Return a body-frame vector expressed in ECI for an RA/Dec/roll attitude.
 
     This is the inverse of the ``scbodyvector`` body-frame transform.
@@ -281,7 +280,9 @@ def body_vector_to_eci(
     y_hat = y0 * c - z0 * s
     z_hat = y0 * s + z0 * c
 
-    body = _unit_vector(body_vector, "body_vector")
+    body = _unit_vector_or_none(body_vector)
+    if body is None:
+        return None
     result: npt.NDArray[np.float64] = np.asarray(
         body[0] * x_hat + body[1] * y_hat + body[2] * z_hat,
         dtype=np.float64,
@@ -303,7 +304,7 @@ def attitude_for_body_vector_tracking(
         0.0,
         1.0,
     ),
-) -> tuple[float, float, float]:
+) -> tuple[float, float, float] | None:
     """Return RA/Dec/roll that points ``body_vector`` at ``target_eci``.
 
     The remaining rotation about ``target_eci`` is chosen by keeping
@@ -311,11 +312,15 @@ def attitude_for_body_vector_tracking(
     projected perpendicular to the tracking axis.
     """
 
-    body_axis = _unit_vector(body_vector, "body_vector")
-    target_axis = _unit_vector(target_eci, "target_eci")
+    body_axis = _unit_vector_or_none(body_vector)
+    target_axis = _unit_vector_or_none(target_eci)
+    if body_axis is None or target_axis is None:
+        return None
 
     body_ref = _perpendicular_reference(body_axis, reference_body)
     eci_ref = _perpendicular_reference(target_axis, reference_eci)
+    if body_ref is None or eci_ref is None:
+        return None
 
     body_cross = np.cross(body_axis, body_ref)
     eci_cross = np.cross(target_axis, eci_ref)

--- a/conops/config/communications.py
+++ b/conops/config/communications.py
@@ -1,5 +1,6 @@
 """Communications system configuration for spacecraft downlink and uplink."""
 
+import warnings
 from typing import Any, Literal
 
 from pydantic import Field, field_validator, model_validator
@@ -100,6 +101,19 @@ class AntennaPointing(ConfigModel):
                 f"Fixed antenna boresight must be a unit vector. Got magnitude {magnitude}"
             )
         return v
+
+    @model_validator(mode="after")
+    def warn_legacy_azimuth_elevation(self) -> "AntennaPointing":
+        if self.fixed_azimuth_deg != 0.0 or self.fixed_elevation_deg != 0.0:
+            warnings.warn(
+                "AntennaPointing.fixed_azimuth_deg and fixed_elevation_deg are "
+                "legacy metadata fields and no longer affect GSP attitude "
+                "generation. Set fixed_boresight_body explicitly to the desired "
+                "body-frame unit vector.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return self
 
 
 class CommunicationsSystem(ConfigModel):

--- a/conops/config/communications.py
+++ b/conops/config/communications.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Literal
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from ..common.enums import AntennaType, Polarization
 from ._base import ConfigModel
@@ -61,15 +61,22 @@ class AntennaPointing(ConfigModel):
     )
 
     # Fixed antenna pointing (body-fixed direction)
+    fixed_boresight_body: tuple[float, float, float] = Field(
+        default=(-1.0, 0.0, 0.0),
+        description=(
+            "Fixed antenna boresight as a unit vector in spacecraft body frame. "
+            "Default -X preserves the legacy ground-station-pass convention."
+        ),
+    )
     fixed_azimuth_deg: float = Field(
         default=0.0,
-        description="Azimuth angle in spacecraft body frame (deg). 0=nadir, 180=zenith",
+        description="Legacy fixed antenna azimuth metadata (deg)",
         ge=0.0,
         le=360.0,
     )
     fixed_elevation_deg: float = Field(
         default=0.0,
-        description="Elevation angle in spacecraft body frame (deg)",
+        description="Legacy fixed antenna elevation metadata (deg)",
         ge=-90.0,
         le=90.0,
     )
@@ -82,13 +89,17 @@ class AntennaPointing(ConfigModel):
         le=180.0,
     )
 
-    def is_nadir_pointing(self) -> bool:
-        """Check if antenna is nadir-pointing (opposite of telescope)."""
-        return (
-            self.antenna_type == AntennaType.FIXED
-            and self.fixed_azimuth_deg == 0.0
-            and self.fixed_elevation_deg == 0.0
-        )
+    @field_validator("fixed_boresight_body")
+    @classmethod
+    def validate_fixed_boresight_body(
+        cls, v: tuple[float, float, float]
+    ) -> tuple[float, float, float]:
+        magnitude = sum(component * component for component in v) ** 0.5
+        if magnitude < 0.99 or magnitude > 1.01:
+            raise ValueError(
+                f"Fixed antenna boresight must be a unit vector. Got magnitude {magnitude}"
+            )
+        return v
 
 
 class CommunicationsSystem(ConfigModel):

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -21,7 +21,7 @@ from ..common.vector import attitude_to_quat
 from ..config import DAY_SECONDS, AttitudeConstraintPolicy, MissionConfig
 from ..simulation.acs_command import ACSCommand
 from ..simulation.emergency_charging import EmergencyCharging
-from ..simulation.passes import GSP_TRACK_ROLL, Pass, pass_slew_trigger_buffer
+from ..simulation.passes import Pass, pass_slew_trigger_buffer
 from ..simulation.roll import optimum_roll
 from ..simulation.slew import Slew
 from ..targets import Plan, PlanEntry, Pointing, Queue
@@ -976,16 +976,23 @@ class QueueDITL(DITLMixin, DITLStats):
             if missing_profile:
                 continue
             assert gspass is not None
-            expected_ra, expected_dec = gspass.ra_dec(utime)
+            expected_ra, expected_dec, expected_roll = gspass.attitude_at(utime)
             if expected_ra is None or expected_dec is None:
                 continue
 
-            error_deg = angular_separation(
-                float(self.ra[i]),
-                float(self.dec[i]),
-                float(expected_ra),
-                float(expected_dec),
+            actual_quat = attitude_to_quat(
+                float(self.ra[i]), float(self.dec[i]), float(self.roll[i])
             )
+            expected_quat = attitude_to_quat(
+                float(expected_ra), float(expected_dec), float(expected_roll)
+            )
+            dot = min(1.0, abs(float(np.dot(actual_quat, expected_quat))))
+            error_deg = float(np.rad2deg(2.0 * np.arccos(dot)))
+            antenna_error = gspass.antenna_pointing_error(
+                float(self.ra[i]), float(self.dec[i]), float(self.roll[i]), utime
+            )
+            if antenna_error is not None:
+                error_deg = max(error_deg, antenna_error)
             if error_deg > tolerance_deg:
                 mismatches.append(
                     self._pointing_mismatch(entry, utime, error_deg, "contact")
@@ -1208,6 +1215,7 @@ class QueueDITL(DITLMixin, DITLStats):
             entry.begin = int(slew.slewstart)
             entry.slewtime = int(round(slew.slewtime))
             entry.slewdist = float(slew.slewdist)
+            entry.roll = float(slew.endroll)
 
     def _sync_slew_metadata(self, slew: Slew) -> None:
         if slew.obstype == ObsType.GSP:
@@ -1445,6 +1453,7 @@ class QueueDITL(DITLMixin, DITLStats):
         entry.name = f"{station}_PASS"
         entry.ra = gspass.gsstartra
         entry.dec = gspass.gsstartdec
+        entry.roll = gspass.gsstartroll
         entry.begin = reserved_begin
         entry.end = pass_end
         entry.slewtime = (
@@ -1465,8 +1474,10 @@ class QueueDITL(DITLMixin, DITLStats):
         entry.contact_end = pass_end
         entry.track_start_ra = gspass.gsstartra
         entry.track_start_dec = gspass.gsstartdec
+        entry.track_start_roll = gspass.gsstartroll
         entry.track_end_ra = gspass.gsendra
         entry.track_end_dec = gspass.gsenddec
+        entry.track_end_roll = gspass.gsendroll
 
         self.plan.append(entry)
         if slew is not None:
@@ -1584,7 +1595,7 @@ class QueueDITL(DITLMixin, DITLStats):
             slew.slewstart = utime
             slew.endra = next_pass.gsstartra
             slew.enddec = next_pass.gsstartdec
-            slew.endroll = GSP_TRACK_ROLL
+            slew.endroll = next_pass.gsstartroll
             slew.obstype = ObsType.GSP  # Ground Station Pass slew
             slew.obsid = next_pass.obsid
             slew.calc_slewtime()

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -657,6 +657,8 @@ class ACS:
             return optimum_roll(
                 self.ra, self.dec, utime, self.ephem, self.solar_panel, self.constraint
             )
+        if self.current_pass is not None and self.current_pass.in_pass(utime):
+            return self.current_pass.roll_at(utime)
         if (
             self.last_slew is not None
             and isinstance(self.last_slew, Slew)

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -910,7 +910,9 @@ class ACS:
             self._calculate_safe_mode_pointing(utime)
         # If we are in a groundstations pass
         elif self.current_pass is not None:
-            self.ra, self.dec = self.current_pass.ra_dec(utime)  # type: ignore[assignment]
+            pass_ra, pass_dec = self.current_pass.ra_dec(utime)
+            if pass_ra is not None and pass_dec is not None:
+                self.ra, self.dec = pass_ra, pass_dec
         # If we are actively slewing
         elif self.last_slew is not None:
             self.ra, self.dec = self.last_slew.ra_dec(utime)

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -467,13 +467,13 @@ class PassTimes:
         rate = self._station_downlink_rate_mbps(gspass)
         return (rate * gspass.length, gspass.length, -gspass.begin)
 
-    def _gsp_antenna_boresight_body(self) -> tuple[float, float, float]:
+    def _gsp_antenna_boresight_body(self) -> tuple[float, float, float] | None:
         communications = getattr(self.config.spacecraft_bus, "communications", None)
         if communications is None:
             return LEGACY_GSP_ANTENNA_BODY_VECTOR
         antenna = communications.antenna_pointing
         if antenna.antenna_type != AntennaType.FIXED:
-            return LEGACY_GSP_ANTENNA_BODY_VECTOR
+            return None
         boresight = antenna.fixed_boresight_body
         return (float(boresight[0]), float(boresight[1]), float(boresight[2]))
 
@@ -603,6 +603,8 @@ class PassTimes:
                         target_vectors = -gs_to_sat_unit[start_idx:end_idx]
                         target_ra, target_dec = np.degrees(vec2radec(target_vectors.T))
                         antenna_boresight = self._gsp_antenna_boresight_body()
+                        if antenna_boresight is None:
+                            continue
                         attitude_profile: list[tuple[float, float, float]] = []
                         profile_valid = True
                         for target_vector in target_vectors:

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -122,11 +122,11 @@ class Pass(BaseModel):
     def ra_dec(self, utime: float) -> tuple[float | None, float | None]:
         """Return the RA/Dec of the spacecraft during a groundstation pass.
         Note: If utime is outside the pass, returns the earliest or latest
-        RA/Dec in the pass."""
+        RA/Dec in the pass. If no profile is available, returns None values."""
 
         idx = self._profile_index(utime)
         if idx is None:
-            return self.gsstartra, self.gsstartdec
+            return None, None
         return self.ra[idx], self.dec[idx]
 
     def roll_at(self, utime: float) -> float:
@@ -270,6 +270,8 @@ class Pass(BaseModel):
         antenna_vec = body_vector_to_eci(
             spacecraft_ra, spacecraft_dec, roll, self.antenna_boresight_body
         )
+        if antenna_vec is None:
+            return None
         target_vec = radec2vec(target_ra * DTOR, target_dec * DTOR)
         dot = float(np.dot(antenna_vec, target_vec))
         dot = float(np.clip(dot, -1.0, 1.0))
@@ -601,12 +603,18 @@ class PassTimes:
                         target_vectors = -gs_to_sat_unit[start_idx:end_idx]
                         target_ra, target_dec = np.degrees(vec2radec(target_vectors.T))
                         antenna_boresight = self._gsp_antenna_boresight_body()
-                        attitude_profile = [
-                            attitude_for_body_vector_tracking(
+                        attitude_profile: list[tuple[float, float, float]] = []
+                        profile_valid = True
+                        for target_vector in target_vectors:
+                            attitude = attitude_for_body_vector_tracking(
                                 antenna_boresight, target_vector
                             )
-                            for target_vector in target_vectors
-                        ]
+                            if attitude is None:
+                                profile_valid = False
+                                break
+                            attitude_profile.append(attitude)
+                        if not profile_valid or not attitude_profile:
+                            continue
                         track_ra = [attitude[0] for attitude in attitude_profile]
                         track_dec = [attitude[1] for attitude in attitude_profile]
                         track_roll = [attitude[2] for attitude in attitude_profile]

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -8,13 +8,21 @@ from pydantic import BaseModel, Field
 
 from ..common import ics_date_conv, unixtime2date
 from ..common.enums import AntennaType, ObsType
-from ..common.vector import radec2vec, rotvec, separation, vec2radec
+from ..common.vector import (
+    attitude_for_body_vector_tracking,
+    body_vector_to_eci,
+    radec2vec,
+    rotvec,
+    separation,
+    vec2radec,
+)
 from ..config import Constraint, GroundStationRegistry, MissionConfig
 from ..config.constants import DTOR
 from .slew import Slew
 
-# Current ground-pass model tracks RA/Dec while holding a fixed roll.
+# Legacy ground-pass roll for profiles without explicit roll samples.
 GSP_TRACK_ROLL = 0.0
+LEGACY_GSP_ANTENNA_BODY_VECTOR = (-1.0, 0.0, 0.0)
 
 
 def pass_slew_trigger_buffer(step_size: float) -> float:
@@ -54,15 +62,21 @@ class Pass(BaseModel):
     obstype: ObsType = ObsType.GSP
 
     # Ground station pointing vectors (start/end of contact)
+    antenna_boresight_body: tuple[float, float, float] = LEGACY_GSP_ANTENNA_BODY_VECTOR
     gsstartra: float = 0.0
     gsstartdec: float = 0.0
+    gsstartroll: float = GSP_TRACK_ROLL
     gsendra: float = 0.0
     gsenddec: float = 0.0
+    gsendroll: float = GSP_TRACK_ROLL
 
     # Recorded pointing profile during the pass dwell
     utime: list[float] = Field(default_factory=list)
     ra: list[float] = Field(default_factory=list)
     dec: list[float] = Field(default_factory=list)
+    roll: list[float] = Field(default_factory=list)
+    station_ra: list[float] = Field(default_factory=list)
+    station_dec: list[float] = Field(default_factory=list)
 
     # Scheduling / status
     slewrequired: float = 0.0
@@ -96,26 +110,56 @@ class Pass(BaseModel):
 
         return timetopassstring
 
+    def _profile_index(self, utime: float) -> int | None:
+        if not self.utime:
+            return None
+
+        idx = int(np.searchsorted(self.utime, utime))
+        if idx >= len(self.utime):
+            return len(self.utime) - 1
+        return idx
+
     def ra_dec(self, utime: float) -> tuple[float | None, float | None]:
-        """Return the RA/Dec of the Spacecraft during a groundstation pass.
+        """Return the RA/Dec of the spacecraft during a groundstation pass.
         Note: If utime is outside the pass, returns the earliest or latest
         RA/Dec in the pass."""
 
-        # Find the closest time index
-        idx = np.searchsorted(self.utime, utime)
-        # searchsorted will return length if utime is beyond the end
-        if idx >= len(self.utime):
-            return self.ra[-1], self.dec[-1]
+        idx = self._profile_index(utime)
+        if idx is None:
+            return self.gsstartra, self.gsstartdec
         return self.ra[idx], self.dec[idx]
+
+    def roll_at(self, utime: float) -> float:
+        """Return the spacecraft roll during a groundstation pass."""
+
+        idx = self._profile_index(utime)
+        if idx is None or not self.roll:
+            return self.gsstartroll
+        return self.roll[idx]
+
+    def attitude_at(self, utime: float) -> tuple[float | None, float | None, float]:
+        """Return RA, Dec, and roll during a groundstation pass."""
+
+        ra, dec = self.ra_dec(utime)
+        return ra, dec, self.roll_at(utime)
+
+    def station_ra_dec(self, utime: float) -> tuple[float | None, float | None]:
+        """Return the spacecraft-to-ground-station line of sight."""
+
+        idx = self._profile_index(utime)
+        if idx is None or not self.station_ra or not self.station_dec:
+            return None, None
+        return self.station_ra[idx], self.station_dec[idx]
 
     @staticmethod
     def apply_antenna_offset(
         ra: float, dec: float, azimuth_deg: float, elevation_deg: float
     ) -> tuple[float, float]:
-        """Apply antenna pointing offset to RA/Dec.
+        """Apply a legacy antenna pointing offset to RA/Dec.
 
-        For a fixed antenna pointing at (azimuth, elevation) in the spacecraft body frame,
-        calculate the adjusted RA/Dec that the antenna actually points toward.
+        This helper is retained for compatibility with older tests and callers.
+        Ground-station-pass attitude generation uses fixed body-frame antenna
+        boresight vectors instead.
 
         Args:
             ra: Original right ascension (degrees)
@@ -174,7 +218,11 @@ class Pass(BaseModel):
         )
 
     def can_communicate(
-        self, spacecraft_ra: float, spacecraft_dec: float, utime: float | None = None
+        self,
+        spacecraft_ra: float,
+        spacecraft_dec: float,
+        utime: float | None = None,
+        spacecraft_roll: float = 0.0,
     ) -> bool:
         """Check if communication is possible given spacecraft pointing.
 
@@ -182,6 +230,7 @@ class Pass(BaseModel):
             spacecraft_ra: Current spacecraft RA (degrees)
             spacecraft_dec: Current spacecraft Dec (degrees)
             utime: Time during pass (optional, uses begin if None)
+            spacecraft_roll: Spacecraft roll angle in degrees
 
         Returns:
             True if communication is possible, False otherwise
@@ -198,13 +247,33 @@ class Pass(BaseModel):
         if target_ra is None or target_dec is None:
             return False
 
-        # Calculate pointing error
-        error = self.pointing_error(
-            spacecraft_ra, spacecraft_dec, target_ra, target_dec
+        error = self.antenna_pointing_error(
+            spacecraft_ra, spacecraft_dec, spacecraft_roll, utime
         )
+        if error is None:
+            error = self.pointing_error(
+                spacecraft_ra, spacecraft_dec, target_ra, target_dec
+            )
 
         # Check if within acceptable range
         return self.config.spacecraft_bus.communications.can_communicate(error)
+
+    def antenna_pointing_error(
+        self, spacecraft_ra: float, spacecraft_dec: float, roll: float, utime: float
+    ) -> float | None:
+        """Return fixed antenna pointing error to the station line of sight."""
+
+        target_ra, target_dec = self.station_ra_dec(utime)
+        if target_ra is None or target_dec is None:
+            return None
+
+        antenna_vec = body_vector_to_eci(
+            spacecraft_ra, spacecraft_dec, roll, self.antenna_boresight_body
+        )
+        target_vec = radec2vec(target_ra * DTOR, target_dec * DTOR)
+        dot = float(np.dot(antenna_vec, target_vec))
+        dot = float(np.clip(dot, -1.0, 1.0))
+        return float(np.rad2deg(np.arccos(dot)))
 
     def get_data_rate(self, band: str, direction: str = "downlink") -> float:
         """Get data rate for this pass in the specified band.
@@ -252,6 +321,7 @@ class Pass(BaseModel):
         roll: float,
         target_ra: float,
         target_dec: float,
+        target_roll: float,
     ) -> float:
         assert self.config is not None, "Config must be set for Pass class"
         if self.config.spacecraft_bus.attitude_control is None:
@@ -263,7 +333,7 @@ class Pass(BaseModel):
         slew.startroll = roll
         slew.endra = target_ra
         slew.enddec = target_dec
-        slew.endroll = GSP_TRACK_ROLL
+        slew.endroll = target_roll
         slew.slewstart = utime
         return slew.calc_slewtime()
 
@@ -282,17 +352,21 @@ class Pass(BaseModel):
         # Determine target pointing: if we're late, target where pass currently is
         if utime >= self.begin:
             # We're late - target current pass position
-            target_ra, target_dec = self.ra_dec(utime)
+            target_ra, target_dec, target_roll = self.attitude_at(utime)
             if target_ra is None or target_dec is None:
                 return False
         else:
             # On time - target pass start
             if not self.ra or not self.dec:
                 return False
-            target_ra, target_dec = self.ra[0], self.dec[0]
+            target_ra, target_dec, target_roll = (
+                self.ra[0],
+                self.dec[0],
+                self.roll[0] if self.roll else self.gsstartroll,
+            )
 
         slewtime = self._slew_time_to_target(
-            utime, ra, dec, roll, target_ra, target_dec
+            utime, ra, dec, roll, target_ra, target_dec, target_roll
         )
         # Determine if we need to start slewing now
         time_until_slew = (self.begin - slewtime) - utime
@@ -391,6 +465,16 @@ class PassTimes:
         rate = self._station_downlink_rate_mbps(gspass)
         return (rate * gspass.length, gspass.length, -gspass.begin)
 
+    def _gsp_antenna_boresight_body(self) -> tuple[float, float, float]:
+        communications = getattr(self.config.spacecraft_bus, "communications", None)
+        if communications is None:
+            return LEGACY_GSP_ANTENNA_BODY_VECTOR
+        antenna = communications.antenna_pointing
+        if antenna.antenna_type != AntennaType.FIXED:
+            return LEGACY_GSP_ANTENNA_BODY_VECTOR
+        boresight = antenna.fixed_boresight_body
+        return (float(boresight[0]), float(boresight[1]), float(boresight[2]))
+
     def _deconflict_overlapping_passes(self) -> None:
         selected: list[Pass] = []
         self.dropped_overlapping_passes = []
@@ -439,16 +523,6 @@ class PassTimes:
                 begin=begin_time,
                 end=end_time,
                 step_size=self.ephem.step_size,
-            )
-
-            # Calculate satellite RA/Dec as seen from ground station
-            sat_ra, sat_dec = np.degrees(
-                vec2radec(
-                    (
-                        self.ephem.gcrs_pv.position[startindex:endindex]
-                        - gs_ephem.gcrs_pv.position
-                    ).T
-                )
             )
 
             # Fast vectorized approach: compute Earth limb constraint directly
@@ -524,15 +598,31 @@ class PassTimes:
                     )
                     if should_schedule:
                         # Schedule this pass if the dice roll allows it
+                        target_vectors = -gs_to_sat_unit[start_idx:end_idx]
+                        target_ra, target_dec = np.degrees(vec2radec(target_vectors.T))
+                        antenna_boresight = self._gsp_antenna_boresight_body()
+                        attitude_profile = [
+                            attitude_for_body_vector_tracking(
+                                antenna_boresight, target_vector
+                            )
+                            for target_vector in target_vectors
+                        ]
+                        track_ra = [attitude[0] for attitude in attitude_profile]
+                        track_dec = [attitude[1] for attitude in attitude_profile]
+                        track_roll = [attitude[2] for attitude in attitude_profile]
+
                         gspass = Pass(
                             config=self.config,
                             ephem=self.ephem,
                             station=station.code,
                             begin=passstart,
-                            gsstartra=sat_ra[start_idx],
-                            gsstartdec=sat_dec[start_idx],
-                            gsendra=sat_ra[end_idx - 1],
-                            gsenddec=sat_dec[end_idx - 1],
+                            antenna_boresight_body=antenna_boresight,
+                            gsstartra=track_ra[0],
+                            gsstartdec=track_dec[0],
+                            gsstartroll=track_roll[0],
+                            gsendra=track_ra[-1],
+                            gsenddec=track_dec[-1],
+                            gsendroll=track_roll[-1],
                             length=passlen,
                         )
 
@@ -540,44 +630,11 @@ class PassTimes:
                         gspass.utime = timestamp_unix[
                             startindex + start_idx : startindex + end_idx
                         ].tolist()
-                        gspass.ra = sat_ra[start_idx:end_idx].tolist()
-                        gspass.dec = sat_dec[start_idx:end_idx].tolist()
-
-                        # Apply antenna pointing offset for fixed antennas
-                        if (
-                            gspass.config is not None
-                            and gspass.config.spacecraft_bus.communications is not None
-                            and gspass.config.spacecraft_bus.communications.antenna_pointing.antenna_type
-                            == AntennaType.FIXED
-                        ):
-                            antenna = gspass.config.spacecraft_bus.communications.antenna_pointing
-                            # Adjust start/end pointing
-                            gspass.gsstartra, gspass.gsstartdec = (
-                                Pass.apply_antenna_offset(
-                                    gspass.gsstartra,
-                                    gspass.gsstartdec,
-                                    antenna.fixed_azimuth_deg,
-                                    antenna.fixed_elevation_deg,
-                                )
-                            )
-                            gspass.gsendra, gspass.gsenddec = Pass.apply_antenna_offset(
-                                gspass.gsendra,
-                                gspass.gsenddec,
-                                antenna.fixed_azimuth_deg,
-                                antenna.fixed_elevation_deg,
-                            )
-                            # Adjust full pointing profile
-                            adjusted_pointing = [
-                                Pass.apply_antenna_offset(
-                                    ra_val,
-                                    dec_val,
-                                    antenna.fixed_azimuth_deg,
-                                    antenna.fixed_elevation_deg,
-                                )
-                                for ra_val, dec_val in zip(gspass.ra, gspass.dec)
-                            ]
-                            gspass.ra = [pt[0] for pt in adjusted_pointing]
-                            gspass.dec = [pt[1] for pt in adjusted_pointing]
+                        gspass.ra = track_ra
+                        gspass.dec = track_dec
+                        gspass.roll = track_roll
+                        gspass.station_ra = target_ra.tolist()
+                        gspass.station_dec = target_dec.tolist()
 
                         self.passes.append(gspass)
 

--- a/conops/targets/plan_entry.py
+++ b/conops/targets/plan_entry.py
@@ -30,8 +30,10 @@ class PlanEntry:
     contact_end: float | None
     track_start_ra: float | None
     track_start_dec: float | None
+    track_start_roll: float | None
     track_end_ra: float | None
     track_end_dec: float | None
+    track_end_roll: float | None
 
     def __init__(
         self,
@@ -63,8 +65,10 @@ class PlanEntry:
         self.contact_end = None
         self.track_start_ra = None
         self.track_start_dec = None
+        self.track_start_roll = None
         self.track_end_ra = None
         self.track_end_dec = None
+        self.track_end_roll = None
 
         self.saa = None
         self.merit = 101

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -76,8 +76,10 @@ class PlanEntrySchema(BaseModel):
     contact_end: float | None = None
     track_start_ra: float | None = None
     track_start_dec: float | None = None
+    track_start_roll: float | None = None
     track_end_ra: float | None = None
     track_end_dec: float | None = None
+    track_end_roll: float | None = None
 
     @staticmethod
     def _computed_exposure(entry: PlanEntry) -> int:
@@ -137,8 +139,10 @@ class PlanEntrySchema(BaseModel):
                 "contact_end": getattr(data, "contact_end", None),
                 "track_start_ra": getattr(data, "track_start_ra", None),
                 "track_start_dec": getattr(data, "track_start_dec", None),
+                "track_start_roll": getattr(data, "track_start_roll", None),
                 "track_end_ra": getattr(data, "track_end_ra", None),
                 "track_end_dec": getattr(data, "track_end_dec", None),
+                "track_end_roll": getattr(data, "track_end_roll", None),
             }
         return data
 

--- a/docs/communications.rst
+++ b/docs/communications.rst
@@ -62,8 +62,13 @@ Defines how the antenna is mounted and pointed.
 * ``fixed_boresight_body``: Fixed antenna boresight as a unit vector in spacecraft body frame.
   The default ``(-1, 0, 0)`` preserves the legacy ground-station-pass tracking convention.
 * ``fixed_azimuth_deg`` / ``fixed_elevation_deg``: Legacy metadata fields. Use
-  ``fixed_boresight_body`` for GSP attitude generation.
+  ``fixed_boresight_body`` for GSP attitude generation. Nonzero values are accepted
+  with a deprecation warning and do not affect generated GSP attitudes.
 * ``gimbal_range_deg``: Angular range for gimbaled antennas (from boresight)
+
+Only ``FIXED`` antennas currently drive spacecraft attitude during generated
+ground-station-pass profiles. ``OMNI`` and ``GIMBALED`` antennas do not imply a
+body-frame tracking vector.
 
 Polarization
 ^^^^^^^^^^^^

--- a/docs/communications.rst
+++ b/docs/communications.rst
@@ -59,8 +59,10 @@ Defines how the antenna is mounted and pointed.
 **Fields:**
 
 * ``antenna_type``: Type of antenna mounting
-* ``fixed_azimuth_deg``: Azimuth in spacecraft body frame (0° = nadir, 180° = zenith)
-* ``fixed_elevation_deg``: Elevation angle in body frame
+* ``fixed_boresight_body``: Fixed antenna boresight as a unit vector in spacecraft body frame.
+  The default ``(-1, 0, 0)`` preserves the legacy ground-station-pass tracking convention.
+* ``fixed_azimuth_deg`` / ``fixed_elevation_deg``: Legacy metadata fields. Use
+  ``fixed_boresight_body`` for GSP attitude generation.
 * ``gimbal_range_deg``: Angular range for gimbaled antennas (from boresight)
 
 Polarization
@@ -112,7 +114,7 @@ Python Mission Configuration
        Polarization,
    )
 
-   # LEO satellite with nadir-pointing S-band (using defaults)
+   # LEO satellite with body-fixed -X S-band (using defaults)
    leo_comms = CommunicationsSystem(
        name="LEO S-band",
        band_capabilities=[
@@ -120,8 +122,7 @@ Python Mission Configuration
        ],
        antenna_pointing=AntennaPointing(
            antenna_type=AntennaType.FIXED,
-           fixed_azimuth_deg=0.0,  # Nadir pointing
-           fixed_elevation_deg=0.0,
+           fixed_boresight_body=(-1.0, 0.0, 0.0),
        ),
        polarization=Polarization.CIRCULAR_RIGHT,
        pointing_accuracy_deg=10.0,
@@ -227,7 +228,7 @@ Common Configurations
 
 See ``examples/example_communications_configs.json`` for complete examples:
 
-* LEO S-band (nadir-pointing)
+* LEO S-band (body-fixed -X)
 * High-rate X-band (gimbaled)
 * Dual S/X-band
 * Deep space Ka-band

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -267,18 +267,26 @@ Entry Fields
      - float | null
      - Ground-station tracking declination at ``contact_begin`` in degrees. Only present
        for ``obstype="GSP"``. For GSP entries, ``dec`` uses the same pass-start convention.
+   * - ``track_start_roll``
+     - float | null
+     - Ground-station tracking roll at ``contact_begin`` in degrees. Only present
+       for ``obstype="GSP"``. For GSP entries, ``roll`` uses the same pass-start convention.
    * - ``track_end_ra``
      - float | null
      - Ground-station tracking right ascension used by ACS at pass end, in degrees. This is
-       derived from the final tracking sample and matches ``Pass.ra_dec(contact_end)``. Only
+       derived from the final tracking sample and matches ``Pass.attitude_at(contact_end)``. Only
        present for ``obstype="GSP"``. Use this with ``track_end_dec`` when inspecting slews
        after a pass.
    * - ``track_end_dec``
      - float | null
      - Ground-station tracking declination used by ACS at pass end, in degrees. This is
-       derived from the final tracking sample and matches ``Pass.ra_dec(contact_end)``. Only
+       derived from the final tracking sample and matches ``Pass.attitude_at(contact_end)``. Only
        present for ``obstype="GSP"``. Use this with ``track_end_ra`` when inspecting slews
        after a pass.
+   * - ``track_end_roll``
+     - float | null
+     - Ground-station tracking roll used by ACS at pass end, in degrees. This is derived
+       from the final tracking sample and matches ``Pass.attitude_at(contact_end)``.
 
 Ground Station Pass (GSP) Entries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -297,11 +305,11 @@ and execution of data downlink passes.
 * **Metadata fields**: The ``station``, ``contact_begin``, and ``contact_end`` fields are
   only present for GSP entries (``null`` or omitted for other observation types).
 * **Tracking attitude**: GSP entries track the ground station through the contact. The
-  generic ``ra`` and ``dec`` fields are the pass-start pointing, matching
-  ``track_start_ra`` and ``track_start_dec``. Use ``track_end_ra`` and
-  ``track_end_dec`` to inspect the spacecraft pointing at the end of the pass. The end
-  fields are derived from the final tracking sample, matching ACS
-  ``Pass.ra_dec(contact_end)`` behavior.
+  generic ``ra``, ``dec``, and ``roll`` fields are the pass-start attitude, matching
+  ``track_start_ra``, ``track_start_dec``, and ``track_start_roll``. Use ``track_end_ra``,
+  ``track_end_dec``, and ``track_end_roll`` to inspect the spacecraft attitude at the end
+  of the pass. The end fields are derived from the final tracking sample, matching ACS
+  ``Pass.attitude_at(contact_end)`` behavior.
 * **Deconfliction**: When multiple ground stations are visible simultaneously, COASTSim
   automatically selects the pass with the highest expected data volume (downlink rate × duration).
   Dropped overlapping opportunities are logged but not exported to the plan.
@@ -325,8 +333,10 @@ and execution of data downlink passes.
      "end": "2025-12-01T12:12:00+00:00",
      "track_start_ra": 120.0,
      "track_start_dec": 45.0,
+     "track_start_roll": 12.4,
      "track_end_ra": 231.67,
      "track_end_dec": -0.38,
+     "track_end_roll": 18.2,
      "slewtime": 120,
      "exptime": 600,
      "obsid": 65535

--- a/tests/acs/test_acs_comprehensive.py
+++ b/tests/acs/test_acs_comprehensive.py
@@ -394,6 +394,7 @@ class TestPointing:
         current_pass = Mock(spec=Pass)
         current_pass.in_pass = Mock(return_value=True)
         current_pass.ra_dec = Mock(return_value=(50.0, 35.0))
+        current_pass.roll_at = Mock(return_value=12.0)
         current_pass.obsid = 0xFFFF
 
         stale_science = Mock()

--- a/tests/common/test_common.py
+++ b/tests/common/test_common.py
@@ -12,6 +12,7 @@ from conops import (
 )
 from conops.common import (
     attitude_for_body_vector_tracking,
+    attitude_from_body_axes,
     body_vector_to_eci,
     scbodyvector,
 )
@@ -152,8 +153,11 @@ class TestBodyVectorTrackingAttitude:
         target = np.array([0.3, -0.4, 0.8660254])
         target = target / np.linalg.norm(target)
 
-        ra, dec, roll = attitude_for_body_vector_tracking(body_vector, target)
+        attitude = attitude_for_body_vector_tracking(body_vector, target)
+        assert attitude is not None
+        ra, dec, roll = attitude
         tracked = body_vector_to_eci(ra, dec, roll, body_vector)
+        assert tracked is not None
         target_in_body = scbodyvector(
             np.deg2rad(ra), np.deg2rad(dec), np.deg2rad(roll), target
         )
@@ -184,6 +188,7 @@ class TestBodyVectorTrackingAttitude:
         ra, dec, roll = attitude
 
         inertial_vector = body_vector_to_eci(ra, dec, roll, body_vector)
+        assert inertial_vector is not None
         recovered_body_vector = scbodyvector(
             np.deg2rad(ra),
             np.deg2rad(dec),
@@ -197,10 +202,50 @@ class TestBodyVectorTrackingAttitude:
         target = np.array([0.3, -0.4, 0.8660254])
         target = target / np.linalg.norm(target)
 
-        ra, dec, roll = attitude_for_body_vector_tracking((-1.0, 0.0, 0.0), target)
+        attitude = attitude_for_body_vector_tracking((-1.0, 0.0, 0.0), target)
+        assert attitude is not None
+        ra, dec, roll = attitude
         minus_x = body_vector_to_eci(ra, dec, roll, (-1.0, 0.0, 0.0))
         plus_x = body_vector_to_eci(ra, dec, roll, (1.0, 0.0, 0.0))
+        assert minus_x is not None
+        assert plus_x is not None
 
         assert np.dot(minus_x, target) == pytest.approx(1.0, abs=1e-9)
         assert np.dot(plus_x, -target) == pytest.approx(1.0, abs=1e-9)
         assert roll == pytest.approx(0.0, abs=1e-9)
+
+    def test_tracking_skips_zero_reference_vectors(self):
+        target = np.array([0.3, -0.4, 0.8660254])
+        target = target / np.linalg.norm(target)
+
+        attitude = attitude_for_body_vector_tracking(
+            (0.0, 1.0, 0.0),
+            target,
+            reference_body=(0.0, 0.0, 0.0),
+            reference_eci=(0.0, 0.0, 0.0),
+        )
+
+        assert attitude is not None
+        ra, dec, roll = attitude
+        tracked = body_vector_to_eci(ra, dec, roll, (0.0, 1.0, 0.0))
+        assert tracked is not None
+        assert np.dot(tracked, target) == pytest.approx(1.0, abs=1e-9)
+
+    def test_attitude_from_body_axes_handles_parallel_z_reference(self):
+        attitude = attitude_from_body_axes((1.0, 0.0, 0.0), (1.0, 0.0, 0.0))
+
+        assert attitude is not None
+        ra, dec, roll = attitude
+        body_x = body_vector_to_eci(ra, dec, roll, (1.0, 0.0, 0.0))
+        assert body_x is not None
+        assert body_x == pytest.approx((1.0, 0.0, 0.0), abs=1e-9)
+
+    def test_degenerate_tracking_vectors_return_none(self):
+        target = np.array([0.3, -0.4, 0.8660254])
+        target = target / np.linalg.norm(target)
+
+        assert attitude_for_body_vector_tracking((0.0, 0.0, 0.0), target) is None
+        assert (
+            attitude_for_body_vector_tracking((1.0, 0.0, 0.0), (0.0, 0.0, 0.0)) is None
+        )
+        assert body_vector_to_eci(0.0, 0.0, 0.0, (0.0, 0.0, 0.0)) is None

--- a/tests/common/test_common.py
+++ b/tests/common/test_common.py
@@ -1,11 +1,19 @@
 """Tests for conops.common module."""
 
+import numpy as np
+import pytest
+
 from conops import (
     ACSMode,
     givename,
     ics_date_conv,
     unixtime2date,
     unixtime2yearday,
+)
+from conops.common import (
+    attitude_for_body_vector_tracking,
+    body_vector_to_eci,
+    scbodyvector,
 )
 
 
@@ -124,3 +132,75 @@ class TestUnixtimeToYearday:
         year, day = unixtime2yearday(utime)
         assert year == 2023
         assert day > 100  # Mid-year
+
+
+class TestBodyVectorTrackingAttitude:
+    """Test attitude solutions for tracking arbitrary body vectors."""
+
+    @pytest.mark.parametrize(
+        "body_vector",
+        [
+            (1.0, 0.0, 0.0),
+            (-1.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0),
+            (0.0, -1.0, 0.0),
+            (0.0, 0.0, 1.0),
+            (0.0, 0.0, -1.0),
+        ],
+    )
+    def test_body_vector_tracks_target(self, body_vector):
+        target = np.array([0.3, -0.4, 0.8660254])
+        target = target / np.linalg.norm(target)
+
+        ra, dec, roll = attitude_for_body_vector_tracking(body_vector, target)
+        tracked = body_vector_to_eci(ra, dec, roll, body_vector)
+        target_in_body = scbodyvector(
+            np.deg2rad(ra), np.deg2rad(dec), np.deg2rad(roll), target
+        )
+
+        assert np.dot(tracked, target) == pytest.approx(1.0, abs=1e-9)
+        assert target_in_body == pytest.approx(body_vector, abs=1e-9)
+
+    @pytest.mark.parametrize(
+        "attitude",
+        [
+            (0.0, 0.0, 30.0),
+            (90.0, 45.0, 30.0),
+            (120.0, -20.0, 275.0),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "body_vector",
+        [
+            (1.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0),
+            (0.0, 0.0, 1.0),
+            (0.0, -1.0, 0.0),
+        ],
+    )
+    def test_body_vector_to_eci_matches_spacecraft_body_transform(
+        self, attitude, body_vector
+    ):
+        ra, dec, roll = attitude
+
+        inertial_vector = body_vector_to_eci(ra, dec, roll, body_vector)
+        recovered_body_vector = scbodyvector(
+            np.deg2rad(ra),
+            np.deg2rad(dec),
+            np.deg2rad(roll),
+            inertial_vector,
+        )
+
+        assert recovered_body_vector == pytest.approx(body_vector, abs=1e-9)
+
+    def test_legacy_minus_x_tracking_keeps_zero_roll(self):
+        target = np.array([0.3, -0.4, 0.8660254])
+        target = target / np.linalg.norm(target)
+
+        ra, dec, roll = attitude_for_body_vector_tracking((-1.0, 0.0, 0.0), target)
+        minus_x = body_vector_to_eci(ra, dec, roll, (-1.0, 0.0, 0.0))
+        plus_x = body_vector_to_eci(ra, dec, roll, (1.0, 0.0, 0.0))
+
+        assert np.dot(minus_x, target) == pytest.approx(1.0, abs=1e-9)
+        assert np.dot(plus_x, -target) == pytest.approx(1.0, abs=1e-9)
+        assert roll == pytest.approx(0.0, abs=1e-9)

--- a/tests/config/test_communications.py
+++ b/tests/config/test_communications.py
@@ -67,6 +67,18 @@ class TestAntennaPointing:
         assert pointing.antenna_type == AntennaType.FIXED
         assert pointing.fixed_boresight_body == (0.0, 1.0, 0.0)
 
+    def test_legacy_azimuth_elevation_warns(self):
+        """Legacy azimuth/elevation fields remain accepted with a warning."""
+        with pytest.warns(DeprecationWarning, match="legacy metadata fields"):
+            pointing = AntennaPointing(
+                antenna_type=AntennaType.FIXED,
+                fixed_azimuth_deg=45.0,
+                fixed_elevation_deg=30.0,
+            )
+
+        assert pointing.fixed_azimuth_deg == 45.0
+        assert pointing.fixed_elevation_deg == 30.0
+
     def test_gimbaled_antenna(self):
         """Test gimbaled antenna configuration."""
         pointing = AntennaPointing(

--- a/tests/config/test_communications.py
+++ b/tests/config/test_communications.py
@@ -51,27 +51,21 @@ class TestAntennaPointing:
         """Test omnidirectional antenna configuration."""
         pointing = AntennaPointing(antenna_type=AntennaType.OMNI)
         assert pointing.antenna_type == AntennaType.OMNI
-        assert not pointing.is_nadir_pointing()
 
-    def test_fixed_nadir_pointing(self):
-        """Test fixed nadir-pointing antenna (default)."""
+    def test_fixed_antenna_default_boresight_is_legacy_minus_x(self):
+        """Test fixed -X antenna (legacy default)."""
+        pointing = AntennaPointing(antenna_type=AntennaType.FIXED)
+        assert pointing.antenna_type == AntennaType.FIXED
+        assert pointing.fixed_boresight_body == (-1.0, 0.0, 0.0)
+
+    def test_fixed_antenna_accepts_non_minus_x_boresight(self):
+        """Test fixed antenna not pointing along -X."""
         pointing = AntennaPointing(
             antenna_type=AntennaType.FIXED,
-            fixed_azimuth_deg=0.0,
-            fixed_elevation_deg=0.0,
+            fixed_boresight_body=(0.0, 1.0, 0.0),
         )
         assert pointing.antenna_type == AntennaType.FIXED
-        assert pointing.is_nadir_pointing()
-
-    def test_fixed_non_nadir_pointing(self):
-        """Test fixed antenna not pointing nadir."""
-        pointing = AntennaPointing(
-            antenna_type=AntennaType.FIXED,
-            fixed_azimuth_deg=180.0,
-            fixed_elevation_deg=0.0,
-        )
-        assert pointing.antenna_type == AntennaType.FIXED
-        assert not pointing.is_nadir_pointing()  # Zenith pointing
+        assert pointing.fixed_boresight_body == (0.0, 1.0, 0.0)
 
     def test_gimbaled_antenna(self):
         """Test gimbaled antenna configuration."""
@@ -80,7 +74,6 @@ class TestAntennaPointing:
         )
         assert pointing.antenna_type == AntennaType.GIMBALED
         assert pointing.gimbal_range_deg == 30.0
-        assert not pointing.is_nadir_pointing()
 
     def test_antenna_pointing_validation(self):
         """Test validation of antenna pointing angles."""
@@ -95,6 +88,13 @@ class TestAntennaPointing:
         # Gimbal range must be 0-180
         with pytest.raises(Exception):
             AntennaPointing(antenna_type=AntennaType.GIMBALED, gimbal_range_deg=200.0)
+
+        # Fixed antenna boresight must be a unit vector
+        with pytest.raises(Exception):
+            AntennaPointing(
+                antenna_type=AntennaType.FIXED,
+                fixed_boresight_body=(2.0, 0.0, 0.0),
+            )
 
 
 class TestPolarization:
@@ -292,8 +292,8 @@ class TestCommunicationsIntegration:
         assert comms.can_communicate(2.0)
         assert not comms.can_communicate(5.0)
 
-    def test_nadir_pointing_s_band(self):
-        """Test a nadir-pointing S-band system (typical for LEO)."""
+    def test_fixed_s_band_uses_explicit_boresight(self):
+        """Test a fixed -X S-band system."""
         comms = CommunicationsSystem(
             name="LEO S-band",
             band_capabilities=[
@@ -301,14 +301,13 @@ class TestCommunicationsIntegration:
             ],
             antenna_pointing=AntennaPointing(
                 antenna_type=AntennaType.FIXED,
-                fixed_azimuth_deg=0.0,
-                fixed_elevation_deg=0.0,
+                fixed_boresight_body=(-1.0, 0.0, 0.0),
             ),
             polarization=Polarization.CIRCULAR_RIGHT,
             pointing_accuracy_deg=10.0,
         )
 
-        assert comms.antenna_pointing.is_nadir_pointing()
+        assert comms.antenna_pointing.fixed_boresight_body == (-1.0, 0.0, 0.0)
         assert comms.get_downlink_rate("S") == 5.0
         assert comms.can_communicate(9.0)
         assert not comms.can_communicate(11.0)

--- a/tests/passes/test_antenna_offset.py
+++ b/tests/passes/test_antenna_offset.py
@@ -1,4 +1,4 @@
-"""Tests for Pass antenna pointing offset functionality."""
+"""Tests for legacy Pass antenna pointing offset helpers."""
 
 from datetime import datetime, timezone
 
@@ -17,7 +17,7 @@ from conops.simulation import Pass
 
 
 class TestAntennaPointingOffset:
-    """Test antenna pointing offset calculations."""
+    """Test legacy antenna pointing offset calculations."""
 
     def test_apply_antenna_offset_zero(self):
         """Test that zero offset returns original pointing."""
@@ -86,8 +86,8 @@ class TestPassWithAntennaOffset:
         return constraint
 
     def test_pass_with_nadir_antenna_offset(self, mock_config, constraint, ephem):
-        """Test Pass with nadir-pointing antenna (most common case)."""
-        # Create nadir-pointing antenna (0, 0 = default, points away from telescope)
+        """Test Pass with legacy zero-offset antenna metadata."""
+        # Legacy zero azimuth/elevation metadata preserves the pass fields.
         comms = CommunicationsSystem(
             name="Nadir Antenna",
             band_capabilities=[BandCapability(band="S", downlink_rate_mbps=10.0)],
@@ -152,8 +152,7 @@ class TestPassWithAntennaOffset:
         )
 
         # Pointing should be different from original due to antenna offset
-        # Note: The offset is applied in PassTimes.get(), not in Pass.__init__
-        # So we need to manually verify the offset calculation
+        # The legacy offset helper is not applied in Pass.__init__.
         adjusted_ra, adjusted_dec = Pass.apply_antenna_offset(
             original_ra, original_dec, 45.0, 30.0
         )
@@ -265,8 +264,7 @@ class TestPassWithAntennaOffset:
         gs_pass.ra = original_ra.copy()
         gs_pass.dec = original_dec.copy()
 
-        # Verify offset would be applied by PassTimes.get()
-        # In Pass.__init__, values remain unchanged
+        # In Pass.__init__, values remain unchanged.
         for i in range(len(gs_pass.ra)):
             assert gs_pass.ra[i] == original_ra[i]  # Not yet offset in __init__
             assert gs_pass.dec[i] == original_dec[i]

--- a/tests/passes/test_antenna_offset.py
+++ b/tests/passes/test_antenna_offset.py
@@ -123,16 +123,17 @@ class TestPassWithAntennaOffset:
     def test_pass_with_offset_antenna(self, mock_config, constraint, ephem):
         """Test Pass with offset fixed antenna."""
         # Create antenna pointing 45 degrees in azimuth and elevation
-        comms = CommunicationsSystem(
-            name="Offset Antenna",
-            band_capabilities=[BandCapability(band="X", downlink_rate_mbps=150.0)],
-            antenna_pointing=AntennaPointing(
-                antenna_type=AntennaType.FIXED,
-                fixed_azimuth_deg=45.0,
-                fixed_elevation_deg=30.0,
-            ),
-            pointing_accuracy_deg=10.0,
-        )
+        with pytest.warns(DeprecationWarning, match="legacy metadata fields"):
+            comms = CommunicationsSystem(
+                name="Offset Antenna",
+                band_capabilities=[BandCapability(band="X", downlink_rate_mbps=150.0)],
+                antenna_pointing=AntennaPointing(
+                    antenna_type=AntennaType.FIXED,
+                    fixed_azimuth_deg=45.0,
+                    fixed_elevation_deg=30.0,
+                ),
+                pointing_accuracy_deg=10.0,
+            )
 
         begin = datetime(2025, 8, 15, 12, 0, 0, tzinfo=timezone.utc)
         original_ra, original_dec = 45.0, 25.0
@@ -231,16 +232,17 @@ class TestPassWithAntennaOffset:
 
     def test_pass_pointing_profile_offset(self, mock_config, constraint, ephem):
         """Test that full pointing profile is offset for fixed antenna."""
-        comms = CommunicationsSystem(
-            name="Offset Antenna",
-            band_capabilities=[BandCapability(band="X", downlink_rate_mbps=150.0)],
-            antenna_pointing=AntennaPointing(
-                antenna_type=AntennaType.FIXED,
-                fixed_azimuth_deg=30.0,
-                fixed_elevation_deg=20.0,
-            ),
-            pointing_accuracy_deg=10.0,
-        )
+        with pytest.warns(DeprecationWarning, match="legacy metadata fields"):
+            comms = CommunicationsSystem(
+                name="Offset Antenna",
+                band_capabilities=[BandCapability(band="X", downlink_rate_mbps=150.0)],
+                antenna_pointing=AntennaPointing(
+                    antenna_type=AntennaType.FIXED,
+                    fixed_azimuth_deg=30.0,
+                    fixed_elevation_deg=20.0,
+                ),
+                pointing_accuracy_deg=10.0,
+            )
 
         begin = datetime(2025, 8, 15, 12, 0, 0, tzinfo=timezone.utc)
         mock_config.constraint = constraint

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -198,7 +198,9 @@ class TestPassMethods:
         target_dec = 20.0
         target_vec = radec2vec(np.deg2rad(target_ra), np.deg2rad(target_dec))
         antenna = (0.0, 1.0, 0.0)
-        ra, dec, roll = attitude_for_body_vector_tracking(antenna, target_vec)
+        attitude = attitude_for_body_vector_tracking(antenna, target_vec)
+        assert attitude is not None
+        ra, dec, roll = attitude
 
         basic_pass.antenna_boresight_body = antenna
         basic_pass.utime = [basic_pass.begin]
@@ -208,6 +210,15 @@ class TestPassMethods:
         error = basic_pass.antenna_pointing_error(ra, dec, roll, basic_pass.begin)
 
         assert error == pytest.approx(0.0, abs=1e-8)
+
+    def test_empty_profile_returns_no_pointing(self, basic_pass):
+        """An empty pass profile does not imply pass-start pointing exists."""
+        assert basic_pass.ra_dec(basic_pass.begin) == (None, None)
+        assert basic_pass.attitude_at(basic_pass.begin) == (
+            None,
+            None,
+            basic_pass.gsstartroll,
+        )
 
 
 class TestPassTimeToSlew:

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 
+import numpy as np
 import pytest
 
 from conops import (
@@ -11,9 +12,16 @@ from conops import (
     Pass,
     PassTimes,
 )
-from conops.common.enums import ObsType
-from conops.config import AttitudeControlSystem, BandCapability, GroundStation
-from conops.simulation.passes import GSP_TRACK_ROLL, pass_slew_trigger_buffer
+from conops.common import attitude_for_body_vector_tracking, radec2vec
+from conops.common.enums import AntennaType, ObsType
+from conops.config import (
+    AntennaPointing,
+    AttitudeControlSystem,
+    BandCapability,
+    CommunicationsSystem,
+    GroundStation,
+)
+from conops.simulation.passes import pass_slew_trigger_buffer
 
 
 class TestPassInitialization:
@@ -171,6 +179,36 @@ class TestPassMethods:
         assert ra == 12.0
         assert dec == 22.0
 
+    def test_attitude_lookup_includes_roll(self, basic_pass, three_step_utime):
+        """Test attitude_at returns RA, Dec, and roll from profile."""
+        basic_pass.utime = three_step_utime
+        basic_pass.ra = [10.0, 12.0, 14.0]
+        basic_pass.dec = [20.0, 22.0, 24.0]
+        basic_pass.roll = [1.0, 2.0, 3.0]
+
+        ra, dec, roll = basic_pass.attitude_at(1514764900.0)
+
+        assert ra == 12.0
+        assert dec == 22.0
+        assert roll == 2.0
+
+    def test_antenna_pointing_error_uses_body_vector(self, basic_pass):
+        """A side-mounted antenna can point at the station even when +X does not."""
+        target_ra = 30.0
+        target_dec = 20.0
+        target_vec = radec2vec(np.deg2rad(target_ra), np.deg2rad(target_dec))
+        antenna = (0.0, 1.0, 0.0)
+        ra, dec, roll = attitude_for_body_vector_tracking(antenna, target_vec)
+
+        basic_pass.antenna_boresight_body = antenna
+        basic_pass.utime = [basic_pass.begin]
+        basic_pass.station_ra = [target_ra]
+        basic_pass.station_dec = [target_dec]
+
+        error = basic_pass.antenna_pointing_error(ra, dec, roll, basic_pass.begin)
+
+        assert error == pytest.approx(0.0, abs=1e-8)
+
 
 class TestPassTimeToSlew:
     """Test Pass.time_to_slew method."""
@@ -313,7 +351,7 @@ class TestPassTimeToSlew:
         assert p.time_to_slew(base_begin - 600.0, ra=10.0, dec=20.0, roll=0.0) is False
         assert p.time_to_slew(base_begin - 600.0, ra=10.0, dec=20.0, roll=180.0) is True
 
-    def test_slew_time_to_target_uses_gsp_track_roll(
+    def test_slew_time_to_target_uses_pass_target_roll(
         self,
         mock_config,
         mock_constraint,
@@ -351,11 +389,12 @@ class TestPassTimeToSlew:
                 roll=42.0,
                 target_ra=30.0,
                 target_dec=40.0,
+                target_roll=37.0,
             )
 
         assert slewtime == 123.0
         assert captured["startroll"] == pytest.approx(42.0)
-        assert captured["endroll"] == pytest.approx(GSP_TRACK_ROLL)
+        assert captured["endroll"] == pytest.approx(37.0)
 
     def test_time_to_slew_raises_value_error_when_no_acs_config(
         self, mock_config, mock_constraint, create_ephem, base_begin
@@ -436,6 +475,20 @@ class TestPassTimes:
         mock_config.ground_stations = custom_gs
         pt = PassTimes(config=mock_config)
         assert pt.ground_stations is custom_gs
+
+    def test_gsp_antenna_boresight_uses_fixed_config(
+        self, mock_constraint, mock_config
+    ):
+        """Fixed GSP attitudes use the configured antenna body vector."""
+        mock_config.spacecraft_bus.communications = CommunicationsSystem(
+            antenna_pointing=AntennaPointing(
+                antenna_type=AntennaType.FIXED,
+                fixed_boresight_body=(0.0, 1.0, 0.0),
+            )
+        )
+        pt = PassTimes(config=mock_config)
+
+        assert pt._gsp_antenna_boresight_body() == (0.0, 1.0, 0.0)
 
     def test_passtimes_requires_ephemeris(self, mock_config):
         """Test PassTimes requires ephemeris."""

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -501,6 +501,18 @@ class TestPassTimes:
 
         assert pt._gsp_antenna_boresight_body() == (0.0, 1.0, 0.0)
 
+    @pytest.mark.parametrize("antenna_type", [AntennaType.OMNI, AntennaType.GIMBALED])
+    def test_gsp_antenna_boresight_undefined_for_non_fixed_antennas(
+        self, mock_constraint, mock_config, antenna_type
+    ):
+        """Non-fixed antennas do not imply a spacecraft body-frame boresight."""
+        mock_config.spacecraft_bus.communications = CommunicationsSystem(
+            antenna_pointing=AntennaPointing(antenna_type=antenna_type)
+        )
+        pt = PassTimes(config=mock_config)
+
+        assert pt._gsp_antenna_boresight_body() is None
+
     def test_passtimes_requires_ephemeris(self, mock_config):
         """Test PassTimes requires ephemeris."""
         constraint = Mock(spec=Constraint)

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -118,8 +118,10 @@ class TestPlanEntrySchema:
                 contact_end=1_000_720.0,
                 track_start_ra=12.5,
                 track_start_dec=-4.25,
+                track_start_roll=11.0,
                 track_end_ra=48.75,
                 track_end_dec=9.5,
+                track_end_roll=13.0,
             )
         )
 
@@ -129,8 +131,10 @@ class TestPlanEntrySchema:
         assert dumped["contact_end"] == "1970-01-12T13:58:40+00:00"
         assert dumped["track_start_ra"] == pytest.approx(12.5)
         assert dumped["track_start_dec"] == pytest.approx(-4.25)
+        assert dumped["track_start_roll"] == pytest.approx(11.0)
         assert dumped["track_end_ra"] == pytest.approx(48.75)
         assert dumped["track_end_dec"] == pytest.approx(9.5)
+        assert dumped["track_end_roll"] == pytest.approx(13.0)
 
         reloaded = PlanEntrySchema(**dumped)
         assert reloaded.station == "TRO"
@@ -138,8 +142,10 @@ class TestPlanEntrySchema:
         assert reloaded.contact_end == pytest.approx(1_000_720.0)
         assert reloaded.track_start_ra == pytest.approx(12.5)
         assert reloaded.track_start_dec == pytest.approx(-4.25)
+        assert reloaded.track_start_roll == pytest.approx(11.0)
         assert reloaded.track_end_ra == pytest.approx(48.75)
         assert reloaded.track_end_dec == pytest.approx(9.5)
+        assert reloaded.track_end_roll == pytest.approx(13.0)
 
 
 # ── PlanSchema ─────────────────────────────────────────────────────────────────
@@ -282,8 +288,10 @@ class TestPlanSchema:
         assert "contact_end" not in entry
         assert "track_start_ra" not in entry
         assert "track_start_dec" not in entry
+        assert "track_start_roll" not in entry
         assert "track_end_ra" not in entry
         assert "track_end_dec" not in entry
+        assert "track_end_roll" not in entry
 
     def test_load_existing_example_json(self):
         """Load a plan JSON file produced by a previous version (backward compat)."""

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -22,7 +22,6 @@ from conops.common.enums import ObsType
 from conops.config.config import MissionConfig
 from conops.ditl.telemetry import Housekeeping
 from conops.simulation.acs import IDLE_OBSID
-from conops.simulation.passes import GSP_TRACK_ROLL
 from conops.targets import PlanEntry, PlanSchema
 
 
@@ -1619,6 +1618,7 @@ class TestPlanExecutionValidation:
                 utime=[1000.0, 1060.0],
                 ra=[10.0, 11.0],
                 dec=[20.0, 21.0],
+                roll=[0.0, 10.0],
             )
         ]
         queue_ditl.utime = [1000.0, 1060.0]
@@ -3070,6 +3070,7 @@ class TestCheckAndManagePasses:
             length=600.0,
             gsstartra=100.0,
             gsstartdec=50.0,
+            gsstartroll=37.0,
         )
 
         # Mock the pass request methods
@@ -3096,7 +3097,7 @@ class TestCheckAndManagePasses:
 
         # Verify slew points to the pass start position
         assert command.slew.startroll == roll
-        assert command.slew.endroll == GSP_TRACK_ROLL
+        assert command.slew.endroll == pass_obj.gsstartroll
         assert command.slew.endra == pass_obj.gsstartra
         assert command.slew.enddec == pass_obj.gsstartdec
         assert command.slew.obsid == pass_obj.obsid
@@ -3114,13 +3115,16 @@ class TestCheckAndManagePasses:
             length=600.0,
             gsstartra=100.0,
             gsstartdec=50.0,
+            gsstartroll=37.0,
             gsendra=115.0,
             gsenddec=42.0,
+            gsendroll=41.0,
             obsid=4242,
         )
         pass_obj.utime = [pass_obj.begin, pass_obj.end - 60.0]
         pass_obj.ra = [pass_obj.gsstartra, pass_obj.gsendra]
         pass_obj.dec = [pass_obj.gsstartdec, pass_obj.gsenddec]
+        pass_obj.roll = [pass_obj.gsstartroll, pass_obj.gsendroll]
 
         queue_ditl.acs.passrequests.current_pass = Mock(return_value=None)
         queue_ditl.acs.passrequests.next_pass = Mock(return_value=pass_obj)
@@ -3151,11 +3155,14 @@ class TestCheckAndManagePasses:
         assert entry.contact_end == pass_obj.end
         assert entry.ra == pytest.approx(pass_obj.gsstartra)
         assert entry.dec == pytest.approx(pass_obj.gsstartdec)
+        assert entry.roll == pytest.approx(pass_obj.gsstartroll)
         assert entry.track_start_ra == pytest.approx(pass_obj.gsstartra)
         assert entry.track_start_dec == pytest.approx(pass_obj.gsstartdec)
-        pass_end_ra, pass_end_dec = pass_obj.ra_dec(pass_obj.end)
+        assert entry.track_start_roll == pytest.approx(pass_obj.gsstartroll)
+        pass_end_ra, pass_end_dec, pass_end_roll = pass_obj.attitude_at(pass_obj.end)
         assert entry.track_end_ra == pytest.approx(pass_end_ra)
         assert entry.track_end_dec == pytest.approx(pass_end_dec)
+        assert entry.track_end_roll == pytest.approx(pass_end_roll)
 
         schema = PlanSchema.from_plan(queue_ditl.plan)
         assert schema.entries[0].obstype == ObsType.GSP
@@ -3166,14 +3173,18 @@ class TestCheckAndManagePasses:
         assert schema.entries[0].contact_begin == pass_obj.begin
         assert schema.entries[0].track_start_ra == pytest.approx(pass_obj.gsstartra)
         assert schema.entries[0].track_start_dec == pytest.approx(pass_obj.gsstartdec)
+        assert schema.entries[0].track_start_roll == pytest.approx(pass_obj.gsstartroll)
         assert schema.entries[0].track_end_ra == pytest.approx(pass_end_ra)
         assert schema.entries[0].track_end_dec == pytest.approx(pass_end_dec)
+        assert schema.entries[0].track_end_roll == pytest.approx(pass_end_roll)
         saved_path = schema.save(tmp_path / "plan.json")
         saved_json = saved_path.read_text()
         assert '"obstype": "GSP"' in saved_json
         assert '"station": "GS_TEST"' in saved_json
         assert '"track_start_ra": 100.0' in saved_json
+        assert '"track_start_roll": 37.0' in saved_json
         assert '"track_end_ra": 115.0' in saved_json
+        assert '"track_end_roll": 41.0' in saved_json
 
     def test_check_and_manage_passes_records_gsp_after_pass_slew_command_enqueue(
         self, queue_ditl


### PR DESCRIPTION
## Summary
- add an explicit fixed antenna body-frame boresight vector, defaulting to legacy -X
- generate GSP attitude profiles so a FIXED configured antenna vector tracks the station line of sight
- carry GSP roll through ACS execution, plan export, and plan/execution validation
- keep the old azimuth/elevation helper as legacy compatibility metadata, with a deprecation warning for nonzero legacy az/el config
- avoid silently treating OMNI/GIMBALED antennas as legacy fixed -X body tracking

Closes #172.
Closes #173.

Follow-up: #181 tracks proper OMNI/GIMBALED ground-contact behavior without body-frame attitude tracking.

## Validation
- `pytest -q`
- `pytest tests/config/test_communications.py tests/passes/test_passes.py tests/passes/test_antenna_offset.py tests/passes/test_passes_communications.py`
- `PREK_HOME=.prek-cache PREK_LOG=.prek-cache/prek.log PATH="coastvenv/bin:$PATH" prek run --all-files`
- representative Tamalpais DITL with fixed +Y antenna override: 3 GSP entries, 24 contact samples, 0 GSP validation mismatches, max +Y-to-station error 8.5e-7 deg, legacy -X-to-station error ~90 deg