### PR TITLE
fix: keep executed science attempts in exported plan

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1039,8 +1039,11 @@ class QueueDITL(DITLMixin, DITLStats):
 
     def _close_last_plan_entry(self, end_time: float) -> None:
         """Close the last plan entry in the timeline by setting its end time.
-        If it's a science observation that didn't meet the minimum snapshot
-        requirement, log it and remove it from the plan."""
+
+        Science entries with no collection are removed. Short entries with
+        executed science collection remain in the plan so the export matches
+        ACS telemetry.
+        """
         if len(self.plan) == 0:
             return
         self.plan[-1].end = end_time
@@ -1048,17 +1051,30 @@ class QueueDITL(DITLMixin, DITLStats):
             entry = self.plan[-1]
             collection_time = self._science_collection_time(entry)
             collected = max(0.0, collection_time or 0.0)
+            if collected <= 0.0:
+                self.log.log_event(
+                    utime=end_time,
+                    event_type="QUEUE",
+                    description=(
+                        f"Dropping under-collected science entry {entry.obsid} - "
+                        f"collected {collected:.0f}s of required {float(entry.ss_min):.0f}s"
+                    ),
+                    obsid=entry.obsid,
+                    acs_mode=self.acs.acsmode,
+                )
+                self.plan.pop()
+                return
+
             self.log.log_event(
                 utime=end_time,
                 event_type="QUEUE",
                 description=(
-                    f"Dropping under-collected science entry {entry.obsid} - "
+                    f"Keeping under-collected science entry {entry.obsid} - "
                     f"collected {collected:.0f}s of required {float(entry.ss_min):.0f}s"
                 ),
                 obsid=entry.obsid,
                 acs_mode=self.acs.acsmode,
             )
-            self.plan.pop()
 
     def _create_housekeeping_record(
         self, utime: float, ra: float, dec: float, roll: float, mode: ACSMode
@@ -1268,6 +1284,8 @@ class QueueDITL(DITLMixin, DITLStats):
         # Check for battery alert and initiate emergency charging if needed
         if self._should_initiate_charging(utime):
             self._initiate_charging(utime, ra, dec)
+            if self.charging_ppt is not None:
+                return
 
         # Check for TOO interrupts (before managing PPT lifecycle)
         # This allows TOOs to preempt ongoing observations
@@ -1311,6 +1329,7 @@ class QueueDITL(DITLMixin, DITLStats):
                     self._close_last_plan_entry(utime)
                 if self._is_short_science_entry(interrupted_ppt):
                     interrupted_ppt.done = False
+                self.acs.end_science_observation()
 
             command = ACSCommand(
                 command_type=ACSCommandType.START_BATTERY_CHARGE,

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -2184,9 +2184,12 @@ class TestCalcMethod:
         queue_ditl._initiate_charging(1250.0, 10.0, 20.0)
 
         assert science_ppt.done is False
-        assert science_ppt not in queue_ditl.plan
+        assert science_ppt in queue_ditl.plan
         assert queue_ditl.ppt is charging_ppt
+        queue_ditl.acs.end_science_observation.assert_called_once()
         queue_ditl.acs.enqueue_command.assert_called_once()
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Keeping under-collected science entry 1001" in log_text
 
     def test_calc_drops_short_science_entry_when_charging_interrupts(
         self, queue_ditl
@@ -2477,8 +2480,8 @@ class TestCalcMethod:
         assert "Dropping under-collected science entry 1001" in log_text
         assert "collected 0s" in log_text
 
-    def test_track_ppt_drops_science_entry_below_ss_min(self, queue_ditl) -> None:
-        """A science entry with less than ss_min collection is not kept as AT."""
+    def test_track_ppt_keeps_under_collected_science_entry(self, queue_ditl) -> None:
+        """A science entry with executed collection remains in the plan."""
         previous_ppt = Mock()
         previous_ppt.obstype = "AT"
         previous_ppt.begin = 1000.0
@@ -2498,10 +2501,9 @@ class TestCalcMethod:
 
         queue_ditl._track_ppt_in_timeline()
 
-        assert previous_ppt not in queue_ditl.plan
-        assert queue_ditl.plan == [current_ppt]
+        assert queue_ditl.plan == [previous_ppt, current_ppt]
         log_text = "\n".join(event.description for event in queue_ditl.log.events)
-        assert "Dropping under-collected science entry 1002" in log_text
+        assert "Keeping under-collected science entry 1002" in log_text
         assert "collected 250s of required 300s" in log_text
 
     def test_close_ppt_timeline_if_needed_closes_when_ppt_none(
@@ -4245,6 +4247,52 @@ class TestQueueDITLCoverage:
                 # Verify that PPT lifecycle management and fetching were NOT called
                 mock_manage_ppt.assert_not_called()
                 mock_fetch_ppt.assert_not_called()
+
+    def test_charging_interrupt_return_early(self, queue_ditl: QueueDITL) -> None:
+        """Starting emergency charging stops science-mode work for the timestep."""
+        charging_ppt = Mock()
+
+        def initiate_charging(utime: float, ra: float, dec: float) -> None:
+            queue_ditl.charging_ppt = charging_ppt
+
+        with (
+            patch.object(
+                queue_ditl, "_should_initiate_charging", return_value=True
+            ) as should_initiate,
+            patch.object(
+                queue_ditl, "_initiate_charging", side_effect=initiate_charging
+            ) as initiate,
+            patch.object(queue_ditl, "_check_too_interrupt") as check_too,
+            patch.object(queue_ditl, "_manage_ppt_lifecycle") as manage_ppt,
+            patch.object(queue_ditl, "_fetch_new_ppt") as fetch_ppt,
+        ):
+            queue_ditl._handle_science_mode(1000.0, 0.0, 0.0, ACSMode.SCIENCE)
+
+        should_initiate.assert_called_once_with(1000.0)
+        initiate.assert_called_once_with(1000.0, 0.0, 0.0)
+        check_too.assert_not_called()
+        manage_ppt.assert_not_called()
+        fetch_ppt.assert_not_called()
+
+    def test_failed_charging_initiation_continues_science_mode(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        with (
+            patch.object(
+                queue_ditl, "_should_initiate_charging", return_value=True
+            ) as should_initiate,
+            patch.object(queue_ditl, "_initiate_charging") as initiate,
+            patch.object(
+                queue_ditl, "_check_too_interrupt", return_value=False
+            ) as check_too,
+            patch.object(queue_ditl, "_manage_ppt_lifecycle") as manage_ppt,
+        ):
+            queue_ditl._handle_science_mode(1000.0, 0.0, 0.0, ACSMode.SCIENCE)
+
+        should_initiate.assert_called_once_with(1000.0)
+        initiate.assert_called_once_with(1000.0, 0.0, 0.0)
+        check_too.assert_called_once_with(1000.0, 0.0, 0.0)
+        manage_ppt.assert_called_once_with(1000.0, ACSMode.SCIENCE)
 
     def test_pass_ending_logic_triggered(self, mock_config, mock_ephem) -> None:
         """Test pass ending logic when previous pass existed but current doesn't (lines 631-642)."""


### PR DESCRIPTION
## Summary
- End ACS science collection immediately when emergency charging interrupts an observation.
- Stop science-mode bookkeeping for the timestep once a charging PPT is created.
- Keep science plan entries that actually collected data, even when they are shorter than `ss_min`; only zero-collection science entries are dropped.

## Why
The attitude timeseries can contain real SCIENCE samples for partial observations. Dropping those entries from the exported plan made validation report unplanned science, so the plan no longer represented what ACS executed.
