### PR TITLE
Fix one-tick science transition gaps

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -447,6 +447,10 @@ class QueueDITL(DITLMixin, DITLStats):
             # Handle spacecraft operations based on current mode
             self._handle_mode_operations(mode, utime, ra, dec)
 
+            same_tick_pointing = self._process_due_acs_commands(utime)
+            if same_tick_pointing is not None:
+                ra, dec, roll, obsid = same_tick_pointing
+
             # Close PPT timeline segment if no active observation
             self._close_ppt_timeline_if_needed(utime)
 
@@ -1171,6 +1175,25 @@ class QueueDITL(DITLMixin, DITLStats):
                     self._close_last_plan_entry(self.ppt.begin)
 
             self.plan.append(self.ppt.copy())
+
+    def _process_due_acs_commands(
+        self, utime: float
+    ) -> tuple[float, float, float, int] | None:
+        """Process ACS commands queued for the current tick.
+
+        QueueDITL may enqueue a command after the tick's first ACS update.  If
+        that command is due now, re-enter ACS at the same timestamp so exported
+        plan entries start when the simulator actually commanded the slew.
+        """
+        if not (
+            self.acs.command_queue and self.acs.command_queue[0].execution_time <= utime
+        ):
+            return None
+
+        pointing = self.acs.pointing(utime)
+        self._sync_acs_slew_metadata()
+        self._track_ppt_in_timeline()
+        return pointing
 
     def _close_ppt_timeline_if_needed(self, utime: float) -> None:
         """Close the last PPT segment in timeline if no active observation.

--- a/tests/scheduler_queue/conftest.py
+++ b/tests/scheduler_queue/conftest.py
@@ -168,6 +168,7 @@ def queue_ditl(mock_config: Mock, mock_ephem: DummyEphemeris) -> QueueDITL:
         mock_acs.saa = None
         mock_acs.pointing = Mock(return_value=(0.0, 0.0, 0.0, 0))
         mock_acs.enqueue_command = Mock()
+        mock_acs.command_queue = []
         mock_acs.passrequests = mock_pt
         mock_acs.slew_dists = []
         mock_acs.executed_commands = []
@@ -602,6 +603,7 @@ def queue_ditl_no_queue_log(
         mock_acs.saa = None
         mock_acs.pointing = Mock(return_value=(0.0, 0.0, 0.0, 0))
         mock_acs.enqueue_command = Mock()
+        mock_acs.command_queue = []
         mock_acs.passrequests = mock_pt
         mock_acs.slew_dists = []
         mock_acs.last_slew = None
@@ -678,6 +680,7 @@ def queue_ditl_acs_no_ephem(
         mock_acs.saa = None
         mock_acs.pointing = Mock(return_value=(0.0, 0.0, 0.0, 0))
         mock_acs.enqueue_command = Mock()
+        mock_acs.command_queue = []
         mock_acs.passrequests = mock_pt
         mock_acs.slew_dists = []
         mock_acs.last_slew = None

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -3595,6 +3595,67 @@ class TestGetACSQueueStatus:
         assert status == expected
 
 
+class TestSameTickACSCommands:
+    """Regression tests for commands queued after the tick's first ACS update."""
+
+    def test_calc_processes_same_tick_ppt_command_before_recording(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """A PPT command enqueued for ``utime`` executes before telemetry is recorded."""
+        queue_ditl.begin = queue_ditl.ephem.timestamp[0]
+        queue_ditl.end = queue_ditl.ephem.timestamp[1]
+        utime = queue_ditl.begin.timestamp()
+        queue_ditl.ephem.step_size = 3600
+        queue_ditl.acs.command_queue = []
+        queue_ditl.acs.get_mode = Mock(return_value=ACSMode.SLEWING)
+
+        next_ppt = PlanEntry(config=queue_ditl.config)
+        next_ppt.begin = utime
+        next_ppt.end = utime + 600.0
+        next_ppt.obsid = 1002
+        next_ppt.ra = 11.0
+        next_ppt.dec = 22.0
+
+        due_command = ACSCommand(
+            command_type=ACSCommandType.SLEW_TO_TARGET,
+            execution_time=utime,
+        )
+
+        def handle_mode_operations(
+            mode: ACSMode, current_time: float, ra: float, dec: float
+        ) -> None:
+            queue_ditl.ppt = next_ppt
+            queue_ditl.acs.command_queue = [due_command]
+
+        def pointing(current_time: float) -> tuple[float, float, float, int]:
+            if queue_ditl.acs.command_queue:
+                queue_ditl.acs.command_queue = []
+                return 11.0, 22.0, 33.0, 1002
+            return 1.0, 2.0, 3.0, IDLE_OBSID
+
+        queue_ditl.acs.pointing = Mock(side_effect=pointing)
+
+        with (
+            patch.object(
+                queue_ditl,
+                "_handle_mode_operations",
+                side_effect=handle_mode_operations,
+            ),
+            patch.object(queue_ditl, "_assert_plan_matches_execution"),
+            patch.object(queue_ditl, "_attach_attitude_timeseries_to_plan"),
+        ):
+            assert queue_ditl.calc() is True
+
+        assert queue_ditl.acs.pointing.call_count == 2
+        assert [(entry.begin, entry.obsid) for entry in queue_ditl.plan] == [
+            (utime, 1002)
+        ]
+        assert queue_ditl.ra == [11.0]
+        assert queue_ditl.dec == [22.0]
+        assert queue_ditl.roll == [33.0]
+        assert queue_ditl.obsid == [1002]
+
+
 class TestTOOFunctionality:
     """Test Target of Opportunity (TOO) functionality in QueueDITL."""
 


### PR DESCRIPTION
## Summary
- process ACS commands that QueueDITL enqueues for the current tick before telemetry/export state is recorded
- sync slew metadata and track the newly commanded PPT timeline entry during that same tick
- add focused regression coverage for a command enqueued after the tick's first ACS update

## Validation
- `pytest tests/scheduler_queue/test_queue_ditl.py -q`
- `prek run --all-files`

This PR is scoped to the same-tick ACS command gap. The broader representative Tamalpais closed-loop generation case is covered by stacked PR #184.