### PR TITLE
fix: keep QueueDITL target state aligned after command churn

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -2045,27 +2045,25 @@ class QueueDITL(DITLMixin, DITLStats):
         self._retry_fetch_without_current_ppt(utime, ra, dec)
         return True
 
-    def _fetch_new_ppt(
-        self, utime: float, ra: float, dec: float, *, _fetch_loop_active: bool = False
-    ) -> None:
+    def _fetch_new_ppt(self, utime: float, ra: float, dec: float) -> None:
         """Fetch a new pointing target from the queue and enqueue slew command."""
-        if not _fetch_loop_active:
-            self._temporary_rejected_ppts = []
-            self._retry_ppt_fetch_requested = False
-            try:
-                while True:
-                    self._retry_ppt_fetch_requested = False
-                    self._fetch_new_ppt(utime, ra, dec, _fetch_loop_active=True)
-                    if self._retry_ppt_fetch_requested:
-                        continue
-                    return
-            finally:
-                temporary_rejections = self._temporary_rejected_ppts or []
-                for rejected_ppt, was_done in temporary_rejections:
-                    rejected_ppt.done = was_done
-                self._temporary_rejected_ppts = None
+        self._temporary_rejected_ppts = []
+        self._retry_ppt_fetch_requested = False
+        try:
+            while True:
                 self._retry_ppt_fetch_requested = False
+                self._fetch_new_ppt_inner(utime, ra, dec)
+                if self._retry_ppt_fetch_requested:
+                    continue
+                return
+        finally:
+            temporary_rejections = self._temporary_rejected_ppts or []
+            for rejected_ppt, was_done in temporary_rejections:
+                rejected_ppt.done = was_done
+            self._temporary_rejected_ppts = None
+            self._retry_ppt_fetch_requested = False
 
+    def _fetch_new_ppt_inner(self, utime: float, ra: float, dec: float) -> None:
         # Don't issue science slews during an active pass - this prevents the
         # teleportation bug where a slew is issued with start position from the
         # pass tracking, but the spacecraft continues following the pass instead.

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -163,6 +163,8 @@ class QueueDITL(DITLMixin, DITLStats):
             starting_obsid=999000,
             log=self.log,
         )
+        self._temporary_rejected_ppts: list[tuple[Any, bool]] | None = None
+        self._retry_ppt_fetch_requested = False
 
         # Track whether the last PPT fetch attempt was unsuccessful (no target dispatched).
         # Set True when the queue is empty or all candidates are rejected; False on
@@ -478,9 +480,9 @@ class QueueDITL(DITLMixin, DITLStats):
             # Fault management checks (e.g., battery level thresholds)
             self._handle_fault_management(utime, hk)
 
-        # Make sure the last PPT of the day ends (if any)
-        if self.plan:
-            self._close_last_plan_entry(utime)
+        # Make sure an active PPT ends at the simulation boundary.
+        if self.plan and self.ppt is not None:
+            self._close_last_plan_entry(self.uend)
 
         self._assert_plan_matches_execution()
         self._attach_attitude_timeseries_to_plan()
@@ -1219,8 +1221,45 @@ class QueueDITL(DITLMixin, DITLStats):
 
         pointing = self.acs.pointing(utime)
         self._sync_acs_slew_metadata()
+        self._clear_canceled_ppt(utime)
         self._track_ppt_in_timeline()
         return pointing
+
+    @staticmethod
+    def _slew_matches_obsid(slew: Slew | None, obsid: int) -> bool:
+        return isinstance(slew, Slew) and int(slew.obsid) == obsid
+
+    def _ppt_has_pending_or_active_slew(self, obsid: int) -> bool:
+        if self._slew_matches_obsid(self.acs.current_slew, obsid):
+            return True
+        if self._slew_matches_obsid(self.acs.last_slew, obsid):
+            return True
+        return any(
+            command.command_type == ACSCommandType.SLEW_TO_TARGET
+            and self._slew_matches_obsid(command.slew, obsid)
+            for command in self.acs.command_queue
+        )
+
+    def _clear_canceled_ppt(self, utime: float) -> None:
+        """Clear a just-selected science PPT whose ACS slew was canceled."""
+        if self.ppt is None or self.ppt is self.charging_ppt:
+            return
+        obstype = self._entry_obstype(self.ppt)
+        if obstype not in (ObsType.AT, ObsType.TOO):
+            return
+
+        obsid = int(self.ppt.obsid)
+        if self._ppt_has_pending_or_active_slew(obsid):
+            return
+
+        self.log.log_event(
+            utime=utime,
+            event_type="QUEUE",
+            description=f"Clearing PPT {obsid} - ACS slew was canceled before execution",
+            obsid=obsid,
+            acs_mode=self.acs.acsmode,
+        )
+        self.ppt = None
 
     def _close_ppt_timeline_if_needed(self, utime: float) -> None:
         """Close the last PPT segment in timeline if no active observation.
@@ -1961,6 +2000,12 @@ class QueueDITL(DITLMixin, DITLStats):
         was_done = rejected_ppt.done
         rejected_ppt.done = True
         self.ppt = None
+
+        if self._temporary_rejected_ppts is not None:
+            self._temporary_rejected_ppts.append((rejected_ppt, was_done))
+            self._retry_ppt_fetch_requested = True
+            return
+
         try:
             self._fetch_new_ppt(utime, ra, dec)
         finally:
@@ -2000,8 +2045,27 @@ class QueueDITL(DITLMixin, DITLStats):
         self._retry_fetch_without_current_ppt(utime, ra, dec)
         return True
 
-    def _fetch_new_ppt(self, utime: float, ra: float, dec: float) -> None:
+    def _fetch_new_ppt(
+        self, utime: float, ra: float, dec: float, *, _fetch_loop_active: bool = False
+    ) -> None:
         """Fetch a new pointing target from the queue and enqueue slew command."""
+        if not _fetch_loop_active:
+            self._temporary_rejected_ppts = []
+            self._retry_ppt_fetch_requested = False
+            try:
+                while True:
+                    self._retry_ppt_fetch_requested = False
+                    self._fetch_new_ppt(utime, ra, dec, _fetch_loop_active=True)
+                    if self._retry_ppt_fetch_requested:
+                        continue
+                    return
+            finally:
+                temporary_rejections = self._temporary_rejected_ppts or []
+                for rejected_ppt, was_done in temporary_rejections:
+                    rejected_ppt.done = was_done
+                self._temporary_rejected_ppts = None
+                self._retry_ppt_fetch_requested = False
+
         # Don't issue science slews during an active pass - this prevents the
         # teleportation bug where a slew is issued with start position from the
         # pass tracking, but the spacecraft continues following the pass instead.

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -1196,6 +1196,52 @@ class TestFetchNewPPT:
         assert "Target 1001 rejected" in log_text
         assert "available before pass" in log_text
 
+    def test_fetch_ppt_retries_many_rejected_targets_without_recursion(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Large queues of infeasible targets should not recurse through the stack."""
+        queue_ditl.ephem.step_size = 60
+
+        targets = []
+        for index in range(1100):
+            target = Mock()
+            target.ra = 45.0
+            target.dec = 30.0
+            target.obsid = 1000 + index
+            target.done = False
+            target.next_vis = Mock(return_value=1000.0)
+            target.ss_max = 3600.0
+            target.ss_min = 300.0
+            target.windows = [[0.0, 1100.0]]
+            targets.append(target)
+
+        good_ppt = Mock()
+        good_ppt.ra = 46.0
+        good_ppt.dec = 31.0
+        good_ppt.obsid = 9999
+        good_ppt.done = False
+        good_ppt.next_vis = Mock(return_value=1000.0)
+        good_ppt.ss_max = 3600.0
+        good_ppt.ss_min = 30.0
+        good_ppt.windows = [[0.0, 5000.0]]
+        targets.append(good_ppt)
+
+        queue_ditl.queue.targets = targets
+
+        def get_next_not_done(ra: float, dec: float, utime: float) -> Mock | None:
+            return next((target for target in targets if not target.done), None)
+
+        cast(Mock, queue_ditl.queue).get = Mock(side_effect=get_next_not_done)
+        cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
+        cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(return_value=None)
+
+        queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        assert queue_ditl.ppt is good_ppt
+        assert all(target.done is False for target in targets)
+        assert queue_ditl._temporary_rejected_ppts is None
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_called_once()
+
     def test_fetch_ppt_rejects_when_locked_roll_violates_constraint_in_window(
         self, queue_ditl
     ) -> None:
@@ -2213,6 +2259,33 @@ class TestCalcMethod:
         assert len(queue_ditl.mode) == 24
         assert len(queue_ditl.ra) == 24
         assert len(queue_ditl.dec) == 24
+
+    def test_calc_closes_final_ppt_at_simulation_end(self, queue_ditl) -> None:
+        begin = queue_ditl.ephem.timestamp[0]
+        end = queue_ditl.ephem.timestamp[1]
+        queue_ditl.begin = begin
+        queue_ditl.end = end
+        queue_ditl.step_size = 3600
+        queue_ditl.acs.get_mode = Mock(return_value=ACSMode.SCIENCE)
+        queue_ditl.acs.pointing = Mock(return_value=(10.0, 20.0, 0.0, 1001))
+        queue_ditl._assert_plan_matches_execution = Mock()
+
+        ppt = PlanEntry(config=queue_ditl.config)
+        ppt.obstype = ObsType.AT
+        ppt.begin = begin.timestamp()
+        ppt.end = begin.timestamp() + 86400.0
+        ppt.slewtime = 0.0
+        ppt.insaa = 0.0
+        ppt.ss_min = 0.0
+        ppt.obsid = 1001
+        ppt.ra = 10.0
+        ppt.dec = 20.0
+        ppt.exptime = 7200
+        queue_ditl.ppt = ppt
+
+        assert queue_ditl.calc() is True
+
+        assert queue_ditl.plan[-1].end == end.timestamp()
 
     def test_calc_sets_acs_ephemeris(self, queue_ditl) -> None:
         queue_ditl.acs.ephem = None
@@ -3943,6 +4016,9 @@ class TestSameTickACSCommands:
             command_type=ACSCommandType.SLEW_TO_TARGET,
             execution_time=utime,
         )
+        active_slew = Slew(config=queue_ditl.config)
+        active_slew.obstype = ObsType.PPT
+        active_slew.obsid = 1002
 
         def handle_mode_operations(
             mode: ACSMode, current_time: float, ra: float, dec: float
@@ -3953,6 +4029,8 @@ class TestSameTickACSCommands:
         def pointing(current_time: float) -> tuple[float, float, float, int]:
             if queue_ditl.acs.command_queue:
                 queue_ditl.acs.command_queue = []
+                queue_ditl.acs.current_slew = active_slew
+                queue_ditl.acs.last_slew = active_slew
                 return 11.0, 22.0, 33.0, 1002
             return 1.0, 2.0, 3.0, IDLE_OBSID
 
@@ -4000,6 +4078,9 @@ class TestSameTickACSCommands:
         science.roll = 24.0
         science.begin = utime
         science.end = utime + 600.0
+        science_slew = Slew(config=queue_ditl.config)
+        science_slew.obstype = ObsType.PPT
+        science_slew.obsid = science.obsid
 
         queue_ditl.plan = [charge]
         queue_ditl.ppt = charge
@@ -4019,6 +4100,7 @@ class TestSameTickACSCommands:
                 ACSCommand(
                     command_type=ACSCommandType.SLEW_TO_TARGET,
                     execution_time=current_time,
+                    slew=science_slew,
                 )
             )
 
@@ -4026,6 +4108,8 @@ class TestSameTickACSCommands:
             assert current_time == utime
             queue_ditl.acs.executed_commands.extend(queue_ditl.acs.command_queue)
             queue_ditl.acs.command_queue = []
+            queue_ditl.acs.current_slew = science_slew
+            queue_ditl.acs.last_slew = science_slew
             return science.ra, science.dec, science.roll, science.obsid
 
         queue_ditl.acs.enqueue_command = Mock(side_effect=enqueue)
@@ -4051,6 +4135,49 @@ class TestSameTickACSCommands:
             (ObsType.AT, utime, utime + 600.0),
         ]
         assert queue_ditl.plan[0].end == queue_ditl.plan[1].begin
+
+    def test_process_due_commands_clears_ppt_when_slew_is_canceled(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        utime = 1000.0
+        previous_entry = PlanEntry(config=queue_ditl.config)
+        previous_entry.obstype = ObsType.AT
+        previous_entry.obsid = 1001
+        previous_entry.begin = 0.0
+        previous_entry.end = 900.0
+        queue_ditl.plan.append(previous_entry)
+
+        canceled_ppt = PlanEntry(config=queue_ditl.config)
+        canceled_ppt.obstype = ObsType.AT
+        canceled_ppt.obsid = 10545
+        canceled_ppt.begin = utime
+        canceled_ppt.end = utime + 86400.0
+        queue_ditl.ppt = canceled_ppt
+
+        due_command = ACSCommand(
+            command_type=ACSCommandType.SLEW_TO_TARGET,
+            execution_time=utime,
+        )
+        queue_ditl.acs.command_queue = [due_command]
+        charge_slew = Slew(config=queue_ditl.config)
+        charge_slew.obstype = ObsType.CHARGE
+        charge_slew.obsid = 999000
+
+        def pointing(current_time: float) -> tuple[float, float, float, int]:
+            queue_ditl.acs.command_queue = []
+            queue_ditl.acs.current_slew = charge_slew
+            queue_ditl.acs.last_slew = charge_slew
+            return 1.0, 2.0, 3.0, 999000
+
+        queue_ditl.acs.pointing = Mock(side_effect=pointing)
+
+        assert queue_ditl._process_due_acs_commands(utime) == (1.0, 2.0, 3.0, 999000)
+
+        assert queue_ditl.ppt is None
+        assert list(queue_ditl.plan) == [previous_entry]
+        assert previous_entry.end == 900.0
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Clearing PPT 10545" in log_text
 
 
 class TestTOOFunctionality:


### PR DESCRIPTION
## Summary
- clear a newly selected science PPT when same-tick ACS processing shows its target slew was canceled before execution
- retry rejected PPT candidates iteratively instead of recursively, restoring temporary `done` flags after selection
- close an active PPT at the simulation end boundary rather than at the last recorded sample
- keep this PR scoped to the remaining work not covered by #192

## Why
#192 handles the broad plan/execution bookkeeping drift and dropped-window validation. This follow-up keeps the QueueDITL target pointer aligned with ACS after command churn so a canceled science target cannot become a phantom plan entry, and it removes the recursive retry path that can overflow when many queued targets are rejected in sequence.

This remains stacked on #187 because it uses #187 same-tick ACS command processing.

## Validation
- `/home/aaron/Projects/Cosmic/ops/coast-sim/coastvenv/bin/python -m pytest tests/scheduler_queue/test_queue_ditl.py -q` -> 223 passed
- temporary merge with #192 plus `/home/aaron/Projects/Cosmic/ops/coast-sim/coastvenv/bin/python -m pytest tests/scheduler_queue/test_queue_ditl.py tests/acs/test_acs_coverage.py -q` -> 305 passed

## Relationship to #192
#192 replaces the previous under-collected science / dropped-window validation parts of this branch. Those changes have been removed from this PR.