### PR TITLE
ci: add QueueDITL engine seed smoke

### DIFF
--- a/.github/workflows/queue-ditl-seed-smoke.yml
+++ b/.github/workflows/queue-ditl-seed-smoke.yml
@@ -1,0 +1,73 @@
+name: QueueDITL Engine Seed Smoke
+
+on:
+  schedule:
+    - cron: "37 9 * * *"
+  workflow_dispatch:
+    inputs:
+      start_seed:
+        description: First seed to scan
+        required: false
+        default: "0"
+      seed_count:
+        description: Number of seeds to scan
+        required: false
+        default: "32"
+      target_count:
+        description: Number of generated targets per seed
+        required: false
+        default: "1000"
+      max_failures:
+        description: Stop each shard after this many failures
+        required: false
+        default: "10"
+
+permissions:
+  contents: read
+
+jobs:
+  seed-scan:
+    name: Seed smoke shard ${{ matrix.shard_index }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard_index: [0, 1, 2, 3]
+    env:
+      START_SEED: ${{ github.event.inputs.start_seed || '0' }}
+      SEED_COUNT: ${{ github.event.inputs.seed_count || '32' }}
+      TARGET_COUNT: ${{ github.event.inputs.target_count || '1000' }}
+      MAX_FAILURES: ${{ github.event.inputs.max_failures || '10' }}
+      SHARD_COUNT: "4"
+      OUTPUT_DIR: seed-scan-results/shard-${{ matrix.shard_index }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          activate-environment: true
+          python-version: "3.12"
+
+      - name: Install package
+        run: uv pip install .[test]
+
+      - name: Run seed scan
+        run: >-
+          python scripts/scan_queue_ditl_seeds.py
+          --start-seed "$START_SEED"
+          --seed-count "$SEED_COUNT"
+          --target-count "$TARGET_COUNT"
+          --shard-index "${{ matrix.shard_index }}"
+          --shard-count "$SHARD_COUNT"
+          --max-failures "$MAX_FAILURES"
+          --output-dir "$OUTPUT_DIR"
+
+      - name: Upload seed scan results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: seed-scan-shard-${{ matrix.shard_index }}
+          path: seed-scan-results/
+          if-no-files-found: ignore

--- a/scripts/scan_queue_ditl_seeds.py
+++ b/scripts/scan_queue_ditl_seeds.py
@@ -1,0 +1,332 @@
+"""Smoke-test seeded QueueDITL plan generation runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from rust_ephem import TLEEphemeris
+
+from conops.config.config import MissionConfig
+from conops.ditl.queue_ditl import PlanExecutionMismatchError, QueueDITL
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def build_seeded_example_ditl(seed: int, target_count: int) -> QueueDITL:
+    """Build the generic seeded QueueDITL scenario used by CI."""
+    config = MissionConfig(random_seed=seed)
+    config.constraint.ignore_roll = True
+    ephemeris = TLEEphemeris(
+        begin=datetime(2025, 12, 1, 0, 0, 0),
+        end=datetime(2025, 12, 2, 0, 0, 0),
+        step_size=60,
+        tle=str(REPO_ROOT / "examples/example.tle"),
+    )
+
+    ditl = QueueDITL(config=config, ephem=ephemeris)
+    rng = np.random.default_rng(seed)
+    for index in range(target_count):
+        ditl.queue.add(
+            ra=rng.uniform(0, 360),
+            dec=rng.uniform(-90, 90),
+            exptime=1000,
+            obsid=10000 + index,
+        )
+    return ditl
+
+
+def run_seeded_example_plan(seed: int, target_count: int) -> QueueDITL:
+    """Run one seeded generic QueueDITL scenario through validation."""
+    ditl = build_seeded_example_ditl(seed=seed, target_count=target_count)
+    ditl.calc()
+    return ditl
+
+
+def shard_seeds(
+    start_seed: int, seed_count: int, shard_index: int, shard_count: int
+) -> list[int]:
+    """Return the seeds assigned to one shard."""
+    return [
+        start_seed + offset
+        for offset in range(seed_count)
+        if offset % shard_count == shard_index
+    ]
+
+
+def failure_record(seed: int, exc: Exception, ditl: QueueDITL | None) -> dict[str, Any]:
+    """Build a JSON-serializable failure record for one seed."""
+    record: dict[str, Any] = {
+        "seed": seed,
+        "error_type": type(exc).__name__,
+        "message": str(exc),
+    }
+    if ditl is None:
+        return record
+
+    record["plan_entries"] = len(ditl.plan)
+    record["telemetry_samples"] = len(ditl.utime)
+    record["last_events"] = [str(event) for event in ditl.log.events[-20:]]
+    record["stats"] = collect_ditl_stats(seed, ditl)
+    if isinstance(exc, PlanExecutionMismatchError):
+        record["mismatches"] = [
+            str(mismatch) for mismatch in ditl.validate_plan_matches_execution()[:20]
+        ]
+    return record
+
+
+def _name(value: Any) -> str:
+    name = getattr(value, "name", None)
+    if isinstance(name, str):
+        return name
+    return str(value)
+
+
+def _duration_seconds(begin: Any, end: Any) -> float:
+    try:
+        return max(0.0, float(end) - float(begin))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _mode_sample_durations(ditl: QueueDITL) -> list[float]:
+    utime = [float(t) for t in getattr(ditl, "utime", [])]
+    if not utime:
+        return []
+
+    fallback = float(getattr(ditl, "step_size", 0.0) or 0.0)
+    durations: list[float] = []
+    for index, start in enumerate(utime):
+        if index + 1 < len(utime):
+            durations.append(max(0.0, float(utime[index + 1]) - start))
+        else:
+            durations.append(fallback)
+    return durations
+
+
+def _event_counts(ditl: QueueDITL) -> dict[str, int]:
+    return dict(
+        Counter(_name(getattr(event, "event_type", "")) for event in ditl.log.events)
+    )
+
+
+def _event_description_count(ditl: QueueDITL, needles: tuple[str, ...]) -> int:
+    count = 0
+    for event in ditl.log.events:
+        description = str(getattr(event, "description", "")).lower()
+        if any(needle in description for needle in needles):
+            count += 1
+    return count
+
+
+def _numeric(values: list[Any]) -> list[float]:
+    result: list[float] = []
+    for value in values:
+        if value is None:
+            continue
+        try:
+            result.append(float(value))
+        except (TypeError, ValueError):
+            continue
+    return result
+
+
+def collect_ditl_stats(seed: int, ditl: QueueDITL) -> dict[str, Any]:
+    """Collect non-failing summary statistics for one completed DITL run."""
+    entry_counts: Counter[str] = Counter()
+    planned_seconds_by_type: Counter[str] = Counter()
+    slew_times: list[float] = []
+    slew_distances: list[float] = []
+
+    for entry in ditl.plan:
+        entry_type = _name(getattr(entry, "obstype", "unknown"))
+        entry_counts[entry_type] += 1
+        planned_seconds_by_type[entry_type] += _duration_seconds(
+            getattr(entry, "begin", None),
+            getattr(entry, "end", None),
+        )
+        slew_times.extend(_numeric([getattr(entry, "slewtime", None)]))
+        slew_distances.extend(_numeric([getattr(entry, "slewdist", None)]))
+
+    mode_seconds: Counter[str] = Counter()
+    for mode, duration in zip(getattr(ditl, "mode", []), _mode_sample_durations(ditl)):
+        mode_seconds[_name(mode)] += duration
+
+    validation_mismatches = ditl.validate_plan_matches_execution()
+    constraint_mismatches = [
+        mismatch
+        for mismatch in validation_mismatches
+        if "constraint_violation" in str(mismatch)
+    ]
+
+    battery_levels = _numeric(getattr(ditl, "batterylevel", []))
+    recorder_fill = _numeric(getattr(ditl, "recorder_fill_fraction", []))
+
+    return {
+        "seed": seed,
+        "plan_entries": len(ditl.plan),
+        "telemetry_samples": len(getattr(ditl, "utime", [])),
+        "entries_by_type": dict(entry_counts),
+        "planned_seconds_by_type": dict(planned_seconds_by_type),
+        "executed_seconds_by_mode": dict(mode_seconds),
+        "executed_science_seconds": float(mode_seconds.get("SCIENCE", 0.0)),
+        "executed_contact_seconds": float(mode_seconds.get("PASS", 0.0)),
+        "executed_slew_seconds": float(mode_seconds.get("SLEWING", 0.0)),
+        "executed_idle_seconds": float(mode_seconds.get("IDLE", 0.0)),
+        "max_slew_seconds": max(slew_times, default=0.0),
+        "max_slew_degrees": max(slew_distances, default=0.0),
+        "battery_min": min(battery_levels, default=None),
+        "battery_final": battery_levels[-1] if battery_levels else None,
+        "recorder_fill_final": recorder_fill[-1] if recorder_fill else None,
+        "event_counts": _event_counts(ditl),
+        "queue_rejection_events": _event_description_count(
+            ditl, ("rejected", "skipped")
+        ),
+        "constraint_log_events": _event_description_count(ditl, ("constraint",)),
+        "validation_mismatch_count": len(validation_mismatches),
+        "constraint_mismatch_count": len(constraint_mismatches),
+    }
+
+
+def _rollup_values(values: list[float]) -> dict[str, float] | None:
+    if not values:
+        return None
+    return {
+        "min": min(values),
+        "max": max(values),
+        "mean": sum(values) / len(values),
+    }
+
+
+def rollup_stats(seed_stats: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return aggregate stats for all successful seeds in one shard."""
+    numeric_keys = (
+        "plan_entries",
+        "executed_science_seconds",
+        "executed_contact_seconds",
+        "executed_slew_seconds",
+        "executed_idle_seconds",
+        "max_slew_seconds",
+        "max_slew_degrees",
+        "queue_rejection_events",
+        "constraint_log_events",
+        "validation_mismatch_count",
+        "constraint_mismatch_count",
+    )
+    return {
+        key: rollup
+        for key in numeric_keys
+        if (
+            rollup := _rollup_values(
+                [
+                    float(stats[key])
+                    for stats in seed_stats
+                    if stats.get(key) is not None
+                ]
+            )
+        )
+        is not None
+    }
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def scan_seeds(args: argparse.Namespace) -> int:
+    seeds = shard_seeds(
+        start_seed=args.start_seed,
+        seed_count=args.seed_count,
+        shard_index=args.shard_index,
+        shard_count=args.shard_count,
+    )
+    output_dir = Path(args.output_dir)
+    failures: list[dict[str, Any]] = []
+    seed_stats: list[dict[str, Any]] = []
+    scanned_seeds: list[int] = []
+
+    print(
+        f"Scanning {len(seeds)} seed(s): start={args.start_seed}, "
+        f"count={args.seed_count}, shard={args.shard_index}/{args.shard_count}, "
+        f"target_count={args.target_count}"
+    )
+    for seed in seeds:
+        scanned_seeds.append(seed)
+        ditl: QueueDITL | None = None
+        try:
+            ditl = build_seeded_example_ditl(
+                seed=seed,
+                target_count=args.target_count,
+            )
+            ditl.calc()
+        except Exception as exc:
+            failure = failure_record(seed, exc, ditl)
+            failures.append(failure)
+            write_json(output_dir / f"seed_{seed}_failure.json", failure)
+            print(f"FAIL seed={seed}: {type(exc).__name__}: {exc}")
+            if len(failures) >= args.max_failures:
+                break
+        else:
+            stats = collect_ditl_stats(seed, ditl)
+            seed_stats.append(stats)
+            write_json(output_dir / f"seed_{seed}_stats.json", stats)
+            print(
+                f"PASS seed={seed}: entries={stats['plan_entries']} "
+                f"science_s={stats['executed_science_seconds']:.0f} "
+                f"slew_s={stats['executed_slew_seconds']:.0f}"
+            )
+
+    summary = {
+        "start_seed": args.start_seed,
+        "seed_count": args.seed_count,
+        "shard_index": args.shard_index,
+        "shard_count": args.shard_count,
+        "target_count": args.target_count,
+        "scanned_seeds": scanned_seeds,
+        "failure_count": len(failures),
+        "failures": failures,
+        "seed_stats": seed_stats,
+        "stats_rollup": rollup_stats(seed_stats),
+    }
+    write_json(output_dir / "summary.json", summary)
+    return 1 if failures else 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Smoke-test seeded QueueDITL plan generation runs."
+    )
+    parser.add_argument("--start-seed", type=int, default=0)
+    parser.add_argument("--seed-count", type=int, default=32)
+    parser.add_argument("--target-count", type=int, default=1000)
+    parser.add_argument("--shard-index", type=int, default=0)
+    parser.add_argument("--shard-count", type=int, default=1)
+    parser.add_argument("--max-failures", type=int, default=10)
+    parser.add_argument("--output-dir", default="seed-scan-results")
+    args = parser.parse_args()
+
+    if args.seed_count < 1:
+        parser.error("--seed-count must be positive")
+    if args.target_count < 1:
+        parser.error("--target-count must be positive")
+    if args.shard_count < 1:
+        parser.error("--shard-count must be positive")
+    if not 0 <= args.shard_index < args.shard_count:
+        parser.error("--shard-index must satisfy 0 <= index < shard-count")
+    if args.max_failures < 1:
+        parser.error("--max-failures must be positive")
+    return args
+
+
+def main() -> int:
+    return scan_seeds(parse_args())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -2,13 +2,10 @@
 
 import json
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from typing import cast
 from unittest.mock import Mock, patch
 
-import numpy as np
 import pytest
-from rust_ephem import TLEEphemeris
 
 from conops import (
     ACS,
@@ -26,6 +23,7 @@ from conops.config.config import MissionConfig
 from conops.ditl.telemetry import Housekeeping
 from conops.simulation.acs import IDLE_OBSID
 from conops.targets import PlanEntry, PlanSchema, Pointing
+from scripts.scan_queue_ditl_seeds import run_seeded_example_plan
 
 
 class TestQueueDITLInitialization:
@@ -2158,27 +2156,7 @@ class TestClosedLoopPlanGeneration:
 
     def test_seeded_example_plan_generation_matches_execution(self, tmp_path) -> None:
         """Run a representative seeded QueueDITL plan through export validation."""
-        seed = 5
-        config = MissionConfig(random_seed=seed)
-        ephemeris = TLEEphemeris(
-            begin=datetime(2025, 12, 1, 0, 0, 0),
-            end=datetime(2025, 12, 2, 0, 0, 0),
-            step_size=60,
-            tle=str(Path("examples/example.tle")),
-        )
-        config.constraint.ignore_roll = True
-
-        ditl = QueueDITL(config=config, ephem=ephemeris)
-        rng = np.random.default_rng(seed)
-        for index in range(1000):
-            ditl.queue.add(
-                ra=rng.uniform(0, 360),
-                dec=rng.uniform(-90, 90),
-                exptime=1000,
-                obsid=10000 + index,
-            )
-
-        assert ditl.calc() is True
+        ditl = run_seeded_example_plan(seed=5, target_count=1000)
         assert len(ditl.plan) > 0
         assert ditl.validate_plan_matches_execution() == []
 

--- a/tests/scheduler_queue/test_seed_scan.py
+++ b/tests/scheduler_queue/test_seed_scan.py
@@ -1,0 +1,98 @@
+"""Tests for the QueueDITL seed scan helper script."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from conops import ACSMode, PlanExecutionMismatchError
+from conops.common.enums import ObsType
+from scripts import scan_queue_ditl_seeds
+
+
+def _scan_args(tmp_path, seed: int = 7) -> Mock:
+    return Mock(
+        start_seed=seed,
+        seed_count=1,
+        target_count=10,
+        shard_index=0,
+        shard_count=1,
+        max_failures=10,
+        output_dir=str(tmp_path),
+    )
+
+
+def test_scan_writes_success_stats(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    entry = Mock()
+    entry.obstype = ObsType.AT
+    entry.begin = 0.0
+    entry.end = 120.0
+    entry.slewtime = 30.0
+    entry.slewdist = 4.5
+
+    event = Mock()
+    event.event_type = "QUEUE"
+    event.description = "Target skipped during scan"
+
+    ditl = Mock()
+    ditl.plan = [entry]
+    ditl.utime = [0.0, 60.0]
+    ditl.mode = [ACSMode.SCIENCE, ACSMode.IDLE]
+    ditl.step_size = 60.0
+    ditl.batterylevel = [0.8, 0.7]
+    ditl.recorder_fill_fraction = [0.1, 0.2]
+    ditl.log.events = [event]
+    ditl.validate_plan_matches_execution.return_value = []
+
+    monkeypatch.setattr(
+        scan_queue_ditl_seeds,
+        "build_seeded_example_ditl",
+        Mock(return_value=ditl),
+    )
+
+    assert scan_queue_ditl_seeds.scan_seeds(_scan_args(tmp_path)) == 0
+
+    stats = json.loads((tmp_path / "seed_7_stats.json").read_text())
+    summary = json.loads((tmp_path / "summary.json").read_text())
+    assert stats["executed_science_seconds"] == 60.0
+    assert stats["max_slew_degrees"] == 4.5
+    assert stats["validation_mismatch_count"] == 0
+    assert summary["stats_rollup"]["executed_science_seconds"]["mean"] == 60.0
+
+
+def test_scan_fails_on_plan_execution_constraint_violation(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    event = Mock()
+    event.event_type = "ERROR"
+    event.description = "constraint violation"
+
+    ditl = Mock()
+    ditl.plan = []
+    ditl.utime = [0.0]
+    ditl.mode = [ACSMode.SLEWING]
+    ditl.step_size = 60.0
+    ditl.batterylevel = []
+    ditl.recorder_fill_fraction = []
+    ditl.log.events = [event]
+    ditl.calc.side_effect = PlanExecutionMismatchError(
+        "Plan execution validation failed: constraint_violation"
+    )
+    ditl.validate_plan_matches_execution.return_value = [
+        "attitude constraint_violation: mode SLEWING violates ST Hard"
+    ]
+
+    monkeypatch.setattr(
+        scan_queue_ditl_seeds,
+        "build_seeded_example_ditl",
+        Mock(return_value=ditl),
+    )
+
+    assert scan_queue_ditl_seeds.scan_seeds(_scan_args(tmp_path)) == 1
+
+    failure = json.loads((tmp_path / "seed_7_failure.json").read_text())
+    summary = json.loads((tmp_path / "summary.json").read_text())
+    assert failure["error_type"] == "PlanExecutionMismatchError"
+    assert "constraint_violation" in failure["mismatches"][0]
+    assert failure["stats"]["constraint_mismatch_count"] == 1
+    assert summary["failure_count"] == 1


### PR DESCRIPTION
## Summary
- add a reusable seeded QueueDITL scan script with sharding, max-failure limiting, JSON failure artifacts, per-seed stats, and shard-level stats rollups
- add a scheduled/manual engine smoke workflow that runs a small generic seed sample by default
- make the existing seeded regression use the same helper as the scan so CI and the workflow exercise the same scenario
- add scanner tests proving stats are written and constraint-violation PlanExecutionMismatchError failures make the scan return nonzero

## Why
This keeps coast-sim focused on generic scheduler/QueueDITL engine coverage. The larger mission-specific seed sweep belongs in the mission configuration repo, where the real target sampling, spacecraft config, ground stations, and constraint policy live. This PR still leaves a reusable scanner in coast so engine regressions are caught and mission repos can follow the same artifact pattern.

## Validation
- python scripts/scan_queue_ditl_seeds.py --seed-count 1 --target-count 50 --output-dir /tmp/coast-seed-smoke-split
- pytest tests/scheduler_queue/test_seed_scan.py tests/scheduler_queue/test_queue_ditl.py::TestClosedLoopPlanGeneration::test_seeded_example_plan_generation_matches_execution -q
- prek run --all-files during amend hook
- standalone prek run --all-files progressed through code/workflow hooks, then failed at sphinx-build because sphinx-build is not installed in this local environment

Stacked on #184 because the scan depends on the closed-loop plan/execution validation fixes there.