### PR TITLE
fix: only guard science dispatch below battery floor

### DIFF
--- a/conops/config/battery.py
+++ b/conops/config/battery.py
@@ -72,11 +72,8 @@ class Battery(ConfigModel):
     @property
     def battery_alert(self) -> bool:
         """Is the battery in an alert status caused by discharge"""
-        # Calculate minimum allowed charge level from max depth of discharge
-        min_charge_level = 1.0 - self.max_depth_of_discharge
-
         # Depth of discharge > max_depth_of_discharge, start an emergency recharge state
-        if self.battery_level < min_charge_level:
+        if self.below_minimum_charge_level:
             self.emergency_recharge = True
             return True
 
@@ -87,6 +84,16 @@ class Battery(ConfigModel):
         else:
             self.emergency_recharge = False
             return False
+
+    @property
+    def minimum_charge_level(self) -> float:
+        """Minimum allowed state of charge before the depth-of-discharge limit is exceeded."""
+        return 1.0 - self.max_depth_of_discharge
+
+    @property
+    def below_minimum_charge_level(self) -> bool:
+        """True when state of charge is below the configured depth-of-discharge floor."""
+        return self.battery_level < self.minimum_charge_level
 
     def charge(self, power: float, period: float) -> None:
         """Charge the battery with <power> Watts for <period> seconds"""

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -2064,6 +2064,16 @@ class QueueDITL(DITLMixin, DITLStats):
             self._retry_ppt_fetch_requested = False
 
     def _fetch_new_ppt_inner(self, utime: float, ra: float, dec: float) -> None:
+        if self.battery.battery_alert:
+            self.log.log_event(
+                utime=utime,
+                event_type="QUEUE",
+                description="Deferring PPT fetch - battery alert active",
+                acs_mode=self.acs.acsmode,
+            )
+            self._ppt_unavailable = None
+            return
+
         # Don't issue science slews during an active pass - this prevents the
         # teleportation bug where a slew is issued with start position from the
         # pass tracking, but the spacecraft continues following the pass instead.

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1981,7 +1981,7 @@ class QueueDITL(DITLMixin, DITLStats):
 
         constraint_time = self._ephem_utime_at_or_after(current_time)
         if not self.constraint.in_eclipse(ra=0, dec=0, time=constraint_time):
-            return current_time
+            return constraint_time
 
         for timestamp in self.ephem.timestamp:
             utime = self._ephem_timestamp_to_utime(timestamp)
@@ -1992,7 +1992,7 @@ class QueueDITL(DITLMixin, DITLStats):
         return None
 
     def _next_science_deadline(
-        self, slew_end: float, current_time: float | None = None
+        self, slew_end: float, current_time: float
     ) -> tuple[float, str]:
         """Determine the next science deadline after the slew ends, which could
         be the end of the current visibility window, the next pass, or the end
@@ -2009,9 +2009,7 @@ class QueueDITL(DITLMixin, DITLStats):
         if pass_deadline is not None:
             deadlines.append((pass_deadline, "pass"))
 
-        charge_deadline = self._next_charge_science_deadline(
-            current_time if current_time is not None else slew_end
-        )
+        charge_deadline = self._next_charge_science_deadline(current_time)
         if charge_deadline is not None:
             deadlines.append((charge_deadline, "charge opportunity"))
 

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1967,12 +1967,20 @@ class QueueDITL(DITLMixin, DITLStats):
             return float(timestamp.timestamp())
         return float(timestamp)
 
+    def _ephem_utime_at_or_after(self, utime: float) -> float:
+        timestamps = [self._ephem_timestamp_to_utime(ts) for ts in self.ephem.timestamp]
+        index = bisect_left(timestamps, utime)
+        if index >= len(timestamps):
+            return timestamps[-1]
+        return timestamps[index]
+
     def _next_charge_science_deadline(self, current_time: float) -> float | None:
         """Return when pending battery recharge can next preempt science."""
         if not self.battery.battery_alert or self.charging_ppt is not None:
             return None
 
-        if not self.constraint.in_eclipse(ra=0, dec=0, time=current_time):
+        constraint_time = self._ephem_utime_at_or_after(current_time)
+        if not self.constraint.in_eclipse(ra=0, dec=0, time=constraint_time):
             return current_time
 
         for timestamp in self.ephem.timestamp:

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1961,7 +1961,31 @@ class QueueDITL(DITLMixin, DITLStats):
     def _pass_slew_trigger_buffer(self) -> float:
         return pass_slew_trigger_buffer(self.ephem.step_size)
 
-    def _next_science_deadline(self, slew_end: float) -> tuple[float, str]:
+    @staticmethod
+    def _ephem_timestamp_to_utime(timestamp: Any) -> float:
+        if hasattr(timestamp, "timestamp"):
+            return float(timestamp.timestamp())
+        return float(timestamp)
+
+    def _next_charge_science_deadline(self, current_time: float) -> float | None:
+        """Return when pending battery recharge can next preempt science."""
+        if not self.battery.battery_alert or self.charging_ppt is not None:
+            return None
+
+        if not self.constraint.in_eclipse(ra=0, dec=0, time=current_time):
+            return current_time
+
+        for timestamp in self.ephem.timestamp:
+            utime = self._ephem_timestamp_to_utime(timestamp)
+            if utime <= current_time:
+                continue
+            if not self.constraint.in_eclipse(ra=0, dec=0, time=utime):
+                return utime
+        return None
+
+    def _next_science_deadline(
+        self, slew_end: float, current_time: float | None = None
+    ) -> tuple[float, str]:
         """Determine the next science deadline after the slew ends, which could
         be the end of the current visibility window, the next pass, or the end
         of the simulation."""
@@ -1976,6 +2000,12 @@ class QueueDITL(DITLMixin, DITLStats):
         pass_deadline = self._next_pass_science_deadline(slew_end)
         if pass_deadline is not None:
             deadlines.append((pass_deadline, "pass"))
+
+        charge_deadline = self._next_charge_science_deadline(
+            current_time if current_time is not None else slew_end
+        )
+        if charge_deadline is not None:
+            deadlines.append((charge_deadline, "charge opportunity"))
 
         return min(deadlines, key=lambda item: item[0])
 
@@ -2022,7 +2052,7 @@ class QueueDITL(DITLMixin, DITLStats):
 
         # Check if there's enough time to collect before the next science
         # deadline (visibility window end, next pass, or simulation end)
-        deadline, reason = self._next_science_deadline(slew_end)
+        deadline, reason = self._next_science_deadline(slew_end, current_time=utime)
         available_collect_time = deadline - slew_end
         if available_collect_time >= self.ppt.ss_min:
             return False

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -2064,11 +2064,11 @@ class QueueDITL(DITLMixin, DITLStats):
             self._retry_ppt_fetch_requested = False
 
     def _fetch_new_ppt_inner(self, utime: float, ra: float, dec: float) -> None:
-        if self.battery.battery_alert:
+        if self.battery.below_minimum_charge_level:
             self.log.log_event(
                 utime=utime,
                 event_type="QUEUE",
-                description="Deferring PPT fetch - battery alert active",
+                description="Deferring PPT fetch - battery below minimum charge level",
                 acs_mode=self.acs.acsmode,
             )
             self._ppt_unavailable = None

--- a/tests/scheduler_queue/conftest.py
+++ b/tests/scheduler_queue/conftest.py
@@ -96,6 +96,7 @@ def mock_config() -> Mock:
     config.battery = Mock()
     config.battery.battery_level = 0.8
     config.battery.battery_alert = False
+    config.battery.below_minimum_charge_level = False
     config.battery.charge_state = 0  # NOT_CHARGING
     config.battery.drain = Mock()
     config.battery.charge = Mock()

--- a/tests/scheduler_queue/conftest.py
+++ b/tests/scheduler_queue/conftest.py
@@ -83,6 +83,7 @@ def mock_config() -> Mock:
     config.constraint.in_star_tracker_soft = Mock(return_value=False)
     config.constraint.in_radiator_hard = Mock(return_value=False)
     config.constraint.in_telescope_hard = Mock(return_value=False)
+    config.constraint.in_eclipse = Mock(return_value=False)
     config.attitude_constraint_policy_for_mode = Mock(
         side_effect=lambda mode: (
             AttitudeConstraintPolicy.FULL_MISSION

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -1285,6 +1285,24 @@ class TestFetchNewPPT:
         log_text = "\n".join(event.description for event in queue_ditl.log.events)
         assert "rejected - only 80s available before charge opportunity" in log_text
 
+    def test_charge_science_deadline_checks_eclipse_on_ephemeris_grid(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Fractional slew-end times should not be sent to ephemeris constraints."""
+        queue_ditl.ephem.timestamp = [
+            datetime.fromtimestamp(1000.0 + 60.0 * index, timezone.utc)
+            for index in range(3)
+        ]
+        queue_ditl.battery.battery_alert = True
+        queue_ditl.constraint.in_eclipse = Mock(return_value=False)
+
+        deadline = queue_ditl._next_charge_science_deadline(1001.5)
+
+        assert deadline == 1001.5
+        queue_ditl.constraint.in_eclipse.assert_called_once_with(
+            ra=0, dec=0, time=1060.0
+        )
+
     def test_fetch_ppt_accepts_when_pending_charge_allows_minimum_collect(
         self, queue_ditl: QueueDITL
     ) -> None:

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -1250,6 +1250,73 @@ class TestFetchNewPPT:
         # Command should be enqueued
         cast(Mock, queue_ditl.acs.enqueue_command).assert_called_once()
 
+    def test_fetch_ppt_rejects_when_pending_charge_prevents_minimum_collect(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Pending recharge should be a collection deadline once sunlight returns."""
+        queue_ditl.ephem.step_size = 60
+        queue_ditl.ephem.timestamp = [
+            datetime.fromtimestamp(1000.0 + 60.0 * index, timezone.utc)
+            for index in range(6)
+        ]
+        queue_ditl.battery.battery_alert = True
+        queue_ditl.battery.below_minimum_charge_level = False
+        queue_ditl.constraint.in_eclipse = Mock(
+            side_effect=lambda ra, dec, time: time < 1180.0
+        )
+
+        mock_ppt = Mock()
+        mock_ppt.ra = 45.0
+        mock_ppt.dec = 30.0
+        mock_ppt.obsid = 1001
+        mock_ppt.next_vis = Mock(return_value=1000.0)
+        mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 300.0
+        mock_ppt.windows = [[0.0, 1e12]]
+        cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
+        queue_ditl.queue.targets = [mock_ppt]
+        cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
+        cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(return_value=None)
+
+        queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        assert queue_ditl.ppt is None
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "rejected - only 80s available before charge opportunity" in log_text
+
+    def test_fetch_ppt_accepts_when_pending_charge_allows_minimum_collect(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Recharge-alert state can still schedule science that clears ss_min."""
+        queue_ditl.ephem.step_size = 60
+        queue_ditl.ephem.timestamp = [
+            datetime.fromtimestamp(1000.0 + 60.0 * index, timezone.utc)
+            for index in range(6)
+        ]
+        queue_ditl.battery.battery_alert = True
+        queue_ditl.battery.below_minimum_charge_level = False
+        queue_ditl.constraint.in_eclipse = Mock(
+            side_effect=lambda ra, dec, time: time < 1180.0
+        )
+
+        mock_ppt = Mock()
+        mock_ppt.ra = 45.0
+        mock_ppt.dec = 30.0
+        mock_ppt.obsid = 1001
+        mock_ppt.next_vis = Mock(return_value=1000.0)
+        mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 60.0
+        mock_ppt.windows = [[0.0, 1e12]]
+        cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
+        cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
+        cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(return_value=None)
+
+        queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        assert queue_ditl.ppt is mock_ppt
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_called_once()
+
     def test_fetch_ppt_retries_when_top_target_cannot_collect(
         self, queue_ditl: QueueDITL
     ) -> None:

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -965,6 +965,55 @@ class TestFetchNewPPT:
         log_text = "\n".join(event.description for event in queue_ditl.log.events)
         assert "Deferring PPT fetch - pass in progress" in log_text
 
+    def test_fetch_ppt_defers_while_battery_alert_active(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Battery-alert state should block new science dispatch."""
+        queue_ditl.battery.battery_alert = True
+
+        queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        assert queue_ditl.ppt is None
+        cast(Mock, queue_ditl.queue.get).assert_not_called()
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Deferring PPT fetch - battery alert active" in log_text
+
+    def test_science_completion_does_not_fetch_new_ppt_during_battery_alert(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Do not start another target when charge is pending but unavailable."""
+        utime = 1000.0
+        science = PlanEntry(config=queue_ditl.config)
+        science.obstype = ObsType.AT
+        science.obsid = 1001
+        science.ra = 10.0
+        science.dec = 20.0
+        science.begin = utime - 600.0
+        science.end = utime + 86400.0
+        science.slewtime = 0.0
+        science.insaa = 0.0
+        science.ss_min = 300.0
+        science.exptime = 0.0
+        science.done = False
+
+        queue_ditl.ppt = science
+        queue_ditl.plan.append(science)
+        queue_ditl.battery.battery_alert = True
+        queue_ditl.emergency_charging.should_initiate_charging = Mock(
+            return_value=False
+        )
+
+        queue_ditl._handle_science_mode(utime, science.ra, science.dec, ACSMode.SCIENCE)
+
+        assert queue_ditl.ppt is None
+        assert science.done is True
+        cast(Mock, queue_ditl.queue.get).assert_not_called()
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Exposure complete, ending observation" in log_text
+        assert "Deferring PPT fetch - battery alert active" in log_text
+
     def test_fetch_ppt_rejects_slew_execution_during_pass(
         self, queue_ditl: QueueDITL
     ) -> None:

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -965,11 +965,30 @@ class TestFetchNewPPT:
         log_text = "\n".join(event.description for event in queue_ditl.log.events)
         assert "Deferring PPT fetch - pass in progress" in log_text
 
-    def test_fetch_ppt_defers_while_battery_alert_active(
+    def test_fetch_ppt_continues_while_recharge_alert_above_minimum_charge(
         self, queue_ditl: QueueDITL
     ) -> None:
-        """Battery-alert state should block new science dispatch."""
+        """Recharge-alert state should not block new science dispatch."""
         queue_ditl.battery.battery_alert = True
+        queue_ditl.battery.below_minimum_charge_level = False
+        cast(Mock, queue_ditl.queue).get = Mock(return_value=None)
+
+        queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        assert queue_ditl.ppt is None
+        cast(Mock, queue_ditl.queue.get).assert_called_once_with(10.0, 20.0, 1000.0)
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Fetching new PPT from Queue" in log_text
+        assert (
+            "Deferring PPT fetch - battery below minimum charge level" not in log_text
+        )
+
+    def test_fetch_ppt_defers_below_minimum_charge_level(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Do not start a new science target below the battery operating floor."""
+        queue_ditl.battery.below_minimum_charge_level = True
 
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
 
@@ -977,12 +996,12 @@ class TestFetchNewPPT:
         cast(Mock, queue_ditl.queue.get).assert_not_called()
         cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
         log_text = "\n".join(event.description for event in queue_ditl.log.events)
-        assert "Deferring PPT fetch - battery alert active" in log_text
+        assert "Deferring PPT fetch - battery below minimum charge level" in log_text
 
-    def test_science_completion_does_not_fetch_new_ppt_during_battery_alert(
+    def test_science_completion_fetches_new_ppt_during_recharge_alert(
         self, queue_ditl: QueueDITL
     ) -> None:
-        """Do not start another target when charge is pending but unavailable."""
+        """Recharge-alert state alone does not block the next target."""
         utime = 1000.0
         science = PlanEntry(config=queue_ditl.config)
         science.obstype = ObsType.AT
@@ -1000,6 +1019,48 @@ class TestFetchNewPPT:
         queue_ditl.ppt = science
         queue_ditl.plan.append(science)
         queue_ditl.battery.battery_alert = True
+        queue_ditl.battery.below_minimum_charge_level = False
+        queue_ditl.emergency_charging.should_initiate_charging = Mock(
+            return_value=False
+        )
+        cast(Mock, queue_ditl.queue).get = Mock(return_value=None)
+
+        queue_ditl._handle_science_mode(utime, science.ra, science.dec, ACSMode.SCIENCE)
+
+        assert queue_ditl.ppt is None
+        assert science.done is True
+        cast(Mock, queue_ditl.queue.get).assert_called_once_with(
+            science.ra, science.dec, utime
+        )
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Exposure complete, ending observation" in log_text
+        assert "Fetching new PPT from Queue" in log_text
+        assert (
+            "Deferring PPT fetch - battery below minimum charge level" not in log_text
+        )
+
+    def test_science_completion_does_not_fetch_new_ppt_below_minimum_charge(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Do not start another target below the battery operating floor."""
+        utime = 1000.0
+        science = PlanEntry(config=queue_ditl.config)
+        science.obstype = ObsType.AT
+        science.obsid = 1001
+        science.ra = 10.0
+        science.dec = 20.0
+        science.begin = utime - 600.0
+        science.end = utime + 86400.0
+        science.slewtime = 0.0
+        science.insaa = 0.0
+        science.ss_min = 300.0
+        science.exptime = 0.0
+        science.done = False
+
+        queue_ditl.ppt = science
+        queue_ditl.plan.append(science)
+        queue_ditl.battery.below_minimum_charge_level = True
         queue_ditl.emergency_charging.should_initiate_charging = Mock(
             return_value=False
         )
@@ -1012,7 +1073,7 @@ class TestFetchNewPPT:
         cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
         log_text = "\n".join(event.description for event in queue_ditl.log.events)
         assert "Exposure complete, ending observation" in log_text
-        assert "Deferring PPT fetch - battery alert active" in log_text
+        assert "Deferring PPT fetch - battery below minimum charge level" in log_text
 
     def test_fetch_ppt_rejects_slew_execution_during_pass(
         self, queue_ditl: QueueDITL

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -1298,7 +1298,7 @@ class TestFetchNewPPT:
 
         deadline = queue_ditl._next_charge_science_deadline(1001.5)
 
-        assert deadline == 1001.5
+        assert deadline == 1060.0
         queue_ditl.constraint.in_eclipse.assert_called_once_with(
             ra=0, dec=0, time=1060.0
         )


### PR DESCRIPTION
## Summary
- Keep QueueDITL fetching/dispatching science while the battery is below the recharge target but still above the configured minimum charge floor.
- Only defer new science dispatch when the battery is below the depth-of-discharge floor (`below_minimum_charge_level`).
- Treat the next pending battery-charge opportunity as a science collection deadline, so COAST does not start targets that cannot meet `ss_min` before charge will preempt them.
- Add regression coverage for both direct PPT fetch and science-completion paths, including pending-charge `ss_min` screening.

## Validation
- `pytest tests/scheduler_queue/test_queue_ditl.py -q` on PR #188 branch: 224 passed.
- Full local stack (#187 + #184 + revised #188 + #189) queue tests: 235 passed.
- Representative Tamalpais plan generation on full local stack: 95 plan entries, 1440 housekeeping samples, 0 plan/execution mismatches.
- Representative event log has 0 dropped under-collected science entries, 0 `battery alert active` deferrals, and 0 `below minimum charge level` deferrals.