### PR TITLE
fix: track GSP entries through executed pass exit

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1541,6 +1541,30 @@ class QueueDITL(DITLMixin, DITLStats):
         )
         return True
 
+    def _planned_gsp_entry(self, gspass: Pass) -> PlanEntry | None:
+        station, pass_begin, pass_end = self._ground_pass_key(gspass)
+        for entry in reversed(self.plan):
+            if self._entry_obstype(entry) != ObsType.GSP:
+                continue
+            contact_begin = getattr(entry, "contact_begin", None)
+            contact_end = getattr(entry, "contact_end", None)
+            if (
+                getattr(entry, "station", None) == station
+                and contact_begin is not None
+                and contact_end is not None
+                and abs(float(contact_begin) - pass_begin) <= 1e-6
+                and abs(float(contact_end) - pass_end) <= 1e-6
+            ):
+                return entry
+        return None
+
+    def _close_gsp_plan_entry(self, gspass: Pass, executed_end: float) -> None:
+        entry = self._planned_gsp_entry(gspass)
+        if entry is None:
+            return
+        if entry.end < executed_end:
+            entry.end = executed_end
+
     def _check_and_manage_passes(
         self, utime: float, ra: float, dec: float, roll: float = 0.0
     ) -> bool:
@@ -1561,6 +1585,7 @@ class QueueDITL(DITLMixin, DITLStats):
                 description="Commanded pass ended, commanding ACS to end pass",
                 acs_mode=self.acs.acsmode,
             )
+            self._close_gsp_plan_entry(commanded_pass, utime)
             command = ACSCommand(
                 command_type=ACSCommandType.END_PASS,
                 execution_time=utime,
@@ -1589,16 +1614,15 @@ class QueueDITL(DITLMixin, DITLStats):
 
         # Check if a pass just ended, if yes, command ACS to end the pass.
         # FIXME: This works but isn't super clean.
-        if (
-            self.acs.passrequests.current_pass(utime - self.ephem.step_size)
-            and current_pass is None
-        ):
+        previous_pass = self.acs.passrequests.current_pass(utime - self.ephem.step_size)
+        if previous_pass and current_pass is None:
             self.log.log_event(
                 utime=utime,
                 event_type="PASS",
                 description="Pass ended, commanding ACS to end pass",
                 acs_mode=self.acs.acsmode,
             )
+            self._close_gsp_plan_entry(previous_pass, utime)
             command = ACSCommand(
                 command_type=ACSCommandType.END_PASS,
                 execution_time=utime,

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -3508,6 +3508,71 @@ class TestCheckAndManagePasses:
         ]
         assert len(gsp_entries) == 1
 
+    def test_pass_end_extends_gsp_entry_but_preserves_contact_end(
+        self, queue_ditl
+    ) -> None:
+        """The exported GSP interval should cover executed pass exit."""
+        pass_obj = Pass(
+            station="GS_TEST",
+            begin=1100.0,
+            length=600.0,
+            gsstartra=100.0,
+            gsstartdec=50.0,
+            obsid=4242,
+        )
+        reserved_begin = 1000.0
+        executed_end = pass_obj.end + queue_ditl.ephem.step_size
+
+        queue_ditl._record_gsp_plan_entry(pass_obj, reserved_begin=reserved_begin)
+        entry = next(entry for entry in queue_ditl.plan if entry.obstype == ObsType.GSP)
+        assert entry.end == pass_obj.end
+
+        def current_pass(utime: float) -> Pass | None:
+            if utime == executed_end - queue_ditl.ephem.step_size:
+                return pass_obj
+            return None
+
+        queue_ditl.acs.passrequests.current_pass = Mock(side_effect=current_pass)
+        queue_ditl.acs.acsmode = ACSMode.IDLE
+        queue_ditl.acs.in_safe_mode = False
+
+        assert queue_ditl._check_and_manage_passes(executed_end, 10.0, 20.0)
+
+        command = queue_ditl.acs.enqueue_command.call_args[0][0]
+        assert command.command_type == ACSCommandType.END_PASS
+        assert entry.end == executed_end
+        assert entry.contact_end == pass_obj.end
+        assert entry.exposure == 600
+
+    def test_commanded_pass_end_extends_gsp_entry_but_preserves_contact_end(
+        self, queue_ditl
+    ) -> None:
+        """The active PASS-mode exit path should close the exported interval."""
+        pass_obj = Pass(
+            station="GS_TEST",
+            begin=1100.0,
+            length=600.0,
+            gsstartra=100.0,
+            gsstartdec=50.0,
+            obsid=4242,
+        )
+        reserved_begin = 1000.0
+        executed_end = pass_obj.end + queue_ditl.ephem.step_size
+
+        queue_ditl._record_gsp_plan_entry(pass_obj, reserved_begin=reserved_begin)
+        entry = next(entry for entry in queue_ditl.plan if entry.obstype == ObsType.GSP)
+        queue_ditl.acs.current_pass = pass_obj
+        queue_ditl.acs.acsmode = ACSMode.PASS
+        queue_ditl.acs.in_safe_mode = False
+
+        assert queue_ditl._check_and_manage_passes(executed_end, 10.0, 20.0)
+
+        command = queue_ditl.acs.enqueue_command.call_args[0][0]
+        assert command.command_type == ACSCommandType.END_PASS
+        assert entry.end == executed_end
+        assert entry.contact_end == pass_obj.end
+        assert entry.exposure == 600
+
     def test_executed_gsp_slew_updates_exported_slew_metadata(self, queue_ditl) -> None:
         """GSP plan slew metadata should follow the ACS-executed slew."""
         pass_obj = Pass(


### PR DESCRIPTION
## Summary
- Extend exported GSP plan entries through the tick where QueueDITL commands pass exit.
- Keep `contact_end` as the RF contact end, so contact duration/exposure still describe the communication window.
- Add regression coverage that pass exit updates the GSP schedule interval without changing contact metadata.

## Validation
- `pytest tests/scheduler_queue/test_queue_ditl.py`
- Representative Tamalpais inspection with plan-execution validation disabled: `After GSP` gaps drop from 6 minutes to 3 minutes on this branch alone. The remaining one tick per pass is the queued-command handoff addressed by PR #187.