### PR TITLE
feat: reward collection time during target selection

### DIFF
--- a/conops/__init__.py
+++ b/conops/__init__.py
@@ -74,6 +74,7 @@ from .targets import (
     Queue,
     TargetList,
     TargetQueue,
+    TargetSlewEstimate,
 )
 from .visualization import (
     annotate_slew_distances,
@@ -147,6 +148,7 @@ __all__ = [
     "SpacecraftBus",
     "TargetList",
     "TargetQueue",
+    "TargetSlewEstimate",
     "TOORequest",
     "unixtime2date",
     "unixtime2yearday",

--- a/conops/config/targets.py
+++ b/conops/config/targets.py
@@ -12,6 +12,20 @@ class TargetConfig(ConfigModel):
         default=0.0,
         description="Weight to penalize long slews when selecting next target",
     )
+    slew_time_weight: float = Field(
+        default=0.0,
+        description=(
+            "Weight to penalize slew time during target selection, "
+            "in merit points per minute"
+        ),
+    )
+    collection_time_weight: float = Field(
+        default=0.0,
+        description=(
+            "Weight to reward expected useful collection time during target "
+            "selection, in merit points per minute"
+        ),
+    )
     radiator_sun_exposure_weight: float = Field(
         default=0.0,
         description="Weight to penalize radiator sun exposure during target selection",

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -24,7 +24,7 @@ from ..simulation.emergency_charging import EmergencyCharging
 from ..simulation.passes import Pass, pass_slew_trigger_buffer
 from ..simulation.roll import optimum_roll
 from ..simulation.slew import Slew
-from ..targets import Plan, PlanEntry, Pointing, Queue
+from ..targets import Plan, PlanEntry, Pointing, Queue, TargetSlewEstimate
 from .ditl_log import DITLLog
 from .ditl_mixin import DITLMixin
 from .ditl_stats import DITLStats
@@ -1932,26 +1932,32 @@ class QueueDITL(DITLMixin, DITLStats):
         """Return the Unix timestamp for the end of the simulation."""
         return self.uend if self.uend > 0.0 else self.end.timestamp()
 
-    def _current_ppt_visibility_deadline(self, slew_end: float) -> float | None:
+    def _current_ppt_visibility_deadline(
+        self, slew_end: float, target: Pointing | None = None
+    ) -> float | None:
         """Calculate the end of the current PPT visibility window, if any, after the slew ends."""
-        assert self.ppt is not None
-        if not self.ppt.windows:
+        ppt = target or self.ppt
+        assert ppt is not None
+        if not ppt.windows:
             return None
-        for window in self.ppt.windows:
+        for window in ppt.windows:
             if window[0] <= slew_end <= window[1]:
                 return window[1]
         return slew_end
 
-    def _next_pass_science_deadline(self, slew_end: float) -> float | None:
+    def _next_pass_science_deadline(
+        self, slew_end: float, target: Pointing | None = None
+    ) -> float | None:
         """Calculate the next pass deadline after the slew ends, accounting for
         slew time to the pass start."""
-        assert self.ppt is not None
+        ppt = target or self.ppt
+        assert ppt is not None
         next_pass = self.acs.passrequests.next_pass(slew_end)
         if next_pass is None:
             return None
 
         pass_slew_dist = angular_separation(
-            self.ppt.ra, self.ppt.dec, next_pass.gsstartra, next_pass.gsstartdec
+            ppt.ra, ppt.dec, next_pass.gsstartra, next_pass.gsstartdec
         )
         acs_cfg = self.config.spacecraft_bus.attitude_control
         pass_slew_time = float(acs_cfg.slew_time(pass_slew_dist))
@@ -1992,7 +1998,7 @@ class QueueDITL(DITLMixin, DITLStats):
         return None
 
     def _next_science_deadline(
-        self, slew_end: float, current_time: float
+        self, slew_end: float, current_time: float, target: Pointing | None = None
     ) -> tuple[float, str]:
         """Determine the next science deadline after the slew ends, which could
         be the end of the current visibility window, the next pass, or the end
@@ -2001,11 +2007,11 @@ class QueueDITL(DITLMixin, DITLStats):
             (self._simulation_end_deadline(), "simulation end")
         ]
 
-        visibility_end = self._current_ppt_visibility_deadline(slew_end)
+        visibility_end = self._current_ppt_visibility_deadline(slew_end, target=target)
         if visibility_end is not None:
             deadlines.append((visibility_end, "visibility window"))
 
-        pass_deadline = self._next_pass_science_deadline(slew_end)
+        pass_deadline = self._next_pass_science_deadline(slew_end, target=target)
         if pass_deadline is not None:
             deadlines.append((pass_deadline, "pass"))
 
@@ -2014,6 +2020,61 @@ class QueueDITL(DITLMixin, DITLStats):
             deadlines.append((charge_deadline, "charge opportunity"))
 
         return min(deadlines, key=lambda item: item[0])
+
+    def _ppt_slew_execution_time(self, utime: float) -> float:
+        if (
+            self.acs.last_slew is not None
+            and isinstance(self.acs.last_slew, Slew)
+            and self.acs.last_slew.is_slewing(utime)
+        ):
+            return self.acs.last_slew.slewstart + self.acs.last_slew.slewtime
+        return utime
+
+    def _new_ppt_slew(self, target: Pointing, utime: float) -> Slew:
+        slew = Slew(config=self.config)
+        slew.ephem = self.acs.ephem
+        slew.slewrequest = utime
+        slew.endra = target.ra
+        slew.enddec = target.dec
+        slew.obstype = ObsType.PPT
+        slew.obsid = target.obsid
+        slew.at = target
+        return slew
+
+    def _complete_ppt_slew(
+        self,
+        slew: Slew,
+        target: Pointing,
+        utime: float,
+        execution_time: float,
+    ) -> None:
+        slew.slewstart = execution_time
+        slew.startra, slew.startdec, slew.startroll = (
+            self._expected_slew_start_attitude(utime, execution_time)
+        )
+        slew.endroll = optimum_roll(
+            target.ra,
+            target.dec,
+            execution_time,
+            self.acs.ephem,
+            self.config.solar_panel,
+            self.config.constraint,
+        )
+        slew.calc_slewtime()
+
+    def _estimate_ppt_slew(self, target: Pointing, utime: float) -> TargetSlewEstimate:
+        slew = self._new_ppt_slew(target, utime)
+        self._complete_ppt_slew(
+            slew,
+            target,
+            utime,
+            self._ppt_slew_execution_time(utime),
+        )
+        return TargetSlewEstimate(
+            slewtime=float(slew.slewtime),
+            slewdist=float(slew.slewdist),
+            slewpath=slew.slewpath,
+        )
 
     def _can_retry_without_current_ppt(self) -> bool:
         """Sanity check to see if we can retry fetching a new PPT without just
@@ -2133,22 +2194,20 @@ class QueueDITL(DITLMixin, DITLStats):
         )
 
         # Fetch the next PPT from the queue based on current pointing and time
-        self.ppt = self.queue.get(ra, dec, utime)
+        self.ppt = self.queue.get(
+            ra,
+            dec,
+            utime,
+            collection_deadline=lambda target, slew_end: self._next_science_deadline(
+                slew_end,
+                current_time=utime,
+                target=target,
+            )[0],
+            slew_estimator=lambda target: self._estimate_ppt_slew(target, utime),
+        )
 
         if self.ppt is not None:
-            # Create and configure a Slew object
-            slew = Slew(
-                config=self.config,
-            )
-            slew.ephem = self.acs.ephem
-            slew.slewrequest = utime
-            slew.endra = self.ppt.ra
-            slew.enddec = self.ppt.dec
-            slew.obstype = ObsType.PPT
-            slew.obsid = self.ppt.obsid
-
-            # Use the PPT from the queue which already has visibility calculated
-            slew.at = self.ppt
+            slew = self._new_ppt_slew(self.ppt, utime)
 
             # Check if target is visible
             visstart = self.ppt.next_vis(utime)
@@ -2164,17 +2223,10 @@ class QueueDITL(DITLMixin, DITLStats):
                 return
 
             # Calculate slew timing
-            execution_time = utime
+            execution_time = self._ppt_slew_execution_time(utime)
 
             # Wait for current slew to finish if in progress
-            if (
-                self.acs.last_slew is not None
-                and isinstance(self.acs.last_slew, Slew)
-                and self.acs.last_slew.is_slewing(utime)
-            ):
-                execution_time = (
-                    self.acs.last_slew.slewstart + self.acs.last_slew.slewtime
-                )
+            if execution_time > utime:
                 self.log.log_event(
                     utime=utime,
                     event_type="SLEW",
@@ -2193,11 +2245,6 @@ class QueueDITL(DITLMixin, DITLStats):
                     acs_mode=self.acs.acsmode,
                 )
                 execution_time = visstart
-
-            slew.slewstart = execution_time
-            slew.startra, slew.startdec, slew.startroll = (
-                self._expected_slew_start_attitude(utime, execution_time)
-            )
 
             # When ignore_roll=True, verify that a valid roll exists before slewing.
             # optimum_roll() falls back to the unconstrained solar roll when
@@ -2229,15 +2276,7 @@ class QueueDITL(DITLMixin, DITLStats):
                         self._retry_fetch_without_current_ppt(utime, ra, dec)
                         return
 
-            slew.endroll = optimum_roll(
-                self.ppt.ra,
-                self.ppt.dec,
-                execution_time,
-                self.acs.ephem,
-                self.config.solar_panel,
-                self.config.constraint,
-            )
-            slew.calc_slewtime()
+            self._complete_ppt_slew(slew, self.ppt, utime, execution_time)
 
             # Validate that the locked roll satisfies constraints for at least
             # ss_min seconds after slew completion.  The ACS holds roll constant

--- a/conops/targets/__init__.py
+++ b/conops/targets/__init__.py
@@ -7,7 +7,7 @@ from .plan_schema import (
     PlanSchema,
 )
 from .pointing import Pointing
-from .target_queue import Queue, TargetQueue
+from .target_queue import Queue, TargetQueue, TargetSlewEstimate
 
 __all__ = [
     "PlanEntry",
@@ -20,4 +20,5 @@ __all__ = [
     "TargetList",
     "Queue",
     "TargetQueue",
+    "TargetSlewEstimate",
 ]

--- a/conops/targets/target_queue.py
+++ b/conops/targets/target_queue.py
@@ -213,6 +213,13 @@ class TargetQueue:
 
         # Select targets from queue
         targets = [t for t in self.targets if t.merit > 0 and not t.done]
+        score_candidates = (
+            self.slew_distance_weight != 0.0
+            or self.slew_time_weight != 0.0
+            or self.collection_time_weight != 0.0
+            or self.radiator_sun_exposure_weight != 0.0
+            or self.radiator_earth_exposure_weight != 0.0
+        )
 
         msg = (
             f"{unixtime2date(self.utime)} Searching {len(targets)} targets in queue..."
@@ -236,7 +243,12 @@ class TargetQueue:
             if target.exptime is not None and target.exptime < target.ss_min:
                 continue
 
-            self._estimate_slew(target, ra, dec, slew_estimator)
+            self._estimate_slew(
+                target,
+                ra,
+                dec,
+                slew_estimator if score_candidates else None,
+            )
 
             # Calculate observation window
             endtime = utime + target.slewtime + target.ss_min
@@ -254,16 +266,8 @@ class TargetQueue:
                 target.begin = int(utime)
                 target.end = int(utime + target.slewtime + target.ss_max)
                 # If no slew weighting, return first visible target (fast path)
-                if (
-                    self.slew_distance_weight == 0.0
-                    and self.slew_time_weight == 0.0
-                    and self.collection_time_weight == 0.0
-                ):
-                    if (
-                        self.radiator_sun_exposure_weight == 0.0
-                        and self.radiator_earth_exposure_weight == 0.0
-                    ):
-                        return target
+                if not score_candidates:
+                    return target
                 # Otherwise, score all visible targets and pick best
                 slewdist = getattr(target, "slewdist", 0.0)
                 slew_minutes = float(target.slewtime) / 60.0

--- a/conops/targets/target_queue.py
+++ b/conops/targets/target_queue.py
@@ -1,4 +1,6 @@
 import hashlib
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, cast
 
 import numpy as np
@@ -8,6 +10,15 @@ from ..common import unixtime2date
 from ..config import AttitudeControlSystem, Constraint, MissionConfig
 from ..ditl.ditl_log import DITLLog
 from . import Pointing
+
+
+@dataclass(frozen=True)
+class TargetSlewEstimate:
+    """Estimated slew cost used for target selection."""
+
+    slewtime: float
+    slewdist: float
+    slewpath: tuple[list[float], list[float]] | None = None
 
 
 class TargetQueue:
@@ -43,6 +54,8 @@ class TargetQueue:
         self.log = log
         # Optional weight to penalize long slews when selecting next target
         self.slew_distance_weight = config.targets.slew_distance_weight
+        self.slew_time_weight = config.targets.slew_time_weight
+        self.collection_time_weight = config.targets.collection_time_weight
         self.radiator_sun_exposure_weight = config.targets.radiator_sun_exposure_weight
         self.radiator_earth_exposure_weight = (
             config.targets.radiator_earth_exposure_weight
@@ -131,11 +144,49 @@ class TargetQueue:
         digest = hashlib.blake2b(payload, digest_size=8).digest()
         return int.from_bytes(digest, "big")
 
+    def _candidate_collection_seconds(
+        self,
+        target: Pointing,
+        visibility_window: list[float],
+        utime: float,
+        deadline: float | None = None,
+    ) -> float:
+        """Estimate useful science collection available after the slew."""
+        collection_start = utime + float(target.slewtime)
+        collection_end = float(visibility_window[1])
+        if deadline is not None:
+            collection_end = min(collection_end, float(deadline))
+        window_seconds = max(0.0, collection_end - collection_start)
+        max_snapshot = float(target.ss_max)
+        remaining_exposure = target.exptime
+        if remaining_exposure is None:
+            return min(window_seconds, max_snapshot)
+        return min(window_seconds, float(remaining_exposure), max_snapshot)
+
+    def _estimate_slew(
+        self,
+        target: Pointing,
+        ra: float,
+        dec: float,
+        slew_estimator: Callable[[Pointing], TargetSlewEstimate] | None,
+    ) -> None:
+        if slew_estimator is None:
+            target.slewtime = target.calc_slewtime(ra, dec)
+            return
+
+        estimate = slew_estimator(target)
+        target.slewtime = round(estimate.slewtime)
+        target.slewdist = estimate.slewdist
+        if estimate.slewpath is not None:
+            target.slewpath = estimate.slewpath
+
     def get(
         self,
         ra: float,
         dec: float,
         utime: float,
+        collection_deadline: Callable[[Pointing, float], float | None] | None = None,
+        slew_estimator: Callable[[Pointing], TargetSlewEstimate] | None = None,
     ) -> Pointing | None:
         """Get the next best target to observe from the queue.
 
@@ -146,9 +197,10 @@ class TargetQueue:
             ra: Current right ascension in degrees.
             dec: Current declination in degrees.
             utime: Current time in Unix seconds.
-            current_roll: Current spacecraft roll angle in degrees, used to
-                apply roll-aware star tracker filtering when checking target
-                visibility and attitude constraints.
+            collection_deadline: Optional callback returning the latest time
+                science may be collected for a candidate target after its slew.
+            slew_estimator: Optional callback returning attitude-aware slew
+                cost for a candidate target.
 
         Returns:
             Next target to observe, or None if no suitable target found.
@@ -184,7 +236,7 @@ class TargetQueue:
             if target.exptime is not None and target.exptime < target.ss_min:
                 continue
 
-            target.slewtime = target.calc_slewtime(ra, dec)
+            self._estimate_slew(target, ra, dec, slew_estimator)
 
             # Calculate observation window
             endtime = utime + target.slewtime + target.ss_min
@@ -197,11 +249,16 @@ class TargetQueue:
                 endtime = last_unix
 
             # Check if target is visible for full observation
-            if target.visible(utime, endtime):
+            visibility_window = target.visible(utime, endtime)
+            if visibility_window:
                 target.begin = int(utime)
                 target.end = int(utime + target.slewtime + target.ss_max)
                 # If no slew weighting, return first visible target (fast path)
-                if self.slew_distance_weight == 0.0:
+                if (
+                    self.slew_distance_weight == 0.0
+                    and self.slew_time_weight == 0.0
+                    and self.collection_time_weight == 0.0
+                ):
                     if (
                         self.radiator_sun_exposure_weight == 0.0
                         and self.radiator_earth_exposure_weight == 0.0
@@ -209,7 +266,30 @@ class TargetQueue:
                         return target
                 # Otherwise, score all visible targets and pick best
                 slewdist = getattr(target, "slewdist", 0.0)
-                score = target.merit - self.slew_distance_weight * slewdist
+                slew_minutes = float(target.slewtime) / 60.0
+                score = (
+                    target.merit
+                    - self.slew_distance_weight * slewdist
+                    - self.slew_time_weight * slew_minutes
+                )
+                slew_end = utime + float(target.slewtime)
+                deadline = (
+                    collection_deadline(target, slew_end)
+                    if collection_deadline is not None
+                    else None
+                )
+                collection_seconds = self._candidate_collection_seconds(
+                    target=target,
+                    visibility_window=visibility_window,
+                    utime=utime,
+                    deadline=deadline,
+                )
+                if collection_deadline is not None and collection_seconds < float(
+                    target.ss_min
+                ):
+                    continue
+                collection_minutes = collection_seconds / 60.0
+                score += self.collection_time_weight * collection_minutes
 
                 if (
                     self.radiator_sun_exposure_weight > 0.0

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -687,13 +687,51 @@ logic. A radiator always exists physically; geometry changes its net thermal beh
 Scheduler Optimization Weights
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Queue scheduling can penalize radiator exposure using target-selection weights:
+Queue scheduling can combine target merit with configurable optimization weights.
+All weights default to ``0.0``. When every weight is zero, the queue keeps the
+legacy fast path: targets are sorted by merit and the first visible target is
+selected without the extra scoring pass.
 
-* ``config.targets.radiator_sun_exposure_weight``
-* ``config.targets.radiator_earth_exposure_weight``
+When any weight is non-zero, visible candidates are scored as:
 
-Higher values steer scheduling away from pointings that increase thermal loading on
-radiators. These are merit penalties, so tune relative to your target merit scale.
+.. code-block:: text
+
+   score =
+       target.merit
+       - slew_distance_weight * slew_distance_degrees
+       - slew_time_weight * slew_minutes
+       + collection_time_weight * collection_minutes
+       - radiator_sun_exposure_weight * sun_exposure
+       - radiator_earth_exposure_weight * earth_exposure
+
+The available weights are:
+
+* ``config.targets.slew_distance_weight`` - Merit penalty per degree of slew.
+  This favors nearby pointings when candidates have similar target merit.
+* ``config.targets.slew_time_weight`` - Merit penalty per minute of estimated
+  slew time. In ``QueueDITL`` this uses the same attitude-aware
+  :class:`~conops.simulation.Slew` calculation used when the selected slew is
+  executed.
+* ``config.targets.collection_time_weight`` - Merit reward per minute of useful
+  science collection. Collection time is capped by the target visibility window,
+  remaining target exposure, and ``ss_max``. In ``QueueDITL`` it is also capped
+  by the next science deadline, such as the next ground-station pass handoff or
+  the simulation end. If that downstream deadline leaves less than ``ss_min`` of
+  collection time, the candidate is skipped.
+* ``config.targets.radiator_sun_exposure_weight`` - Merit penalty per unit of
+  radiator Sun exposure.
+* ``config.targets.radiator_earth_exposure_weight`` - Merit penalty per unit of
+  radiator Earth exposure.
+
+The radiator exposure values are area-weighted fractions in ``[0, 1]`` when
+radiators are configured. Higher values steer scheduling away from pointings
+that increase thermal loading on radiators.
+
+All weights operate in merit units, so tune them relative to the target merit
+scale. For example, if normal target merits are around ``100``, then
+``collection_time_weight = 1.0`` gives a ten-minute candidate a ``10`` point
+reward, while ``slew_time_weight = 1.0`` gives a ten-minute slew a ``10`` point
+penalty.
 
 Radiator Net Heat Model
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/example_config.json
+++ b/examples/example_config.json
@@ -414,6 +414,10 @@
         "default_color": "tab:purple"
     },
     "targets": {
-        "slew_distance_weight": 0.0
+        "slew_distance_weight": 0.0,
+        "slew_time_weight": 0.0,
+        "collection_time_weight": 0.0,
+        "radiator_sun_exposure_weight": 0.0,
+        "radiator_earth_exposure_weight": 0.0
     }
 }

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -449,5 +449,13 @@ observation_categories:
 
 # Target Configuration. Defines observational targets and scheduling parameters
 targets:
-  # slew_distance_weight: Weight to penalize long slews when selecting next target
+  # slew_distance_weight: Merit penalty per degree of slew distance when selecting next target
   slew_distance_weight: 0.0
+  # slew_time_weight: Merit penalty per minute of estimated slew time
+  slew_time_weight: 0.0
+  # collection_time_weight: Merit reward per minute of useful science collection time
+  collection_time_weight: 0.0
+  # radiator_sun_exposure_weight: Merit penalty per unit radiator Sun exposure
+  radiator_sun_exposure_weight: 0.0
+  # radiator_earth_exposure_weight: Merit penalty per unit radiator Earth exposure
+  radiator_earth_exposure_weight: 0.0

--- a/tests/scheduler_queue/conftest.py
+++ b/tests/scheduler_queue/conftest.py
@@ -138,6 +138,8 @@ def mock_config() -> Mock:
     # Optional scheduling parameters (via TargetConfig)
     config.targets = Mock()
     config.targets.slew_distance_weight = 0.0
+    config.targets.slew_time_weight = 0.0
+    config.targets.collection_time_weight = 0.0
 
     return config
 

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -3,7 +3,7 @@
 import json
 from datetime import datetime, timezone
 from typing import cast
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import pytest
 
@@ -605,6 +605,8 @@ class TestFetchNewPPT:
             10.0,
             20.0,
             1000.0,
+            collection_deadline=ANY,
+            slew_estimator=ANY,
         )
 
     def test_fetch_ppt_enqueues_slew_command(
@@ -1365,7 +1367,9 @@ class TestFetchNewPPT:
         targets = [bad_ppt, good_ppt]
         queue_ditl.queue.targets = targets
 
-        def get_next_not_done(ra: float, dec: float, utime: float) -> Mock | None:
+        def get_next_not_done(
+            ra: float, dec: float, utime: float, **_: object
+        ) -> Mock | None:
             return next((target for target in targets if not target.done), None)
 
         cast(Mock, queue_ditl.queue).get = Mock(side_effect=get_next_not_done)
@@ -1506,7 +1510,9 @@ class TestFetchNewPPT:
         targets = [bad_ppt, good_ppt]
         queue_ditl.queue.targets = targets
 
-        def get_next_not_done(ra: float, dec: float, utime: float) -> Mock | None:
+        def get_next_not_done(
+            ra: float, dec: float, utime: float, **_: object
+        ) -> Mock | None:
             return next((target for target in targets if not target.done), None)
 
         cast(Mock, queue_ditl.queue).get = Mock(side_effect=get_next_not_done)

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -978,7 +978,13 @@ class TestFetchNewPPT:
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
 
         assert queue_ditl.ppt is None
-        cast(Mock, queue_ditl.queue.get).assert_called_once_with(10.0, 20.0, 1000.0)
+        cast(Mock, queue_ditl.queue.get).assert_called_once_with(
+            10.0,
+            20.0,
+            1000.0,
+            collection_deadline=ANY,
+            slew_estimator=ANY,
+        )
         cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
         log_text = "\n".join(event.description for event in queue_ditl.log.events)
         assert "Fetching new PPT from Queue" in log_text
@@ -1032,7 +1038,11 @@ class TestFetchNewPPT:
         assert queue_ditl.ppt is None
         assert science.done is True
         cast(Mock, queue_ditl.queue.get).assert_called_once_with(
-            science.ra, science.dec, utime
+            science.ra,
+            science.dec,
+            utime,
+            collection_deadline=ANY,
+            slew_estimator=ANY,
         )
         cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
         log_text = "\n".join(event.description for event in queue_ditl.log.events)
@@ -1427,7 +1437,9 @@ class TestFetchNewPPT:
 
         queue_ditl.queue.targets = targets
 
-        def get_next_not_done(ra: float, dec: float, utime: float) -> Mock | None:
+        def get_next_not_done(
+            ra: float, dec: float, utime: float, **_: object
+        ) -> Mock | None:
             return next((target for target in targets if not target.done), None)
 
         cast(Mock, queue_ditl.queue).get = Mock(side_effect=get_next_not_done)

--- a/tests/target_queue/conftest.py
+++ b/tests/target_queue/conftest.py
@@ -26,7 +26,7 @@ def mock_target():
         target.done = False
 
     target.reset = Mock(side_effect=reset_func)
-    target.visible.return_value = True
+    target.visible.return_value = [1762924800.0, 1763011200.0]
     target.calc_slewtime = Mock(return_value=10)
     return target
 
@@ -54,7 +54,7 @@ def mock_targets(mock_target):
             return reset_func
 
         t.reset = Mock(side_effect=create_reset_func(t))
-        t.visible.return_value = True
+        t.visible.return_value = [1762924800.0, 1763011200.0]
         t.calc_slewtime = Mock(return_value=10)
         targets.append(t)
     return targets
@@ -69,6 +69,8 @@ def mock_config():
     config.attitude_control = Mock()
     config.targets = Mock()
     config.targets.slew_distance_weight = 0.0
+    config.targets.slew_time_weight = 0.0
+    config.targets.collection_time_weight = 0.0
     config.targets.radiator_sun_exposure_weight = 0.0
     config.targets.radiator_earth_exposure_weight = 0.0
     return config

--- a/tests/target_queue/test_target_queue.py
+++ b/tests/target_queue/test_target_queue.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock, patch
 
-from conops import Queue
+from conops import Queue, TargetSlewEstimate
 
 
 class TestQueueInitAndAppend:
@@ -272,6 +272,170 @@ class TestSlewDistanceWeight:
 
         # Should still return first target (no penalty applied)
         assert target == queue_instance.targets[0]
+
+
+class TestCollectionTimeWeight:
+    """Tests for collection time reward in target selection."""
+
+    def test_positive_weight_prefers_longer_collection_window(self, queue_instance):
+        """Collection time can choose a longer useful observation over a shorter slew."""
+        utime = 1762924800.0
+        queue_instance.slew_distance_weight = 0.1
+        queue_instance.collection_time_weight = 1.0
+
+        close_target = queue_instance.targets[0]
+        close_target.merit = 100
+        close_target.slewdist = 0.0
+        close_target.calc_slewtime.return_value = 10
+        close_target.exptime = 1500
+        close_target.ss_max = 1500
+        close_target.visible.return_value = [utime, utime + 400]
+
+        longer_target = queue_instance.targets[1]
+        longer_target.merit = 100
+        longer_target.slewdist = 30.0
+        longer_target.calc_slewtime.return_value = 20
+        longer_target.exptime = 1500
+        longer_target.ss_max = 1500
+        longer_target.visible.return_value = [utime, utime + 1700]
+
+        for target in queue_instance.targets[2:]:
+            target.visible.return_value = False
+
+        with patch.object(queue_instance, "meritsort"):
+            target = queue_instance.get(ra=0, dec=0, utime=utime)
+
+        assert target == longer_target
+
+    def test_collection_time_is_capped_by_remaining_exposure(self, queue_instance):
+        """The collection reward should not exceed remaining target exposure."""
+        utime = 1762924800.0
+        target = queue_instance.targets[0]
+        target.slewtime = 20
+        target.exptime = 300
+        target.ss_max = 1000
+
+        collection_seconds = queue_instance._candidate_collection_seconds(
+            target=target,
+            visibility_window=[utime, utime + 2000],
+            utime=utime,
+        )
+
+        assert collection_seconds == 300
+
+    def test_collection_time_is_capped_by_deadline(self, queue_instance):
+        """Collection reward should use the earliest downstream science deadline."""
+        utime = 1762924800.0
+        target = queue_instance.targets[0]
+        target.slewtime = 20
+        target.exptime = 1000
+        target.ss_max = 1000
+
+        collection_seconds = queue_instance._candidate_collection_seconds(
+            target=target,
+            visibility_window=[utime, utime + 2000],
+            utime=utime,
+            deadline=utime + 500,
+        )
+
+        assert collection_seconds == 480
+
+    def test_deadline_skips_target_that_cannot_meet_minimum_snapshot(
+        self, queue_instance
+    ):
+        """A downstream deadline should keep infeasible targets out of scoring."""
+        utime = 1762924800.0
+        queue_instance.slew_distance_weight = 0.1
+        queue_instance.collection_time_weight = 1.0
+
+        infeasible_target = queue_instance.targets[0]
+        infeasible_target.merit = 100
+        infeasible_target.slewdist = 0.0
+        infeasible_target.calc_slewtime.return_value = 10
+        infeasible_target.ss_min = 300
+        infeasible_target.exptime = 1500
+        infeasible_target.ss_max = 1500
+        infeasible_target.visible.return_value = [utime, utime + 1700]
+
+        feasible_target = queue_instance.targets[1]
+        feasible_target.merit = 100
+        feasible_target.slewdist = 40.0
+        feasible_target.calc_slewtime.return_value = 20
+        feasible_target.ss_min = 300
+        feasible_target.exptime = 1500
+        feasible_target.ss_max = 1500
+        feasible_target.visible.return_value = [utime, utime + 1700]
+
+        for target in queue_instance.targets[2:]:
+            target.visible.return_value = False
+
+        def deadline(target, slew_end):
+            if target is infeasible_target:
+                return slew_end + 120
+            return slew_end + 900
+
+        with patch.object(queue_instance, "meritsort"):
+            target = queue_instance.get(
+                ra=0,
+                dec=0,
+                utime=utime,
+                collection_deadline=deadline,
+            )
+
+        assert target == feasible_target
+
+    def test_slew_time_weight_penalizes_longer_slews(self, queue_instance):
+        """Slew time can be scored directly as an opportunity cost."""
+        utime = 1762924800.0
+        queue_instance.slew_time_weight = 10.0
+
+        quick_target = queue_instance.targets[0]
+        quick_target.merit = 100
+        quick_target.calc_slewtime.return_value = 30
+
+        slow_target = queue_instance.targets[1]
+        slow_target.merit = 100
+        slow_target.calc_slewtime.return_value = 300
+
+        for target in queue_instance.targets[2:]:
+            target.visible.return_value = False
+
+        with patch.object(queue_instance, "meritsort"):
+            target = queue_instance.get(ra=0, dec=0, utime=utime)
+
+        assert target == quick_target
+
+    def test_slew_estimator_drives_scored_slew_cost(self, queue_instance):
+        """Selection should use caller-provided attitude-aware slew estimates."""
+        utime = 1762924800.0
+        queue_instance.slew_distance_weight = 1.0
+        queue_instance.slew_time_weight = 1.0
+
+        attitude_expensive_target = queue_instance.targets[0]
+        attitude_expensive_target.merit = 100
+
+        attitude_cheap_target = queue_instance.targets[1]
+        attitude_cheap_target.merit = 100
+
+        for target in queue_instance.targets[2:]:
+            target.visible.return_value = False
+
+        def estimate(target):
+            if target is attitude_expensive_target:
+                return TargetSlewEstimate(slewtime=300.0, slewdist=100.0)
+            return TargetSlewEstimate(slewtime=30.0, slewdist=10.0)
+
+        with patch.object(queue_instance, "meritsort"):
+            target = queue_instance.get(
+                ra=0,
+                dec=0,
+                utime=utime,
+                slew_estimator=estimate,
+            )
+
+        assert target == attitude_cheap_target
+        attitude_expensive_target.calc_slewtime.assert_not_called()
+        attitude_cheap_target.calc_slewtime.assert_not_called()
 
 
 class TestQueueSelectionBehavior:

--- a/tests/target_queue/test_target_queue.py
+++ b/tests/target_queue/test_target_queue.py
@@ -437,6 +437,26 @@ class TestCollectionTimeWeight:
         attitude_expensive_target.calc_slewtime.assert_not_called()
         attitude_cheap_target.calc_slewtime.assert_not_called()
 
+    def test_slew_estimator_is_skipped_when_scoring_disabled(self, queue_instance):
+        """The default fast path should not pay for attitude-aware estimates."""
+        utime = 1762924800.0
+        target = queue_instance.targets[0]
+        target.merit = 100
+
+        estimator = Mock(return_value=TargetSlewEstimate(slewtime=300.0, slewdist=0.0))
+
+        with patch.object(queue_instance, "meritsort"):
+            selected = queue_instance.get(
+                ra=0,
+                dec=0,
+                utime=utime,
+                slew_estimator=estimator,
+            )
+
+        assert selected == target
+        estimator.assert_not_called()
+        target.calc_slewtime.assert_called_once()
+
 
 class TestQueueSelectionBehavior:
     def test_get_without_star_trackers_preserves_existing_behavior(


### PR DESCRIPTION
## Summary
- add configurable `collection_time_weight` and `slew_time_weight` target-selection terms
- cap expected useful collection time by the same downstream science deadline used by `QueueDITL`
- score science candidates with an attitude-aware slew estimate from the same `Slew.calc_slewtime()` path used by execution
- skip candidates that cannot meet `ss_min` before the downstream deadline
- keep the existing `slew_distance_weight` behavior available

## Why
A slew-distance penalty alone can keep choosing nearby targets that barely satisfy `ss_min`, while an uncapped collection-time reward can overvalue far targets that will be truncated by a pass, visibility end, or simulation end. The previous queue score also used simple RA/Dec separation, while execution exports the full attitude slew including roll. This scores what can actually be collected before the next hard science deadline, using the same attitude-aware slew cost execution will use.

## Validation
- `pytest tests/target_queue/test_target_queue.py -q`
- `pytest tests/scheduler_queue/test_queue_ditl.py -q`
- `prek run --all-files`
