### PR TITLE
fix: enforce constraint-safe idle holds

### DIFF
--- a/conops/common/enums.py
+++ b/conops/common/enums.py
@@ -41,6 +41,7 @@ class ObsType(str, Enum):
     SAFE = "SAFE"  # Safe-mode pointing
     CHARGE = "CHARGE"  # Battery-charging / sun-pointing maneuver
     GSP = "GSP"  # Ground Station Pass
+    IDLE = "IDLE"  # Constraint-safe idle hold
 
 
 class AntennaType(str, Enum):

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1399,10 +1399,9 @@ class QueueDITL(DITLMixin, DITLStats):
         return ra, dec, roll, obsid, self.acs.get_mode(utime)
 
     def _has_due_acs_command(self, utime: float) -> bool:
-        command_queue = getattr(self.acs, "command_queue", None)
-        if not isinstance(command_queue, list):
-            return False
-        return any(command.execution_time <= utime for command in command_queue)
+        return any(
+            command.execution_time <= utime for command in self.acs.command_queue
+        )
 
     def _handle_science_mode(
         self, utime: float, ra: float, dec: float, mode: ACSMode

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -458,9 +458,12 @@ class QueueDITL(DITLMixin, DITLStats):
             # Close PPT timeline segment if no active observation
             self._close_ppt_timeline_if_needed(utime)
 
-            # Re-query mode after operations to capture any newly enqueued commands
-            # This prevents 1-step mode gaps when commands are enqueued during this step
-            mode = self.acs.get_mode(utime)
+            # Re-query attitude after operations when they changed mode or queued
+            # an immediate command. This keeps IDLE telemetry from inheriting the
+            # stale science attitude after an observation terminates.
+            ra, dec, roll, obsid, mode = self._refresh_pointing_after_operations(
+                mode, utime, ra, dec, roll, obsid
+            )
 
             # Record pointing and mode
             self._record_pointing_data(ra, dec, roll, obsid, mode)
@@ -1377,6 +1380,29 @@ class QueueDITL(DITLMixin, DITLStats):
         else:
             # Science or SAA modes: handle observations and battery management
             self._handle_science_mode(utime, ra, dec, mode)
+
+    def _refresh_pointing_after_operations(
+        self,
+        previous_mode: ACSMode,
+        utime: float,
+        ra: float,
+        dec: float,
+        roll: float,
+        obsid: int,
+    ) -> tuple[float, float, float, int, ACSMode]:
+        mode = self.acs.get_mode(utime)
+        if mode == previous_mode and not self._has_due_acs_command(utime):
+            return ra, dec, roll, obsid, mode
+
+        ra, dec, roll, obsid = self.acs.pointing(utime)
+        self._sync_acs_slew_metadata()
+        return ra, dec, roll, obsid, self.acs.get_mode(utime)
+
+    def _has_due_acs_command(self, utime: float) -> bool:
+        command_queue = getattr(self.acs, "command_queue", None)
+        if not isinstance(command_queue, list):
+            return False
+        return any(command.execution_time <= utime for command in command_queue)
 
     def _handle_science_mode(
         self, utime: float, ra: float, dec: float, mode: ACSMode

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -10,7 +10,8 @@ from ..common import (
     unixtime2date,
     unixtime2yearday,
 )
-from ..config import MissionConfig
+from ..common.vector import angular_separation
+from ..config import AttitudeConstraintPolicy, MissionConfig
 from ..simulation.passes import PassTimes
 from ..simulation.roll import optimum_roll
 from .acs_command import ACSCommand
@@ -572,6 +573,11 @@ class ACS:
         # Calculate roll angle (must run after _calculate_pointing so ra/dec are current).
         self.roll = self._compute_roll(utime)
 
+        # Idle is an executed attitude, not a constraint-free gap. If a completed
+        # observation is being held after science ends, move the hold to an
+        # attitude that satisfies the configured IDLE policy before recording.
+        self._enforce_idle_constraint_safe_attitude(utime)
+
         # Check current constraints (must run after roll is updated)
         self._check_constraints(utime)
 
@@ -663,6 +669,202 @@ class ACS:
         return optimum_roll(
             self.ra, self.dec, utime, self.ephem, self.solar_panel, self.constraint
         )
+
+    def _enforce_idle_constraint_safe_attitude(self, utime: float) -> None:
+        """Replace unsafe idle holds with an attitude that satisfies IDLE policy."""
+        if self.acsmode != ACSMode.IDLE:
+            return
+        if self.current_pass is not None or self.in_safe_mode:
+            return
+
+        policy = self._idle_attitude_policy()
+        if policy == AttitudeConstraintPolicy.NONE:
+            return
+
+        if not self._idle_attitude_violates_policy(
+            self.ra, self.dec, self.roll, utime, policy
+        ):
+            return
+
+        safe_attitude = self._find_constraint_safe_idle_attitude(utime, policy)
+        if safe_attitude is None:
+            msg = (
+                f"{unixtime2date(utime)}: No constraint-safe IDLE attitude found "
+                f"from RA={self.ra:.2f} Dec={self.dec:.2f}"
+            )
+            self._log_or_print(utime, "ERROR", msg)
+            raise RuntimeError(msg)
+
+        ra, dec, roll = safe_attitude
+        self._hold_idle_attitude(ra, dec, roll, utime)
+        self._log_or_print(
+            utime,
+            "ACS",
+            f"{unixtime2date(utime)}: IDLE attitude constrained; holding safe attitude "
+            f"RA={ra:.2f} Dec={dec:.2f} Roll={roll:.2f}",
+        )
+
+    def _find_constraint_safe_idle_attitude(
+        self, utime: float, policy: AttitudeConstraintPolicy
+    ) -> tuple[float, float, float] | None:
+        """Find a deterministic nearby attitude that satisfies IDLE policy."""
+        candidates = self._idle_safe_attitude_candidates(utime)
+        for candidate_ra, candidate_dec in candidates:
+            optimal_roll = optimum_roll(
+                candidate_ra,
+                candidate_dec,
+                utime,
+                self.ephem,
+                self.solar_panel,
+                self.constraint,
+            )
+            for candidate_roll in self._idle_safe_roll_candidates(optimal_roll):
+                if not self._idle_attitude_violates_policy(
+                    candidate_ra,
+                    candidate_dec,
+                    candidate_roll,
+                    utime,
+                    policy,
+                ):
+                    return candidate_ra, candidate_dec, candidate_roll
+        return None
+
+    def _idle_attitude_policy(self) -> AttitudeConstraintPolicy:
+        return AttitudeConstraintPolicy(
+            self.config.attitude_constraint_policy_for_mode(ACSMode.IDLE)
+        )
+
+    def _idle_attitude_violates_policy(
+        self,
+        ra: float,
+        dec: float,
+        roll: float,
+        utime: float,
+        policy: AttitudeConstraintPolicy,
+    ) -> bool:
+        if policy == AttitudeConstraintPolicy.FULL_MISSION:
+            return self.constraint.in_constraint(
+                ra, dec, utime, target_roll=roll, acs_mode=ACSMode.IDLE
+            )
+        if policy == AttitudeConstraintPolicy.HARD_KEEPOUT:
+            return self._idle_attitude_violates_hard_keepout(ra, dec, roll, utime)
+        return False
+
+    def _idle_attitude_violates_hard_keepout(
+        self, ra: float, dec: float, roll: float, utime: float
+    ) -> bool:
+        if self.constraint.in_star_tracker_hard(
+            ra, dec, utime, target_roll=roll, acs_mode=ACSMode.IDLE
+        ):
+            return True
+        if self.constraint.in_radiator_hard(ra, dec, utime, target_roll=roll):
+            return True
+        if self.constraint.in_telescope_hard(ra, dec, utime, target_roll=roll):
+            return True
+        return False
+
+    @staticmethod
+    def _idle_safe_roll_candidates(optimal_roll: float) -> list[float]:
+        """Try the solar-optimal roll first, then nearby 15 degree alternatives."""
+        rolls: list[float] = []
+
+        def add(roll: float) -> None:
+            normalized = roll % 360.0
+            is_new = all(
+                abs(((normalized - existing + 180.0) % 360.0) - 180.0) > 1e-6
+                for existing in rolls
+            )
+            if is_new:
+                rolls.append(normalized)
+
+        add(optimal_roll)
+        for offset in range(0, 360, 15):
+            add(optimal_roll + offset)
+            add(optimal_roll - offset)
+        return rolls
+
+    def _idle_safe_attitude_candidates(self, utime: float) -> list[tuple[float, float]]:
+        """Generate deterministic IDLE hold candidates, nearest current attitude first."""
+        raw_candidates: list[tuple[float, float]] = []
+
+        def add(ra: float, dec: float) -> None:
+            raw_candidates.append((ra % 360.0, max(-90.0, min(90.0, dec))))
+
+        add(self.ra, self.dec)
+
+        if self.solar_panel is not None:
+            try:
+                solar_ra, solar_dec = self.solar_panel.optimal_charging_pointing(
+                    utime, self.ephem
+                )
+                add(float(solar_ra), float(solar_dec))
+            except (AttributeError, TypeError, ValueError):
+                pass
+
+        try:
+            index = self.ephem.index(dtutcfromtimestamp(utime))
+            add(
+                (180.0 + float(self.ephem.earth_ra_deg[index])) % 360.0,
+                -float(self.ephem.earth_dec_deg[index]),
+            )
+            add(
+                (180.0 + float(self.ephem.sun_ra_deg[index])) % 360.0,
+                -float(self.ephem.sun_dec_deg[index]),
+            )
+        except (AttributeError, IndexError, TypeError, ValueError):
+            pass
+
+        grid: list[tuple[float, float]] = []
+        for dec in (-90, -75, -60, -45, -30, -15, 0, 15, 30, 45, 60, 75, 90):
+            if abs(dec) == 90:
+                grid.append((0.0, float(dec)))
+                continue
+            for ra in range(0, 360, 15):
+                grid.append((float(ra), float(dec)))
+        grid.sort(
+            key=lambda candidate: angular_separation(
+                self.ra, self.dec, candidate[0], candidate[1]
+            )
+        )
+        raw_candidates.extend(grid)
+
+        candidates: list[tuple[float, float]] = []
+        seen: set[tuple[float, float]] = set()
+        for ra, dec in raw_candidates:
+            key = (round(ra, 6), round(dec, 6))
+            if key in seen:
+                continue
+            seen.add(key)
+            candidates.append((ra, dec))
+        return candidates
+
+    def _hold_idle_attitude(
+        self, ra: float, dec: float, roll: float, utime: float
+    ) -> None:
+        """Install a zero-duration IDLE hold so future ticks keep the safe attitude."""
+        hold = Slew(config=self.config)
+        hold.ephem = self.ephem
+        hold.slewrequest = utime
+        hold.slewstart = utime
+        hold.slewend = utime
+        hold.slewtime = 0.0
+        hold.slewdist = 0.0
+        hold.startra = ra
+        hold.startdec = dec
+        hold.startroll = roll
+        hold.endra = ra
+        hold.enddec = dec
+        hold.endroll = roll
+        hold.obstype = ObsType.IDLE
+        hold.obsid = IDLE_OBSID
+        hold.at = None
+
+        self.current_slew = None
+        self.last_slew = hold
+        self.science_observation_active = False
+        self.ra = ra
+        self.dec = dec
+        self.roll = roll
 
     def _is_in_charging_mode(self, utime: float) -> bool:
         """Check if spacecraft is in charging mode (dwelling at charge pointing).

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 import rust_ephem
 
@@ -11,7 +11,7 @@ from ..common import (
     unixtime2yearday,
 )
 from ..common.vector import angular_separation
-from ..config import AttitudeConstraintPolicy, MissionConfig
+from ..config import AttitudeConstraintPolicy, FaultEvent, MissionConfig
 from ..simulation.passes import PassTimes
 from ..simulation.roll import optimum_roll
 from .acs_command import ACSCommand
@@ -24,7 +24,12 @@ if TYPE_CHECKING:
     from ..targets import Pointing
 
 
+def assert_never(value: NoReturn) -> NoReturn:
+    raise AssertionError(f"Expected code to be unreachable, but got: {value!r}")
+
+
 IDLE_OBSID = 0
+IDLE_SAFE_ATTITUDE_GRID_STEP_DEG = 15
 
 
 class ACS:
@@ -688,12 +693,29 @@ class ACS:
 
         safe_attitude = self._find_constraint_safe_idle_attitude(utime, policy)
         if safe_attitude is None:
-            msg = (
-                f"{unixtime2date(utime)}: No constraint-safe IDLE attitude found "
-                f"from RA={self.ra:.2f} Dec={self.dec:.2f}"
+            cause = (
+                "No constraint-safe IDLE attitude found "
+                f"(RA={self.ra:.2f} Dec={self.dec:.2f} policy={policy.value}); "
+                "requesting safe mode"
             )
-            self._log_or_print(utime, "ERROR", msg)
-            raise RuntimeError(msg)
+            self._log_or_print(utime, "ERROR", f"{unixtime2date(utime)}: {cause}")
+            fm = getattr(self.config, "fault_management", None)
+            if fm is not None:
+                fm.events.append(
+                    FaultEvent(
+                        utime=utime,
+                        event_type="safe_mode_trigger",
+                        name="idle_attitude_constraint",
+                        cause=cause,
+                        metadata={
+                            "ra": self.ra,
+                            "dec": self.dec,
+                            "policy": policy.value,
+                        },
+                    )
+                )
+            self.request_safe_mode(utime)
+            return
 
         ra, dec, roll = safe_attitude
         self._hold_idle_attitude(ra, dec, roll, utime)
@@ -748,7 +770,9 @@ class ACS:
             )
         if policy == AttitudeConstraintPolicy.HARD_KEEPOUT:
             return self._idle_attitude_violates_hard_keepout(ra, dec, roll, utime)
-        return False
+        if policy == AttitudeConstraintPolicy.NONE:
+            return False
+        assert_never(policy)
 
     def _idle_attitude_violates_hard_keepout(
         self, ra: float, dec: float, roll: float, utime: float
@@ -765,7 +789,7 @@ class ACS:
 
     @staticmethod
     def _idle_safe_roll_candidates(optimal_roll: float) -> list[float]:
-        """Try the solar-optimal roll first, then nearby 15 degree alternatives."""
+        """Try the solar-optimal roll first, then nearby grid-step alternatives."""
         rolls: list[float] = []
 
         def add(roll: float) -> None:
@@ -778,7 +802,9 @@ class ACS:
                 rolls.append(normalized)
 
         add(optimal_roll)
-        for offset in range(0, 360, 15):
+        for offset in range(
+            IDLE_SAFE_ATTITUDE_GRID_STEP_DEG, 360, IDLE_SAFE_ATTITUDE_GRID_STEP_DEG
+        ):
             add(optimal_roll + offset)
             add(optimal_roll - offset)
         return rolls
@@ -815,11 +841,11 @@ class ACS:
             pass
 
         grid: list[tuple[float, float]] = []
-        for dec in (-90, -75, -60, -45, -30, -15, 0, 15, 30, 45, 60, 75, 90):
+        for dec in range(-90, 91, IDLE_SAFE_ATTITUDE_GRID_STEP_DEG):
             if abs(dec) == 90:
                 grid.append((0.0, float(dec)))
                 continue
-            for ra in range(0, 360, 15):
+            for ra in range(0, 360, IDLE_SAFE_ATTITUDE_GRID_STEP_DEG):
                 grid.append((float(ra), float(dec)))
         grid.sort(
             key=lambda candidate: angular_separation(

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -819,34 +819,28 @@ class ACS:
         add(self.ra, self.dec)
 
         if self.solar_panel is not None:
-            try:
-                solar_ra, solar_dec = self.solar_panel.optimal_charging_pointing(
-                    utime, self.ephem
-                )
-                add(float(solar_ra), float(solar_dec))
-            except (AttributeError, TypeError, ValueError):
-                pass
+            solar_ra, solar_dec = self.solar_panel.optimal_charging_pointing(
+                utime, self.ephem
+            )
+            add(float(solar_ra), float(solar_dec))
 
-        try:
-            index = self.ephem.index(dtutcfromtimestamp(utime))
-            add(
-                (180.0 + float(self.ephem.earth_ra_deg[index])) % 360.0,
-                -float(self.ephem.earth_dec_deg[index]),
-            )
-            add(
-                (180.0 + float(self.ephem.sun_ra_deg[index])) % 360.0,
-                -float(self.ephem.sun_dec_deg[index]),
-            )
-        except (AttributeError, IndexError, TypeError, ValueError):
-            pass
+        index = self.ephem.index(dtutcfromtimestamp(utime))
+        add(
+            (180.0 + float(self.ephem.earth_ra_deg[index])) % 360.0,
+            -float(self.ephem.earth_dec_deg[index]),
+        )
+        add(
+            (180.0 + float(self.ephem.sun_ra_deg[index])) % 360.0,
+            -float(self.ephem.sun_dec_deg[index]),
+        )
 
         grid: list[tuple[float, float]] = []
         for dec in range(-90, 91, IDLE_SAFE_ATTITUDE_GRID_STEP_DEG):
             if abs(dec) == 90:
                 grid.append((0.0, float(dec)))
                 continue
-            for ra in range(0, 360, IDLE_SAFE_ATTITUDE_GRID_STEP_DEG):
-                grid.append((float(ra), float(dec)))
+            for grid_ra in range(0, 360, IDLE_SAFE_ATTITUDE_GRID_STEP_DEG):
+                grid.append((float(grid_ra), float(dec)))
         grid.sort(
             key=lambda candidate: angular_separation(
                 self.ra, self.dec, candidate[0], candidate[1]
@@ -856,34 +850,19 @@ class ACS:
 
         candidates: list[tuple[float, float]] = []
         seen: set[tuple[float, float]] = set()
-        for ra, dec in raw_candidates:
-            key = (round(ra, 6), round(dec, 6))
+        for candidate_ra, candidate_dec in raw_candidates:
+            key = (round(candidate_ra, 6), round(candidate_dec, 6))
             if key in seen:
                 continue
             seen.add(key)
-            candidates.append((ra, dec))
+            candidates.append((candidate_ra, candidate_dec))
         return candidates
 
     def _hold_idle_attitude(
         self, ra: float, dec: float, roll: float, utime: float
     ) -> None:
         """Install a zero-duration IDLE hold so future ticks keep the safe attitude."""
-        hold = Slew(config=self.config)
-        hold.ephem = self.ephem
-        hold.slewrequest = utime
-        hold.slewstart = utime
-        hold.slewend = utime
-        hold.slewtime = 0.0
-        hold.slewdist = 0.0
-        hold.startra = ra
-        hold.startdec = dec
-        hold.startroll = roll
-        hold.endra = ra
-        hold.enddec = dec
-        hold.endroll = roll
-        hold.obstype = ObsType.IDLE
-        hold.obsid = IDLE_OBSID
-        hold.at = None
+        hold = Slew.idle_hold(self.config, ra, dec, roll, utime)
 
         self.current_slew = None
         self.last_slew = hold

--- a/conops/simulation/slew.py
+++ b/conops/simulation/slew.py
@@ -84,6 +84,33 @@ class Slew:
         self.at = None  # What's the target associated with this slew?
         self._quat_roll_path: list[float] = []  # roll path for QUATERNION algorithm
 
+    @classmethod
+    def idle_hold(
+        cls,
+        config: MissionConfig,
+        ra: float,
+        dec: float,
+        roll: float,
+        utime: float,
+    ) -> "Slew":
+        """Create a zero-duration IDLE hold at the given attitude."""
+        hold = cls(config=config)
+        hold.slewrequest = utime
+        hold.slewstart = utime
+        hold.slewend = utime
+        hold.slewtime = 0.0
+        hold.slewdist = 0.0
+        hold.startra = ra
+        hold.startdec = dec
+        hold.startroll = roll
+        hold.endra = ra
+        hold.enddec = dec
+        hold.endroll = roll
+        hold.obstype = ObsType.IDLE
+        hold.obsid = 0
+        hold.at = None
+        return hold
+
     def __str__(self) -> str:
         return f"Slew from {self.startra:.3f},{self.startdec:.3f},{self.startroll:.3f}° to {self.endra:.3f},{self.enddec:.3f},{self.endroll:.3f}° @ {unixtime2date(self.slewstart)}"
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -204,7 +204,9 @@ COASTSim's constraint system has two tiers:
 
 The ``HARD_KEEPOUT`` policy enforces the second tier only, which is appropriate for
 transient modes (slewing, SAA, safe) where soft science-quality limits legitimately do
-not apply.
+not apply. ``IDLE`` uses this policy by default, and the ACS also uses the configured
+``IDLE`` policy at runtime when deciding whether an idle hold must be moved to a safer
+attitude before telemetry is recorded.
 
 **Policy values** (:class:`~conops.config.AttitudeConstraintPolicy`):
 
@@ -256,7 +258,8 @@ not apply.
      - Safe-mode pointing relaxes science constraints but not instrument-protection limits.
    * - ``IDLE``
      - ``hard_keepout``
-     - Idle attitude relaxes science constraints but not instrument-protection limits.
+     - Idle holds may persist, so hard health-and-safety limits are enforced; missions
+       that require science-quality idle holds can override this to ``full_mission``.
 
 **Overriding the policy for individual modes:**
 

--- a/tests/acs/conftest.py
+++ b/tests/acs/conftest.py
@@ -6,7 +6,14 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pytest
 
-from conops import ACS, AttitudeControlSystem, Constraint, SpacecraftBus
+from conops import (
+    ACS,
+    ACSMode,
+    AttitudeConstraintPolicy,
+    AttitudeControlSystem,
+    Constraint,
+    SpacecraftBus,
+)
 from conops.config.solar_panel import SolarPanel, SolarPanelSet
 
 
@@ -51,6 +58,9 @@ def mock_constraint(mock_ephem: DummyEphemeris) -> Mock:
     constraint.panel_constraint = Mock()
     constraint.panel_constraint.solar_panel = None
     constraint.in_constraint = Mock(return_value=False)
+    constraint.in_star_tracker_hard = Mock(return_value=False)
+    constraint.in_radiator_hard = Mock(return_value=False)
+    constraint.in_telescope_hard = Mock(return_value=False)
     constraint.in_eclipse = Mock(return_value=False)
     return constraint
 
@@ -77,6 +87,13 @@ def mock_config(mock_ephem: DummyEphemeris, mock_constraint: Mock) -> Mock:
     config.spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
     config.spacecraft_bus.radiators = Mock()
     config.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
+    config.attitude_constraint_policy_for_mode = Mock(
+        side_effect=lambda mode: (
+            AttitudeConstraintPolicy.FULL_MISSION
+            if ACSMode(int(mode)) in (ACSMode.SCIENCE, ACSMode.CHARGING)
+            else AttitudeConstraintPolicy.HARD_KEEPOUT
+        )
+    )
     return config
 
 

--- a/tests/acs/test_acs.py
+++ b/tests/acs/test_acs.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 
-from conops import ACS, ACSMode, AttitudeConstraintPolicy
+from conops import ACS, ACSCommandType, ACSMode, AttitudeConstraintPolicy
 from conops.common.enums import ObsType
 from conops.simulation.acs import IDLE_OBSID
 from conops.simulation.slew import Slew
@@ -226,6 +226,25 @@ class TestACSStateManagement:
 
         assert (ra, dec, roll, obsid) == (10.0, 20.0, 5.0, IDLE_OBSID)
         acs.constraint.in_constraint.assert_not_called()
+
+    def test_pointing_requests_safe_mode_when_no_idle_attitude_is_safe(
+        self, acs, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """IDLE enforcement should safe-mode instead of crashing on no safe hold."""
+        acs.config.attitude_constraint_policy_for_mode = Mock(
+            return_value=AttitudeConstraintPolicy.FULL_MISSION
+        )
+        acs.config.fault_management.events = []
+        monkeypatch.setattr("conops.simulation.acs.optimum_roll", lambda *args: 5.0)
+        acs.constraint.in_constraint = Mock(return_value=True)
+
+        ra, dec, roll, obsid = acs.pointing(1000.0)
+
+        assert (ra, dec, roll, obsid) == (acs.ra, acs.dec, acs.roll, IDLE_OBSID)
+        assert acs.command_queue[-1].command_type == ACSCommandType.ENTER_SAFE_MODE
+        assert acs.command_queue[-1].execution_time == 1000.0
+        assert acs.config.fault_management.events[-1].event_type == "safe_mode_trigger"
+        assert acs.config.fault_management.events[-1].name == "idle_attitude_constraint"
 
 
 class TestACSPassRequestManagement:

--- a/tests/acs/test_acs.py
+++ b/tests/acs/test_acs.py
@@ -5,8 +5,10 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 
-from conops import ACS, ACSMode
+from conops import ACS, ACSMode, AttitudeConstraintPolicy
 from conops.common.enums import ObsType
+from conops.simulation.acs import IDLE_OBSID
+from conops.simulation.slew import Slew
 
 
 class DummyEphemeris:
@@ -163,6 +165,67 @@ class TestACSStateManagement:
             ]:
                 acs.acsmode = mode
                 assert acs.acsmode == mode
+
+    def test_pointing_replaces_constrained_idle_hold(
+        self, acs, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """IDLE telemetry should not keep holding a constrained science attitude."""
+        science_slew = Slew(config=acs.config)
+        science_slew.obstype = ObsType.PPT
+        science_slew.obsid = 42
+        science_slew.slewstart = 1.0
+        science_slew.slewend = 1.0
+        science_slew.startra = 10.0
+        science_slew.startdec = 20.0
+        science_slew.startroll = 30.0
+        science_slew.endra = 10.0
+        science_slew.enddec = 20.0
+        science_slew.endroll = 30.0
+        acs.last_slew = science_slew
+        acs.science_observation_active = False
+        acs.config.attitude_constraint_policy_for_mode = Mock(
+            return_value=AttitudeConstraintPolicy.FULL_MISSION
+        )
+
+        monkeypatch.setattr("conops.simulation.acs.optimum_roll", lambda *args: 5.0)
+        acs.constraint.in_constraint = Mock(side_effect=[True, False])
+
+        ra, dec, roll, obsid = acs.pointing(1000.0)
+
+        assert (ra, dec, roll, obsid) == (10.0, 20.0, 5.0, IDLE_OBSID)
+        assert acs.last_slew is not None
+        assert acs.last_slew.obstype == ObsType.IDLE
+        assert acs.get_mode(1000.0) == ACSMode.IDLE
+
+    def test_pointing_replaces_hard_constrained_idle_hold(
+        self, acs, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """IDLE enforcement should use the configured hard-keepout policy."""
+        science_slew = Slew(config=acs.config)
+        science_slew.obstype = ObsType.PPT
+        science_slew.obsid = 42
+        science_slew.slewstart = 1.0
+        science_slew.slewend = 1.0
+        science_slew.startra = 10.0
+        science_slew.startdec = 20.0
+        science_slew.startroll = 30.0
+        science_slew.endra = 10.0
+        science_slew.enddec = 20.0
+        science_slew.endroll = 30.0
+        acs.last_slew = science_slew
+        acs.science_observation_active = False
+        acs.config.attitude_constraint_policy_for_mode = Mock(
+            return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+        )
+
+        monkeypatch.setattr("conops.simulation.acs.optimum_roll", lambda *args: 5.0)
+        acs.constraint.in_constraint = Mock(return_value=True)
+        acs.constraint.in_star_tracker_hard = Mock(side_effect=[True, False])
+
+        ra, dec, roll, obsid = acs.pointing(1000.0)
+
+        assert (ra, dec, roll, obsid) == (10.0, 20.0, 5.0, IDLE_OBSID)
+        acs.constraint.in_constraint.assert_not_called()
 
 
 class TestACSPassRequestManagement:

--- a/tests/acs/test_acs_roll.py
+++ b/tests/acs/test_acs_roll.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pytest
 
-from conops import ACS, ACSMode
+from conops import ACS, ACSMode, AttitudeConstraintPolicy
 from conops.config.solar_panel import SolarPanel, SolarPanelSet
 
 
@@ -45,6 +45,9 @@ def mock_constraint_roll(mock_ephem_roll):
     constraint.panel_constraint = Mock()
     constraint.panel_constraint.solar_panel = None
     constraint.in_constraint = Mock(return_value=False)
+    constraint.in_star_tracker_hard = Mock(return_value=False)
+    constraint.in_radiator_hard = Mock(return_value=False)
+    constraint.in_telescope_hard = Mock(return_value=False)
     constraint.in_eclipse = Mock(return_value=False)
     return constraint
 
@@ -69,6 +72,9 @@ def mock_config_roll(mock_ephem_roll, mock_constraint_roll):
     config.spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
     config.spacecraft_bus.radiators = Mock()
     config.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
+    config.attitude_constraint_policy_for_mode = Mock(
+        return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+    )
     return config
 
 
@@ -138,6 +144,9 @@ class TestACSRollCalculation:
         constraint1.panel_constraint = Mock()
         constraint1.panel_constraint.solar_panel = None
         constraint1.in_constraint = Mock(return_value=False)
+        constraint1.in_star_tracker_hard = Mock(return_value=False)
+        constraint1.in_radiator_hard = Mock(return_value=False)
+        constraint1.in_telescope_hard = Mock(return_value=False)
         constraint1.in_eclipse = Mock(return_value=False)
 
         config1 = Mock()
@@ -157,6 +166,9 @@ class TestACSRollCalculation:
         config1.spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
         config1.spacecraft_bus.radiators = Mock()
         config1.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
+        config1.attitude_constraint_policy_for_mode = Mock(
+            return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+        )
 
         with patch("conops.simulation.passes.PassTimes"):
             acs1 = ACS(config=config1)
@@ -169,6 +181,9 @@ class TestACSRollCalculation:
         constraint2.panel_constraint = Mock()
         constraint2.panel_constraint.solar_panel = None
         constraint2.in_constraint = Mock(return_value=False)
+        constraint2.in_star_tracker_hard = Mock(return_value=False)
+        constraint2.in_radiator_hard = Mock(return_value=False)
+        constraint2.in_telescope_hard = Mock(return_value=False)
         constraint2.in_eclipse = Mock(return_value=False)
 
         config2 = Mock()
@@ -188,6 +203,9 @@ class TestACSRollCalculation:
         config2.spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
         config2.spacecraft_bus.radiators = Mock()
         config2.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
+        config2.attitude_constraint_policy_for_mode = Mock(
+            return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+        )
 
         with patch("conops.simulation.passes.PassTimes"):
             acs2 = ACS(config=config2)
@@ -325,6 +343,9 @@ class TestACSRollEdgeCases:
         constraint.panel_constraint = Mock()
         constraint.panel_constraint.solar_panel = None
         constraint.in_constraint = Mock(return_value=False)
+        constraint.in_star_tracker_hard = Mock(return_value=False)
+        constraint.in_radiator_hard = Mock(return_value=False)
+        constraint.in_telescope_hard = Mock(return_value=False)
         constraint.in_eclipse = Mock(return_value=False)
 
         config = Mock()
@@ -344,6 +365,9 @@ class TestACSRollEdgeCases:
         config.spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
         config.spacecraft_bus.radiators = Mock()
         config.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
+        config.attitude_constraint_policy_for_mode = Mock(
+            return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+        )
 
         with patch("conops.simulation.passes.PassTimes"):
             acs = ACS(config=config)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -79,6 +79,10 @@ class TestConfig:
             config.attitude_constraint_policy_for_mode(ACSMode.PASS)
             == AttitudeConstraintPolicy.HARD_KEEPOUT
         )
+        assert (
+            config.attitude_constraint_policy_for_mode(ACSMode.IDLE)
+            == AttitudeConstraintPolicy.HARD_KEEPOUT
+        )
 
     def test_attitude_constraint_policy_accepts_mode_name_overrides(self) -> None:
         """Test mission config can override one ACS mode by name."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from astropy.time import Time  # type: ignore[import-untyped]
 
-from conops import SolarPanel, SolarPanelSet
+from conops import ACSMode, AttitudeConstraintPolicy, SolarPanel, SolarPanelSet
 
 
 @pytest.fixture(autouse=True)
@@ -81,6 +81,9 @@ def test_config_with_panels(mock_ephem_with_pv: Mock) -> tuple[Mock, SolarPanelS
     constraint.roll_dependent_constraint = None
     constraint.panel_constraint = Mock()
     constraint.in_constraint = Mock(return_value=False)
+    constraint.in_star_tracker_hard = Mock(return_value=False)
+    constraint.in_radiator_hard = Mock(return_value=False)
+    constraint.in_telescope_hard = Mock(return_value=False)
     constraint.in_eclipse = Mock(return_value=False)
 
     # Create solar panels
@@ -104,6 +107,13 @@ def test_config_with_panels(mock_ephem_with_pv: Mock) -> tuple[Mock, SolarPanelS
     config.spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
     config.spacecraft_bus.radiators = Mock()
     config.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
+    config.attitude_constraint_policy_for_mode = Mock(
+        side_effect=lambda mode: (
+            AttitudeConstraintPolicy.FULL_MISSION
+            if ACSMode(int(mode)) in (ACSMode.SCIENCE, ACSMode.CHARGING)
+            else AttitudeConstraintPolicy.HARD_KEEPOUT
+        )
+    )
 
     return config, panel_set
 

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -2183,6 +2183,31 @@ class TestPlanExecutionValidation:
         assert any(f"mode {mode.name}" in str(m) for m in mismatches)
         assert any("Radiator Hard" in str(m) for m in mismatches)
 
+    def test_validation_fails_for_idle_full_constraint_violation(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.utime = [1000.0]
+        queue_ditl.mode = [ACSMode.IDLE]
+        queue_ditl.obsid = [IDLE_OBSID]
+        queue_ditl.ra = [10.0]
+        queue_ditl.dec = [20.0]
+        queue_ditl.roll = [30.0]
+        queue_ditl.config.attitude_constraint_policy_for_mode = Mock(
+            return_value=AttitudeConstraintPolicy.FULL_MISSION
+        )
+        queue_ditl.constraint.in_constraint = Mock(return_value=True)
+        queue_ditl.constraint.in_earth = Mock(return_value=True)
+        self._index_telemetry_by_time(queue_ditl)
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any("mode IDLE" in str(m) for m in mismatches)
+        assert any("Earth" in str(m) for m in mismatches)
+        assert any("full_mission" in str(m) for m in mismatches)
+        queue_ditl.constraint.in_constraint.assert_called_once_with(
+            10.0, 20.0, 1000.0, target_roll=30.0, acs_mode=ACSMode.IDLE
+        )
+
     def test_execution_coverage_uses_full_gsp_entry_window(
         self, queue_ditl: QueueDITL
     ) -> None:
@@ -2587,6 +2612,30 @@ class TestCalcMethod:
         assert queue_ditl.acs.pointing.call_count == 25
         assert queue_ditl.ra[0] == 10.0
         assert queue_ditl.obsid[0] == 0xFFFF
+
+    def test_refresh_after_operations_requeries_attitude_when_mode_changes(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.acs.get_mode = Mock(return_value=ACSMode.IDLE)
+        queue_ditl.acs.pointing = Mock(return_value=(11.0, 22.0, 33.0, IDLE_OBSID))
+
+        ra, dec, roll, obsid, mode = queue_ditl._refresh_pointing_after_operations(
+            ACSMode.SCIENCE,
+            1000.0,
+            1.0,
+            2.0,
+            3.0,
+            42,
+        )
+
+        assert (ra, dec, roll, obsid, mode) == (
+            11.0,
+            22.0,
+            33.0,
+            IDLE_OBSID,
+            ACSMode.IDLE,
+        )
+        queue_ditl.acs.pointing.assert_called_once_with(1000.0)
 
     def test_calc_handles_emergency_charging_initiates(self, queue_ditl) -> None:
         queue_ditl.year = 2018

--- a/tests/slew/test_slew.py
+++ b/tests/slew/test_slew.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from conops import Slew
+from conops.common.enums import ObsType
 
 
 class TestSlewInit:
@@ -64,6 +65,30 @@ class TestSlewInit:
         mock_config.spacecraft_bus.attitude_control = None
         with pytest.raises(AssertionError, match="ACS config must be set"):
             Slew(config=mock_config)
+
+    def test_idle_hold_builds_zero_duration_idle_slew(self, mock_config):
+        hold = Slew.idle_hold(
+            config=mock_config,
+            ra=12.0,
+            dec=-34.0,
+            roll=56.0,
+            utime=1234.0,
+        )
+
+        assert hold.slewrequest == 1234.0
+        assert hold.slewstart == 1234.0
+        assert hold.slewend == 1234.0
+        assert hold.slewtime == 0.0
+        assert hold.slewdist == 0.0
+        assert hold.startra == 12.0
+        assert hold.startdec == -34.0
+        assert hold.startroll == 56.0
+        assert hold.endra == 12.0
+        assert hold.enddec == -34.0
+        assert hold.endroll == 56.0
+        assert hold.obstype == ObsType.IDLE
+        assert hold.obsid == 0
+        assert hold.at is None
 
 
 class TestSlewStr:


### PR DESCRIPTION
## Summary
- enforce the configured IDLE attitude constraint policy at runtime instead of treating IDLE waits as constraint-free gaps
- replace constrained IDLE holds with a deterministic policy-safe hold attitude before telemetry is recorded
- add an explicit ObsType.IDLE hold so normal idle remediation is not represented as safe mode
- re-query QueueDITL attitude after mode-changing operations so stale science pointings are not recorded as IDLE

## Notes
- This PR does not change the default IDLE policy; it remains hard_keepout unless mission config overrides it.
- Missions that want science-quality idle waits should set IDLE: full_mission in their configuration.

## Tests
- /home/aaron/Projects/Cosmic/ops/coast-sim/coastvenv/bin/python -m pytest tests/acs tests/scheduler_queue/test_queue_ditl.py tests/config/test_config.py -q
- prek run --all-files (passes available hooks; local sphinx-build executable is missing)