### PR TITLE
fix: cache charge deadline ephemeris timestamps

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -124,6 +124,8 @@ class QueueDITL(DITLMixin, DITLStats):
         self.panel_power = list()
         # Eclipse tracking
         self.in_eclipse = list()
+        self._ephem_utime_cache: list[float] | None = None
+        self._ephem_utime_cache_source: Any | None = None
         # Subsystem power tracking
         self.power_bus = list()
         self.power_payload = list()
@@ -1973,8 +1975,21 @@ class QueueDITL(DITLMixin, DITLStats):
             return float(timestamp.timestamp())
         return float(timestamp)
 
+    def _ephem_utimes(self) -> list[float]:
+        timestamps = self.ephem.timestamp
+        if (
+            self._ephem_utime_cache is None
+            or self._ephem_utime_cache_source is not timestamps
+            or len(self._ephem_utime_cache) != len(timestamps)
+        ):
+            self._ephem_utime_cache = [
+                self._ephem_timestamp_to_utime(ts) for ts in timestamps
+            ]
+            self._ephem_utime_cache_source = timestamps
+        return self._ephem_utime_cache
+
     def _ephem_utime_at_or_after(self, utime: float) -> float:
-        timestamps = [self._ephem_timestamp_to_utime(ts) for ts in self.ephem.timestamp]
+        timestamps = self._ephem_utimes()
         index = bisect_left(timestamps, utime)
         if index >= len(timestamps):
             return timestamps[-1]
@@ -1985,14 +2000,17 @@ class QueueDITL(DITLMixin, DITLStats):
         if not self.battery.battery_alert or self.charging_ppt is not None:
             return None
 
-        constraint_time = self._ephem_utime_at_or_after(current_time)
+        timestamps = self._ephem_utimes()
+        index = bisect_left(timestamps, current_time)
+        if index >= len(timestamps):
+            index = len(timestamps) - 1
+
+        constraint_time = timestamps[index]
         if not self.constraint.in_eclipse(ra=0, dec=0, time=constraint_time):
             return constraint_time
 
-        for timestamp in self.ephem.timestamp:
-            utime = self._ephem_timestamp_to_utime(timestamp)
-            if utime <= current_time:
-                continue
+        for next_index in range(index + 1, len(timestamps)):
+            utime = timestamps[next_index]
             if not self.constraint.in_eclipse(ra=0, dec=0, time=utime):
                 return utime
         return None

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -1349,6 +1349,53 @@ class TestFetchNewPPT:
             ra=0, dec=0, time=1060.0
         )
 
+    def test_charge_science_deadline_reuses_ephemeris_utime_cache(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Repeated deadline checks should not rebuild ephemeris timestamps."""
+
+        class CountingTimestamp:
+            def __init__(self, utime: float) -> None:
+                self.utime = utime
+                self.calls = 0
+
+            def timestamp(self) -> float:
+                self.calls += 1
+                return self.utime
+
+        timestamps = [
+            CountingTimestamp(1000.0),
+            CountingTimestamp(1060.0),
+            CountingTimestamp(1120.0),
+        ]
+        queue_ditl.ephem.timestamp = timestamps
+        queue_ditl.battery.battery_alert = True
+        queue_ditl.constraint.in_eclipse = Mock(return_value=False)
+
+        assert queue_ditl._next_charge_science_deadline(1001.5) == 1060.0
+        assert queue_ditl._next_charge_science_deadline(1001.5) == 1060.0
+        assert [timestamp.calls for timestamp in timestamps] == [1, 1, 1]
+
+    def test_charge_science_deadline_refreshes_ephemeris_utime_cache(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Replacing the ephemeris timestamp sequence should refresh cached utimes."""
+        queue_ditl.ephem.timestamp = [
+            datetime.fromtimestamp(1000.0, timezone.utc),
+            datetime.fromtimestamp(1060.0, timezone.utc),
+        ]
+        queue_ditl.battery.battery_alert = True
+        queue_ditl.constraint.in_eclipse = Mock(return_value=False)
+
+        assert queue_ditl._next_charge_science_deadline(1001.5) == 1060.0
+
+        queue_ditl.ephem.timestamp = [
+            datetime.fromtimestamp(2000.0, timezone.utc),
+            datetime.fromtimestamp(2060.0, timezone.utc),
+        ]
+
+        assert queue_ditl._next_charge_science_deadline(1001.5) == 2000.0
+
     def test_fetch_ppt_accepts_when_pending_charge_allows_minimum_collect(
         self, queue_ditl: QueueDITL
     ) -> None:


### PR DESCRIPTION
## Summary
- cache QueueDITL ephemeris timestamps as Unix floats for charge deadline lookups
- reuse the cached grid for snap-to-ephemeris and next-sunlight scans
- add regression coverage for cache reuse and refresh when ephem.timestamp is replaced

## Validation
- `python -m pytest tests/scheduler_queue/test_queue_ditl.py`
- `python -m ruff check conops/ditl/queue_ditl.py tests/scheduler_queue/test_queue_ditl.py`
- `python -m ruff format --check conops/ditl/queue_ditl.py tests/scheduler_queue/test_queue_ditl.py`
- pre-commit hooks passed during commit, including strict mypy
- Tamalpais plan-entry hash unchanged: `134fbebaf0c72b3c84913f24fd1bc501c8cb1c23f6e8c49bd9131ee37e729c66`

## Performance
On the current 24h / 500-target Tamalpais generation path, warmed timing improved from about `queue_ditl_calc=21.4s` to `queue_ditl_calc=13.1s`. This preserves the exact exported plan entries and only removes repeated timestamp conversion/scanning overhead in the charge-deadline path.