### PR TITLE
fix: cache target optimum roll estimates

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -126,6 +126,9 @@ class QueueDITL(DITLMixin, DITLStats):
         self.in_eclipse = list()
         self._ephem_utime_cache: list[float] | None = None
         self._ephem_utime_cache_source: Any | None = None
+        self._ppt_optimum_roll_cache: dict[
+            tuple[float, float, float, int, int, int], float
+        ] = {}
         # Subsystem power tracking
         self.power_bus = list()
         self.power_payload = list()
@@ -2070,7 +2073,23 @@ class QueueDITL(DITLMixin, DITLStats):
         slew.startra, slew.startdec, slew.startroll = (
             self._expected_slew_start_attitude(utime, execution_time)
         )
-        slew.endroll = optimum_roll(
+        slew.endroll = self._ppt_optimum_roll(target, execution_time)
+        slew.calc_slewtime()
+
+    def _ppt_optimum_roll(self, target: Pointing, execution_time: float) -> float:
+        key = (
+            float(target.ra),
+            float(target.dec),
+            float(execution_time),
+            id(self.acs.ephem),
+            id(self.config.solar_panel),
+            id(self.config.constraint),
+        )
+        cached = self._ppt_optimum_roll_cache.get(key)
+        if cached is not None:
+            return cached
+
+        roll = optimum_roll(
             target.ra,
             target.dec,
             execution_time,
@@ -2078,21 +2097,15 @@ class QueueDITL(DITLMixin, DITLStats):
             self.config.solar_panel,
             self.config.constraint,
         )
-        slew.calc_slewtime()
+        self._ppt_optimum_roll_cache[key] = roll
+        return roll
 
     def _estimate_ppt_slew(self, target: Pointing, utime: float) -> TargetSlewEstimate:
         execution_time = self._ppt_slew_execution_time(utime)
         startra, startdec, startroll = self._expected_slew_start_attitude(
             utime, execution_time
         )
-        endroll = optimum_roll(
-            target.ra,
-            target.dec,
-            execution_time,
-            self.acs.ephem,
-            self.config.solar_panel,
-            self.config.constraint,
-        )
+        endroll = self._ppt_optimum_roll(target, execution_time)
         slewdist = quaternion_attitude_distance(
             startra,
             startdec,

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -643,6 +643,38 @@ class TestFetchNewPPT:
         )
         slew_time.assert_called_once_with(12.5)
 
+    def test_estimate_ppt_slew_reuses_optimum_roll_cache(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.acs.ra = 10.0
+        queue_ditl.acs.dec = 20.0
+        queue_ditl.acs.roll = 30.0
+        target = Mock()
+        target.ra = 45.0
+        target.dec = -10.0
+
+        with (
+            patch(
+                "conops.ditl.queue_ditl.optimum_roll",
+                return_value=70.0,
+            ) as roll,
+            patch(
+                "conops.ditl.queue_ditl.quaternion_attitude_distance",
+                return_value=12.5,
+            ),
+        ):
+            queue_ditl._estimate_ppt_slew(target, 1000.0)
+            queue_ditl._estimate_ppt_slew(target, 1000.0)
+
+        roll.assert_called_once_with(
+            target.ra,
+            target.dec,
+            1000.0,
+            queue_ditl.acs.ephem,
+            queue_ditl.config.solar_panel,
+            queue_ditl.config.constraint,
+        )
+
     def test_fetch_ppt_enqueues_slew_command(
         self, queue_ditl: QueueDITL, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
## Summary
- cache target optimum-roll calculations within a QueueDITL run
- share the cached roll between cheap candidate scoring and full selected slew completion
- add regression coverage that repeated target slew estimates reuse the cached roll

## Validation
- `python -m pytest tests/scheduler_queue/test_queue_ditl.py` (`246 passed`)
- `python -m ruff check conops/ditl/queue_ditl.py tests/scheduler_queue/test_queue_ditl.py`
- `python -m ruff format --check conops/ditl/queue_ditl.py tests/scheduler_queue/test_queue_ditl.py`
- `python -m mypy --strict --ignore-missing-imports conops/ditl/queue_ditl.py`
- commit hooks passed, including strict mypy

## Tamalpais Check
On the current 24h / 500-target Tamalpais generation path after #196, this branch produced the same plan-entry hash:

`134fbebaf0c72b3c84913f24fd1bc501c8cb1c23f6e8c49bd9131ee37e729c66`

Observed warmed timing improved from roughly `queue_ditl_calc=13.4s` post-#196 to `queue_ditl_calc=10.2s` on this branch.