### PR TITLE
fix: use cheap pass slew trigger estimates

### DIFF
--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -331,6 +331,9 @@ class Pass(BaseModel):
             raise ValueError("ACS config must be set to calculate slew time")
 
         acs_config = self.config.spacecraft_bus.attitude_control
+        # This scalar shortcut is equivalent to Slew.calc_slewtime() only for
+        # quaternion slews. Constraint-avoiding and future slew algorithms keep
+        # the full path unless their scalar equivalence has been proven.
         if acs_config.slew_algorithm == SlewAlgorithm.QUATERNION:
             slewdist = quaternion_attitude_distance(
                 ra,

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -7,10 +7,11 @@ import rust_ephem
 from pydantic import BaseModel, Field
 
 from ..common import ics_date_conv, unixtime2date
-from ..common.enums import AntennaType, ObsType
+from ..common.enums import AntennaType, ObsType, SlewAlgorithm
 from ..common.vector import (
     attitude_for_body_vector_tracking,
     body_vector_to_eci,
+    quaternion_attitude_distance,
     radec2vec,
     rotvec,
     separation,
@@ -328,6 +329,23 @@ class Pass(BaseModel):
         assert self.config is not None, "Config must be set for Pass class"
         if self.config.spacecraft_bus.attitude_control is None:
             raise ValueError("ACS config must be set to calculate slew time")
+
+        acs_config = self.config.spacecraft_bus.attitude_control
+        if acs_config.slew_algorithm == SlewAlgorithm.QUATERNION:
+            slewdist = quaternion_attitude_distance(
+                ra,
+                dec,
+                roll,
+                target_ra,
+                target_dec,
+                target_roll,
+            )
+            if np.isnan(slewdist) or slewdist < 0:
+                raise ValueError(
+                    f"Invalid slew distance: {slewdist} "
+                    f"(start={ra},{dec} end={target_ra},{target_dec})"
+                )
+            return round(acs_config.slew_time(slewdist))
 
         slew = Slew(config=self.config)
         slew.startra = ra

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -343,11 +343,6 @@ class Pass(BaseModel):
                 target_dec,
                 target_roll,
             )
-            if np.isnan(slewdist) or slewdist < 0:
-                raise ValueError(
-                    f"Invalid slew distance: {slewdist} "
-                    f"(start={ra},{dec} end={target_ra},{target_dec})"
-                )
             return round(acs_config.slew_time(slewdist))
 
         slew = Slew(config=self.config)

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -13,7 +13,7 @@ from conops import (
     PassTimes,
 )
 from conops.common import attitude_for_body_vector_tracking, radec2vec
-from conops.common.enums import AntennaType, ObsType
+from conops.common.enums import AntennaType, ObsType, SlewAlgorithm
 from conops.config import (
     AntennaPointing,
     AttitudeControlSystem,
@@ -362,7 +362,7 @@ class TestPassTimeToSlew:
         assert p.time_to_slew(base_begin - 600.0, ra=10.0, dec=20.0, roll=0.0) is False
         assert p.time_to_slew(base_begin - 600.0, ra=10.0, dec=20.0, roll=180.0) is True
 
-    def test_slew_time_to_target_uses_pass_target_roll(
+    def test_slew_time_to_target_quaternion_uses_pass_target_roll(
         self,
         mock_config,
         mock_constraint,
@@ -374,6 +374,65 @@ class TestPassTimeToSlew:
         ephem = create_ephem(begin_dt, end_dt, step_size=60)
 
         mock_config.constraint = mock_constraint
+        p = Pass(
+            config=mock_config,
+            ephem=ephem,
+            station="SGS",
+            begin=base_begin,
+            length=600.0,
+        )
+
+        def slew_time(_acs_config, distance):
+            return 123.0
+
+        with (
+            patch(
+                "conops.simulation.passes.quaternion_attitude_distance",
+                return_value=12.5,
+            ) as distance,
+            patch(
+                "conops.config.acs.AttitudeControlSystem.slew_time",
+                autospec=True,
+                side_effect=slew_time,
+            ) as slew_time_mock,
+            patch(
+                "conops.simulation.passes.Slew.calc_slewtime",
+                side_effect=AssertionError(
+                    "quaternion trigger estimate should be cheap"
+                ),
+            ),
+        ):
+            slewtime = p._slew_time_to_target(
+                base_begin - 600.0,
+                ra=10.0,
+                dec=20.0,
+                roll=42.0,
+                target_ra=30.0,
+                target_dec=40.0,
+                target_roll=37.0,
+            )
+
+        assert slewtime == 123.0
+        distance.assert_called_once_with(10.0, 20.0, 42.0, 30.0, 40.0, 37.0)
+        slew_time_mock.assert_called_once_with(
+            mock_config.spacecraft_bus.attitude_control, 12.5
+        )
+
+    def test_slew_time_to_target_constraint_avoiding_uses_full_slew(
+        self,
+        mock_config,
+        mock_constraint,
+        create_ephem,
+        base_begin,
+    ):
+        begin_dt = datetime(2025, 8, 15, 0, 0, 0, tzinfo=timezone.utc)
+        end_dt = datetime(2025, 8, 15, 0, 15, 0, tzinfo=timezone.utc)
+        ephem = create_ephem(begin_dt, end_dt, step_size=60)
+
+        mock_config.constraint = mock_constraint
+        mock_config.spacecraft_bus.attitude_control.slew_algorithm = (
+            SlewAlgorithm.CONSTRAINT_AVOIDING
+        )
         p = Pass(
             config=mock_config,
             ephem=ephem,


### PR DESCRIPTION
## Problem
While waiting for an upcoming ground-station pass, `QueueDITL` calls `Pass.time_to_slew()` on each scheduler tick to decide whether it is time to start slewing for the pass. That check only needs a scalar slew duration, but the old path built a full `Slew` and ran `Slew.calc_slewtime()`. In quaternion slew mode, that generates the 100-step quaternion slew path even though the path is thrown away immediately after the trigger decision.

On the Tamalpais 24h / 500-target plan this happened 991 times, costing about `2.6s` in the pass-trigger path. Actual commanded GSP slews still need full slew paths; this PR only removes full-path generation from the repeated trigger check.

## Summary
- compute the quaternion attitude distance and scalar slew time directly for ground-station pass trigger checks
- keep actual commanded GSP slews on the existing full `Slew.calc_slewtime()` path
- retain the full `Slew.calc_slewtime()` fallback for constraint-avoiding slew mode, where direct scalar equivalence is not guaranteed

## Validation
- `python -m pytest tests/passes/test_passes.py` (`59 passed`)
- `python -m pytest tests/scheduler_queue/test_queue_ditl.py` (`245 passed`)
- `python -m pytest tests/passes/test_passes.py tests/scheduler_queue/test_queue_ditl.py -q` (`304 passed`)
- `python -m ruff check conops/simulation/passes.py tests/passes/test_passes.py`
- `python -m ruff format --check conops/simulation/passes.py tests/passes/test_passes.py`
- `python -m mypy --strict --ignore-missing-imports conops/simulation/passes.py`
- commit hooks passed, including strict mypy

## Tamalpais Check
On the current 24h / 500-target Tamalpais generation path after #196, this branch produced the same plan-entry hash:

`134fbebaf0c72b3c84913f24fd1bc501c8cb1c23f6e8c49bd9131ee37e729c66`

Observed warmed timing improved from roughly `queue_ditl_calc=13.4s` post-#196 to `queue_ditl_calc=10.6-11.0s` on this branch. The pass trigger path dropped from about `2.6s` to about `0.02s` in the targeted profile, and full `Slew.calc_slewtime()` calls dropped from 1251 to 260.