### PR TITLE
fix: skip impossible target candidates before slew estimates

### DIFF
--- a/conops/targets/target_queue.py
+++ b/conops/targets/target_queue.py
@@ -150,9 +150,12 @@ class TargetQueue:
         visibility_window: list[float],
         utime: float,
         deadline: float | None = None,
+        slewtime: float | None = None,
     ) -> float:
         """Estimate useful science collection available after the slew."""
-        collection_start = utime + float(target.slewtime)
+        collection_start = utime + float(
+            target.slewtime if slewtime is None else slewtime
+        )
         collection_end = float(visibility_window[1])
         if deadline is not None:
             collection_end = min(collection_end, float(deadline))
@@ -162,6 +165,39 @@ class TargetQueue:
         if remaining_exposure is None:
             return min(window_seconds, max_snapshot)
         return min(window_seconds, float(remaining_exposure), max_snapshot)
+
+    def _can_fit_min_snapshot_with_zero_slew(
+        self,
+        target: Pointing,
+        utime: float,
+        last_unix: float,
+        collection_deadline: Callable[[Pointing, float], float | None] | None = None,
+    ) -> bool:
+        """Check if a candidate can fit under the current rules with no slew.
+
+        This is only an impossibility filter. If zero slew cannot fit the
+        immediate visibility/deadline window, any nonnegative slew also cannot.
+        """
+        zero_slew_endtime = utime + float(target.ss_min)
+        if zero_slew_endtime > last_unix:
+            zero_slew_endtime = last_unix
+
+        visibility_window = target.visible(utime, zero_slew_endtime)
+        if not visibility_window:
+            return False
+
+        if collection_deadline is None:
+            return True
+
+        deadline = collection_deadline(target, utime)
+        collection_seconds = self._candidate_collection_seconds(
+            target=target,
+            visibility_window=visibility_window,
+            utime=utime,
+            deadline=deadline,
+            slewtime=0.0,
+        )
+        return collection_seconds >= float(target.ss_min)
 
     def _estimate_slew(
         self,
@@ -236,11 +272,20 @@ class TargetQueue:
             print(msg)
         best_target = None
         best_score = -np.inf
+        last_unix = self.ephem.timestamp[-1].timestamp()
 
         # Check each candidate target
         for target in targets:
             # Skip targets with remaining exposure less than minimum snapshot
             if target.exptime is not None and target.exptime < target.ss_min:
+                continue
+
+            if not self._can_fit_min_snapshot_with_zero_slew(
+                target=target,
+                utime=utime,
+                last_unix=last_unix,
+                collection_deadline=collection_deadline if score_candidates else None,
+            ):
                 continue
 
             self._estimate_slew(
@@ -252,9 +297,6 @@ class TargetQueue:
 
             # Calculate observation window
             endtime = utime + target.slewtime + target.ss_min
-
-            # Use timestamp for the end-of-ephemeris bound
-            last_unix = self.ephem.timestamp[-1].timestamp()
 
             # If the end time exceeds ephemeris, clamp it
             if endtime > last_unix:

--- a/tests/target_queue/test_target_queue.py
+++ b/tests/target_queue/test_target_queue.py
@@ -384,6 +384,106 @@ class TestCollectionTimeWeight:
 
         assert target == feasible_target
 
+    def test_zero_slew_prefilter_skips_impossible_visibility_before_slew_estimate(
+        self, queue_instance
+    ):
+        """Do not estimate slew when even zero slew cannot fit the visibility window."""
+        utime = 1762924800.0
+        queue_instance.slew_time_weight = 1.0
+
+        impossible_target = queue_instance.targets[0]
+        impossible_target.merit = 100
+        impossible_target.visible.return_value = False
+
+        feasible_target = queue_instance.targets[1]
+        feasible_target.merit = 90
+        feasible_target.visible.return_value = [utime, utime + 1000]
+
+        for target in queue_instance.targets[2:]:
+            target.visible.return_value = False
+
+        estimator = Mock(return_value=TargetSlewEstimate(slewtime=10.0, slewdist=1.0))
+
+        with patch.object(queue_instance, "meritsort"):
+            target = queue_instance.get(
+                ra=0,
+                dec=0,
+                utime=utime,
+                slew_estimator=estimator,
+            )
+
+        assert target == feasible_target
+        estimator.assert_called_once_with(feasible_target)
+        impossible_target.calc_slewtime.assert_not_called()
+
+    def test_zero_slew_prefilter_skips_impossible_deadline_before_slew_estimate(
+        self, queue_instance
+    ):
+        """Do not estimate slew when zero slew cannot satisfy the deadline."""
+        utime = 1762924800.0
+        queue_instance.slew_time_weight = 1.0
+
+        impossible_target = queue_instance.targets[0]
+        impossible_target.merit = 100
+        impossible_target.ss_min = 300
+        impossible_target.exptime = 1500
+        impossible_target.ss_max = 1500
+        impossible_target.visible.return_value = [utime, utime + 1000]
+
+        feasible_target = queue_instance.targets[1]
+        feasible_target.merit = 90
+        feasible_target.ss_min = 300
+        feasible_target.exptime = 1500
+        feasible_target.ss_max = 1500
+        feasible_target.visible.return_value = [utime, utime + 1000]
+
+        for target in queue_instance.targets[2:]:
+            target.visible.return_value = False
+
+        def deadline(target, _slew_end):
+            if target is impossible_target:
+                return utime + 120
+            return utime + 900
+
+        estimator = Mock(return_value=TargetSlewEstimate(slewtime=10.0, slewdist=1.0))
+
+        with patch.object(queue_instance, "meritsort"):
+            target = queue_instance.get(
+                ra=0,
+                dec=0,
+                utime=utime,
+                collection_deadline=deadline,
+                slew_estimator=estimator,
+            )
+
+        assert target == feasible_target
+        estimator.assert_called_once_with(feasible_target)
+        impossible_target.calc_slewtime.assert_not_called()
+
+    def test_deadline_prefilter_is_skipped_when_scoring_disabled(self, queue_instance):
+        """Preserve the unscored fast path, which ignores collection deadlines."""
+        utime = 1762924800.0
+        target = queue_instance.targets[0]
+        target.merit = 100
+        target.ss_min = 300
+        target.exptime = 1500
+        target.ss_max = 1500
+        target.visible.return_value = [utime, utime + 1000]
+
+        def deadline(_target, _slew_end):
+            return utime + 120
+
+        with patch.object(queue_instance, "meritsort"):
+            selected = queue_instance.get(
+                ra=0,
+                dec=0,
+                utime=utime,
+                collection_deadline=deadline,
+            )
+
+        assert selected == target
+        target.calc_slewtime.assert_called_once_with(0, 0)
+
     def test_slew_time_weight_penalizes_longer_slews(self, queue_instance):
         """Slew time can be scored directly as an opportunity cost."""
         utime = 1762924800.0


### PR DESCRIPTION
## Summary
- add a zero-slew impossibility prefilter in TargetQueue.get() before candidate slew estimation
- skip candidates only when the current immediate visibility/deadline rules cannot fit ss_min even with zero slew
- keep collection-deadline prefiltering limited to the scored path so the existing unscored fast path behavior is preserved

## Safety
This is a rejection-only filter. Under the current TargetQueue semantics, science collection for a candidate cannot start before utime and real slew times are nonnegative. If the target cannot fit the required ss_min window with zero slew, adding any real slew cannot make that same immediate visibility/deadline window feasible.

The helper is intentionally named and documented as a zero-slew impossibility check, not a ranking heuristic. If future scheduling semantics allow waiting for future visibility before target selection or collecting before target acquisition, this helper should be revisited.

## Validation
- ruff format conops/targets/target_queue.py tests/target_queue/test_target_queue.py
- ruff check conops/targets/target_queue.py tests/target_queue/test_target_queue.py
- pytest tests/target_queue/test_target_queue.py
- pytest tests/scheduler_queue/test_queue_ditl.py::TestFetchNewPPT
- Tamalpais repeatable generation check: repeatable=true, plan_entries=85, attitude_samples=1440
- Normalized Tamalpais plan hash matches origin/main: d78f4544f7a8935f9e481b0efbf80bf13ccef1f48c2ad5648fec0221a6966cf3

## Timing Sample
Single-run Tamalpais queue_ditl_calc samples on this machine:
- origin/main f9c5574: 15.317s, 15.561s
- this branch: 14.131s, 14.242s

These are coarse wall-clock samples, but the normalized plan payload is unchanged.