### PR TITLE
fix: cache fetch-wide science deadlines

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -72,6 +72,14 @@ class PlanExecutionMismatch:
         return self.message
 
 
+@dataclass(frozen=True)
+class _ScienceDeadlineInputs:
+    """Target-independent deadline components for one scheduler fetch."""
+
+    simulation_end: float
+    charge_deadline: float | None
+
+
 class QueueDITL(DITLMixin, DITLStats):
     """
     Class to run a Day In The Life (DITL) simulation based on a target
@@ -2040,14 +2048,28 @@ class QueueDITL(DITLMixin, DITLStats):
                 return utime
         return None
 
+    def _science_deadline_inputs(self, current_time: float) -> _ScienceDeadlineInputs:
+        """Calculate deadline inputs that are stable during one queue fetch."""
+        return _ScienceDeadlineInputs(
+            simulation_end=self._simulation_end_deadline(),
+            charge_deadline=self._next_charge_science_deadline(current_time),
+        )
+
     def _next_science_deadline(
-        self, slew_end: float, current_time: float, target: Pointing | None = None
+        self,
+        slew_end: float,
+        current_time: float,
+        target: Pointing | None = None,
+        deadline_inputs: _ScienceDeadlineInputs | None = None,
     ) -> tuple[float, str]:
         """Determine the next science deadline after the slew ends, which could
         be the end of the current visibility window, the next pass, or the end
         of the simulation."""
+        if deadline_inputs is None:
+            deadline_inputs = self._science_deadline_inputs(current_time)
+
         deadlines: list[tuple[float, str]] = [
-            (self._simulation_end_deadline(), "simulation end")
+            (deadline_inputs.simulation_end, "simulation end")
         ]
 
         visibility_end = self._current_ppt_visibility_deadline(slew_end, target=target)
@@ -2058,9 +2080,8 @@ class QueueDITL(DITLMixin, DITLStats):
         if pass_deadline is not None:
             deadlines.append((pass_deadline, "pass"))
 
-        charge_deadline = self._next_charge_science_deadline(current_time)
-        if charge_deadline is not None:
-            deadlines.append((charge_deadline, "charge opportunity"))
+        if deadline_inputs.charge_deadline is not None:
+            deadlines.append((deadline_inputs.charge_deadline, "charge opportunity"))
 
         return min(deadlines, key=lambda item: item[0])
 
@@ -2248,16 +2269,29 @@ class QueueDITL(DITLMixin, DITLStats):
             acs_mode=self.acs.acsmode,
         )
 
-        # Fetch the next PPT from the queue based on current pointing and time
+        # Fetch the next PPT from the queue based on current pointing and time.
+        # These deadline inputs are target-independent for one queue fetch, but
+        # build them lazily so unscored queue modes do not pay for them.
+        deadline_inputs: _ScienceDeadlineInputs | None = None
+
+        def collection_deadline(target: Pointing, slew_end: float) -> float:
+            nonlocal deadline_inputs
+            if deadline_inputs is None:
+                deadline_inputs = self._science_deadline_inputs(utime)
+            # The cached inputs cover only fetch-wide pieces; each callback
+            # still evaluates target-specific visibility and pass deadlines.
+            return self._next_science_deadline(
+                slew_end,
+                current_time=utime,
+                target=target,
+                deadline_inputs=deadline_inputs,
+            )[0]
+
         self.ppt = self.queue.get(
             ra,
             dec,
             utime,
-            collection_deadline=lambda target, slew_end: self._next_science_deadline(
-                slew_end,
-                current_time=utime,
-                target=target,
-            )[0],
+            collection_deadline=collection_deadline,
             slew_estimator=lambda target: self._estimate_ppt_slew(target, utime),
         )
 

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -609,6 +609,47 @@ class TestFetchNewPPT:
             slew_estimator=ANY,
         )
 
+    def test_fetch_ppt_reuses_charge_deadline_for_candidate_scoring(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Target scoring should not recalculate fetch-wide charge deadlines."""
+        queue_ditl.uend = 10_000.0
+        observed_deadlines = []
+        targets = []
+        for obsid in (1001, 1002):
+            target = Mock()
+            target.ra = 40.0 + obsid
+            target.dec = 10.0
+            target.windows = [[0.0, 1e12]]
+            targets.append(target)
+
+        def queue_get(*_args, collection_deadline, **_kwargs):
+            observed_deadlines.append(collection_deadline(targets[0], 1100.0))
+            observed_deadlines.append(collection_deadline(targets[1], 1200.0))
+            return None
+
+        cast(Mock, queue_ditl.queue).get = Mock(side_effect=queue_get)
+        with patch.object(
+            queue_ditl, "_next_charge_science_deadline", return_value=1500.0
+        ) as charge_deadline:
+            queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        charge_deadline.assert_called_once_with(1000.0)
+        assert observed_deadlines == [1500.0, 1500.0]
+
+    def test_fetch_ppt_does_not_build_deadline_inputs_until_scoring_uses_them(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Unscored queue paths should not pay to build deadline inputs."""
+        cast(Mock, queue_ditl.queue).get = Mock(return_value=None)
+
+        with patch.object(
+            queue_ditl, "_next_charge_science_deadline", return_value=1500.0
+        ) as charge_deadline:
+            queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        charge_deadline.assert_not_called()
+
     def test_estimate_ppt_slew_uses_quaternion_distance_without_full_path(
         self, queue_ditl: QueueDITL
     ) -> None:


### PR DESCRIPTION
## Summary
- cache target-independent science deadline inputs for a single QueueDITL PPT fetch
- reuse simulation-end and pending-charge deadlines across candidate scoring callbacks
- keep the cache lazy so unscored queue paths do not pay to compute deadline inputs

## Safety
This does not cache target-dependent deadlines. Visibility-window and pass deadlines still evaluate per candidate and per slew_end. The cached pieces are stable during one QueueDITL fetch: simulation end, and the pending charge opportunity for the fixed current utime.

## Validation
- ruff format conops/ditl/queue_ditl.py tests/scheduler_queue/test_queue_ditl.py
- ruff check conops/ditl/queue_ditl.py tests/scheduler_queue/test_queue_ditl.py
- pytest tests/scheduler_queue/test_queue_ditl.py::TestFetchNewPPT
- pytest tests/scheduler_queue/test_queue_ditl.py
- Tamalpais repeatable generation: repeatable=true, plan_entries=85, attitude_samples=1440
- Normalized Tamalpais plan hash matches origin/main: 425582ad4f0885230671ba4e4d010e48eb2ecd89bdb2355af0de478f70f0f216

## Timing Sample
Single-run Tamalpais queue_ditl_calc samples on this machine:
- origin/main dc3987d: 18.138s
- this branch: 16.650s

These are coarse wall-clock samples, but the normalized plan payload is unchanged.