### PR TITLE
fix: prune target scoring with score upper bound

### DIFF
--- a/conops/targets/target_queue.py
+++ b/conops/targets/target_queue.py
@@ -199,6 +199,47 @@ class TargetQueue:
         )
         return collection_seconds >= float(target.ss_min)
 
+    def _score_upper_bound_pruning_is_safe(self) -> bool:
+        """Return True when configured weights make the score bound conservative."""
+        return (
+            self.slew_distance_weight >= 0.0
+            and self.slew_time_weight >= 0.0
+            and self.collection_time_weight >= 0.0
+            and self.radiator_sun_exposure_weight >= 0.0
+            and self.radiator_earth_exposure_weight >= 0.0
+        )
+
+    def _candidate_score_upper_bound(
+        self,
+        target: Pointing,
+        utime: float,
+        last_unix: float,
+    ) -> float:
+        """Calculate a conservative best possible score before slew estimation.
+
+        This ignores all nonnegative penalties and assumes zero slew. If that
+        optimistic score cannot beat the current best score, the real score
+        cannot either.
+        """
+        zero_slew_endtime = utime + float(target.ss_min)
+        if zero_slew_endtime > last_unix:
+            zero_slew_endtime = last_unix
+
+        visibility_window = target.visible(utime, zero_slew_endtime)
+        if not visibility_window:
+            return -np.inf
+
+        upper_bound = float(target.merit)
+        if self.collection_time_weight > 0.0:
+            collection_seconds = self._candidate_collection_seconds(
+                target=target,
+                visibility_window=visibility_window,
+                utime=utime,
+                slewtime=0.0,
+            )
+            upper_bound += self.collection_time_weight * (collection_seconds / 60.0)
+        return upper_bound
+
     def _estimate_slew(
         self,
         target: Pointing,
@@ -273,6 +314,9 @@ class TargetQueue:
         best_target = None
         best_score = -np.inf
         last_unix = self.ephem.timestamp[-1].timestamp()
+        prune_by_score_bound = (
+            score_candidates and self._score_upper_bound_pruning_is_safe()
+        )
 
         # Check each candidate target
         for target in targets:
@@ -287,6 +331,15 @@ class TargetQueue:
                 collection_deadline=collection_deadline if score_candidates else None,
             ):
                 continue
+
+            if prune_by_score_bound:
+                upper_bound = self._candidate_score_upper_bound(
+                    target=target,
+                    utime=utime,
+                    last_unix=last_unix,
+                )
+                if upper_bound <= best_score:
+                    continue
 
             self._estimate_slew(
                 target,

--- a/tests/target_queue/test_target_queue.py
+++ b/tests/target_queue/test_target_queue.py
@@ -484,6 +484,109 @@ class TestCollectionTimeWeight:
         assert selected == target
         target.calc_slewtime.assert_called_once_with(0, 0)
 
+    def test_score_bound_skips_candidate_that_cannot_beat_best(self, queue_instance):
+        """Candidates whose optimistic score cannot win should skip slew scoring."""
+        utime = 1762924800.0
+        queue_instance.slew_distance_weight = 1.0
+
+        best_target = queue_instance.targets[0]
+        best_target.merit = 100
+        best_target.visible.return_value = [utime, utime + 1000]
+
+        beaten_target = queue_instance.targets[1]
+        beaten_target.merit = 90
+        beaten_target.visible.return_value = [utime, utime + 1000]
+
+        for target in queue_instance.targets[2:]:
+            target.merit = 80
+            target.visible.return_value = [utime, utime + 1000]
+
+        estimator = Mock(return_value=TargetSlewEstimate(slewtime=0.0, slewdist=0.0))
+
+        with patch.object(queue_instance, "meritsort"):
+            target = queue_instance.get(
+                ra=0,
+                dec=0,
+                utime=utime,
+                slew_estimator=estimator,
+            )
+
+        assert target == best_target
+        estimator.assert_called_once_with(best_target)
+        beaten_target.calc_slewtime.assert_not_called()
+
+    def test_score_bound_still_scores_candidate_that_could_beat_best(
+        self, queue_instance
+    ):
+        """Collection reward upper bound must keep possible winners in scoring."""
+        utime = 1762924800.0
+        queue_instance.slew_distance_weight = 1.0
+        queue_instance.collection_time_weight = 10.0
+
+        short_target = queue_instance.targets[0]
+        short_target.merit = 100
+        short_target.ss_max = 60
+        short_target.exptime = 60
+        short_target.visible.return_value = [utime, utime + 60]
+
+        long_target = queue_instance.targets[1]
+        long_target.merit = 90
+        long_target.ss_max = 300
+        long_target.exptime = 300
+        long_target.visible.return_value = [utime, utime + 300]
+
+        for target in queue_instance.targets[2:]:
+            target.visible.return_value = False
+
+        estimator = Mock(return_value=TargetSlewEstimate(slewtime=0.0, slewdist=0.0))
+
+        with patch.object(queue_instance, "meritsort"):
+            target = queue_instance.get(
+                ra=0,
+                dec=0,
+                utime=utime,
+                slew_estimator=estimator,
+            )
+
+        assert target == long_target
+        estimator.assert_any_call(short_target)
+        estimator.assert_any_call(long_target)
+
+    def test_score_bound_pruning_is_disabled_for_negative_weights(self, queue_instance):
+        """Negative weights can reward costs, so they must keep full scoring."""
+        utime = 1762924800.0
+        queue_instance.slew_distance_weight = -1.0
+
+        nominal_target = queue_instance.targets[0]
+        nominal_target.merit = 100
+        nominal_target.visible.return_value = [utime, utime + 1000]
+
+        rewarded_target = queue_instance.targets[1]
+        rewarded_target.merit = 90
+        rewarded_target.visible.return_value = [utime, utime + 1000]
+
+        for target in queue_instance.targets[2:]:
+            target.visible.return_value = False
+
+        def estimate(target):
+            if target is rewarded_target:
+                return TargetSlewEstimate(slewtime=0.0, slewdist=20.0)
+            return TargetSlewEstimate(slewtime=0.0, slewdist=0.0)
+
+        estimator = Mock(side_effect=estimate)
+
+        with patch.object(queue_instance, "meritsort"):
+            target = queue_instance.get(
+                ra=0,
+                dec=0,
+                utime=utime,
+                slew_estimator=estimator,
+            )
+
+        assert target == rewarded_target
+        estimator.assert_any_call(nominal_target)
+        estimator.assert_any_call(rewarded_target)
+
     def test_slew_time_weight_penalizes_longer_slews(self, queue_instance):
         """Slew time can be scored directly as an opportunity cost."""
         utime = 1762924800.0


### PR DESCRIPTION
## Summary
- add a conservative candidate score upper bound before expensive slew estimation
- skip scored candidates when their optimistic zero-slew/no-penalty score cannot beat the current best score
- keep the old full scoring path for negative weights, because negative penalties can reward costs

## Safety
This is exact branch-and-bound pruning, not approximate top-N selection. The bound assumes zero slew and ignores all nonnegative penalties, so it is at least as high as the candidate real score whenever the configured weights are nonnegative. Candidates are skipped only when that optimistic score is still <= the current best score; equal scores are safe to skip because TargetQueue already keeps the first best score and only replaces on strictly greater score.

If any scoring weight is negative, pruning is disabled and the previous full scoring behavior is preserved.

## Validation
- ruff format conops/targets/target_queue.py tests/target_queue/test_target_queue.py
- ruff check conops/targets/target_queue.py tests/target_queue/test_target_queue.py
- pytest tests/target_queue/test_target_queue.py
- Tamalpais repeatable generation: repeatable=true, plan_entries=85, attitude_samples=1440
- Revalidated after #197 landed: normalized Tamalpais plan hash matches current origin/main a7bad5a and PR #201-on-current-main: 6d7018bcec7f23b77e1ad205bde0a915da396d0e526d1906b98649e63f2b6d75

## Timing Sample
Single-run Tamalpais queue_ditl_calc samples on this machine:
- current origin/main a7bad5a: 9.663s
- PR #201 applied on current main: 8.353s

These are coarse wall-clock samples, but the normalized plan payload is unchanged.
