### PR TITLE
Add TLE plan metadata helper

### DIFF
--- a/conops/targets/__init__.py
+++ b/conops/targets/__init__.py
@@ -1,5 +1,6 @@
 from .plan import Plan, TargetList
 from .plan_entry import PlanEntry
+from .plan_metadata import attach_tle_plan_metadata, tle_plan_metadata
 from .plan_schema import (
     AttitudeSampleSchema,
     AttitudeTimeseriesSchema,
@@ -21,4 +22,6 @@ __all__ = [
     "Queue",
     "TargetQueue",
     "TargetSlewEstimate",
+    "attach_tle_plan_metadata",
+    "tle_plan_metadata",
 ]

--- a/conops/targets/plan_metadata.py
+++ b/conops/targets/plan_metadata.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .plan import Plan
+
+
+def _format_utc_datetime(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def tle_plan_metadata(
+    tle_record: Any,
+    tle_file: str | Path | None = None,
+    *,
+    source: str = "TLE",
+) -> dict[str, Any]:
+    """Build generic plan metadata for a TLE-backed ephemeris.
+
+    COAST owns the plan metadata shape, while rust-ephem owns TLE parsing and
+    element derivation through ``TLERecord.classical_elements()``.
+    """
+    classical_elements = getattr(tle_record, "classical_elements", None)
+    if not callable(classical_elements):
+        raise TypeError(
+            "tle_record must provide classical_elements(); install rust-ephem >= 0.11"
+        )
+
+    return {
+        "ephemeris": {
+            "source": source,
+            "tle_file": str(tle_file) if tle_file is not None else None,
+            "tle_name": tle_record.name,
+            "tle_epoch_utc": _format_utc_datetime(tle_record.epoch),
+            "norad_id": tle_record.norad_id,
+            "line1": tle_record.line1,
+            "line2": tle_record.line2,
+            "classical_elements": classical_elements(),
+            "classical_elements_note": (
+                "TLE mean elements at the TLE epoch; RightAscension_deg is RAAN. "
+                "SemimajorAxis_m is derived from TLE mean motion, and "
+                "TrueAnomaly_deg is derived from TLE mean anomaly."
+            ),
+        }
+    }
+
+
+def attach_tle_plan_metadata(
+    plan: Plan,
+    tle_record: Any,
+    tle_file: str | Path | None = None,
+    *,
+    source: str = "TLE",
+) -> None:
+    """Attach TLE ephemeris metadata to a plan before schema export."""
+    plan.metadata = {
+        **getattr(plan, "metadata", {}),
+        **tle_plan_metadata(tle_record=tle_record, tle_file=tle_file, source=source),
+    }

--- a/tests/plan/test_plan_metadata.py
+++ b/tests/plan/test_plan_metadata.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from rust_ephem.tle import TLERecord
+
+from conops.targets import Plan, attach_tle_plan_metadata, tle_plan_metadata
+
+_TLE1 = "1 43613U 18070A   26060.00000000  .00000000  00000-0  00000-0 0  9991"
+_TLE2 = "2 43613  97.7898  39.6457 0016466  83.3495 116.0254 15.13083683    09"
+
+
+@pytest.fixture
+def tle_record() -> TLERecord:
+    return TLERecord(
+        name="Aperture-1",
+        line1=_TLE1,
+        line2=_TLE2,
+        epoch=datetime(2026, 3, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_tle_plan_metadata_uses_rust_ephem_elements(tle_record: TLERecord) -> None:
+    metadata = tle_plan_metadata(
+        tle_record=tle_record,
+        tle_file="TLEs/Aperture-1_TLE_20260301.tle",
+    )
+
+    ephemeris = metadata["ephemeris"]
+    assert ephemeris["source"] == "TLE"
+    assert ephemeris["tle_file"] == "TLEs/Aperture-1_TLE_20260301.tle"
+    assert ephemeris["tle_name"] == "Aperture-1"
+    assert ephemeris["tle_epoch_utc"] == "2026-03-01T00:00:00Z"
+    assert ephemeris["norad_id"] == 43613
+    assert ephemeris["line1"] == _TLE1
+    assert ephemeris["line2"] == _TLE2
+
+    elements = ephemeris["classical_elements"]
+    assert elements == tle_record.classical_elements()
+    assert elements["SemimajorAxis_m"] == pytest.approx(6904941.542146514)
+    assert elements["Inclination_deg"] == pytest.approx(97.7898)
+    assert elements["RightAscension_deg"] == pytest.approx(39.6457)
+
+
+def test_attach_tle_plan_metadata_preserves_existing_metadata(
+    tle_record: TLERecord,
+) -> None:
+    plan = Plan()
+    plan.metadata = {"producer": {"name": "mission-generator"}}
+
+    attach_tle_plan_metadata(plan, tle_record=tle_record)
+
+    assert plan.metadata["producer"] == {"name": "mission-generator"}
+    assert plan.metadata["ephemeris"]["classical_elements"] == (
+        tle_record.classical_elements()
+    )
+
+
+def test_tle_plan_metadata_requires_rust_ephem_element_api() -> None:
+    class OldRecord:
+        name = "legacy"
+        epoch = datetime(2026, 3, 1, tzinfo=timezone.utc)
+        norad_id = 43613
+        line1 = _TLE1
+        line2 = _TLE2
+
+    with pytest.raises(TypeError, match="rust-ephem >= 0.11"):
+        tle_plan_metadata(OldRecord())


### PR DESCRIPTION
## Summary

- add tle_plan_metadata() to build generic TLE-backed plan metadata
- add attach_tle_plan_metadata() to attach that metadata to a Plan before schema export
- delegate classical element derivation to rust-ephem TLERecord.classical_elements()

## Why

Mission repos should not assemble COAST plan metadata JSON by hand or duplicate orbital derivation logic. rust-ephem owns the TLE/COE derivation and coast-sim owns the plan metadata shape/serialization; mission config code only selects the TLE and calls this helper.

## Validation

- coastvenv/bin/python -m pytest tests/plan/test_plan_metadata.py tests/plan/test_plan.py tests/plan/test_plan_schema.py
- coastvenv/bin/python -m ruff check conops/targets/plan_metadata.py conops/targets/__init__.py tests/plan/test_plan_metadata.py
- coastvenv/bin/python -m ruff format --check conops/targets/plan_metadata.py conops/targets/__init__.py tests/plan/test_plan_metadata.py