### PR TITLE
Add UHF communications band support

### DIFF
--- a/conops/config/communications.py
+++ b/conops/config/communications.py
@@ -12,7 +12,7 @@ from ._base import ConfigModel
 class BandCapability(ConfigModel):
     """Defines a communication band's data rate capabilities."""
 
-    band: Literal["S", "X", "Ka", "Ku", "L", "C", "K"]  # Common spacecraft bands
+    band: Literal["UHF", "S", "X", "Ka", "Ku", "L", "C", "K"]  # Common bands
     uplink_rate_mbps: float = Field(
         default=0.0, description="Uplink data rate in Mbps", ge=0.0
     )

--- a/docs/communications.rst
+++ b/docs/communications.rst
@@ -9,7 +9,7 @@ The Communications System configuration defines the onboard communications capab
 Key Features
 ------------
 
-* **Multiple frequency bands**: S, X, Ka, Ku, L, C, K bands
+* **Multiple frequency bands**: UHF, S, X, Ka, Ku, L, C, K bands
 * **Flexible antenna types**: Omnidirectional, fixed, and gimbaled antennas
 * **Per-band data rates**: Independent uplink and downlink rates for each frequency band
 * **Standard defaults**: Automatic rate assignment based on common band characteristics
@@ -27,7 +27,7 @@ Defines the capabilities for a specific frequency band.
 
 **Fields:**
 
-* ``band``: Frequency band identifier (``"S"``, ``"X"``, ``"Ka"``, ``"Ku"``, ``"L"``, ``"C"``, ``"K"``)
+* ``band``: Frequency band identifier (``"UHF"``, ``"S"``, ``"X"``, ``"Ka"``, ``"Ku"``, ``"L"``, ``"C"``, ``"K"``)
 * ``uplink_rate_mbps``: Uplink data rate in Mbps (≥ 0)
 * ``downlink_rate_mbps``: Downlink data rate in Mbps (≥ 0)
 
@@ -43,7 +43,8 @@ When only the ``band`` is specified, standard defaults are automatically applied
 * **C-band**: uplink 2.0 Mbps, downlink 20.0 Mbps
 * **K-band**: uplink 15.0 Mbps, downlink 200.0 Mbps
 
-Explicitly specified values override these defaults.
+UHF has no generic default rate; specify mission-specific uplink and downlink
+rates explicitly. Explicitly specified values override all defaults.
 
 AntennaPointing
 ^^^^^^^^^^^^^^^

--- a/tests/config/test_communications.py
+++ b/tests/config/test_communications.py
@@ -39,9 +39,16 @@ class TestBandCapability:
 
     def test_supported_bands(self):
         """Test all supported band types."""
-        for band_type in ["S", "X", "Ka", "Ku", "L", "C", "K"]:
+        for band_type in ["UHF", "S", "X", "Ka", "Ku", "L", "C", "K"]:
             band = BandCapability(band=band_type, downlink_rate_mbps=10.0)
             assert band.band == band_type
+
+    def test_uhf_requires_explicit_rates(self):
+        """Test UHF is supported but does not assume generic default rates."""
+        band = BandCapability(band="UHF")
+        assert band.band == "UHF"
+        assert band.uplink_rate_mbps == 0.0
+        assert band.downlink_rate_mbps == 0.0
 
 
 class TestAntennaPointing:

--- a/tests/ditl/test_ditl_mixin_coverage.py
+++ b/tests/ditl/test_ditl_mixin_coverage.py
@@ -166,3 +166,12 @@ def test_get_effective_data_rate_branches(mock_config):
     )
     # Effective per band: S=min(5,10)=5, X=min(50,40)=40, Ka excluded (0)
     assert mixin._get_effective_data_rate(station) == 40.0
+
+    # UHF is a supported comms band and participates in compatibility matching.
+    station.bands = ["UHF"]
+    station.supported_bands = Mock(return_value=["UHF"])
+    station.get_downlink_rate = Mock(return_value=0.0384)
+    mock_config.spacecraft_bus.communications.get_downlink_rate = Mock(
+        return_value=0.0192
+    )
+    assert mixin._get_effective_data_rate(station) == 0.0192


### PR DESCRIPTION
## Summary

- allow UHF as a supported BandCapability value
- keep UHF rates explicit instead of adding generic defaults
- document UHF support and add tests for parsing/defaults and effective downlink matching

## Why

Some mission ground-station RF configurations use UHF as the ground receive band. Without UHF in the COAST schema, mission configs either fail validation or silently omit usable low-rate contacts.

## Validation

- coastvenv/bin/python -m pytest tests/config/test_communications.py tests/ditl/test_ditl_mixin_coverage.py tests/ditl/test_ditl_data_rate.py
- coastvenv/bin/python -m ruff check conops/config/communications.py tests/config/test_communications.py tests/ditl/test_ditl_mixin_coverage.py
- coastvenv/bin/python -m ruff format --check conops/config/communications.py tests/config/test_communications.py tests/ditl/test_ditl_mixin_coverage.py