### PR TITLE
fix: align attitude quaternions with body-vector convention

### DIFF
--- a/conops/common/vector.py
+++ b/conops/common/vector.py
@@ -339,7 +339,7 @@ def attitude_for_body_vector_tracking(
 # Convention: q = [w, x, y, z] (scalar-first).
 # Attitude quaternion represents the rotation from ECI to spacecraft body
 # frame, matching the direction-cosine convention used in scbodyvector():
-#   R = R_x(-roll) @ R_y(dec) @ R_z(-ra)   (all angles in radians)
+#   R = R_x(+roll) @ R_y(dec) @ R_z(-ra)   (all angles in radians)
 # Body X = boresight, Body Z = "up" (defines roll).
 
 
@@ -362,7 +362,7 @@ def attitude_to_quat(
 ) -> npt.NDArray[np.float64]:
     """Convert spacecraft attitude (RA, Dec, Roll) in degrees to quaternion [w, x, y, z].
 
-    The attitude quaternion encodes the rotation R = R_x(-roll) @ R_y(dec) @ R_z(-ra)
+    The attitude quaternion encodes the rotation R = R_x(+roll) @ R_y(dec) @ R_z(-ra)
     that transforms ECI vectors into spacecraft body frame.
     """
     ra = np.deg2rad(ra_deg)
@@ -376,8 +376,8 @@ def attitude_to_quat(
         [np.cos(dec / 2), 0.0, np.sin(dec / 2), 0.0], dtype=np.float64
     )  # R_y(+dec)
     q_x = np.array(
-        [np.cos(roll / 2), -np.sin(roll / 2), 0.0, 0.0], dtype=np.float64
-    )  # R_x(-roll)
+        [np.cos(roll / 2), np.sin(roll / 2), 0.0, 0.0], dtype=np.float64
+    )  # R_x(+roll)
     # Compose: q = q_x ⊗ q_y ⊗ q_z  (rightmost applied first)
     return _quat_mul(_quat_mul(q_x, q_y), q_z)
 
@@ -437,8 +437,8 @@ def quat_to_attitude(q: npt.NDArray[np.float64]) -> tuple[float, float, float]:
         n_proj = north - np.dot(north, b) * b
         n_norm = float(np.linalg.norm(n_proj))
     n_hat = n_proj / n_norm
-    e_hat = np.cross(b, n_hat)  # east direction in boresight-perpendicular plane
-    roll_rad = float(np.arctan2(np.dot(body_z_eci, e_hat), np.dot(body_z_eci, n_hat)))
+    y_hat = np.cross(n_hat, b)
+    roll_rad = float(np.arctan2(np.dot(body_z_eci, y_hat), np.dot(body_z_eci, n_hat)))
 
     return (
         float(np.rad2deg(ra_rad)),

--- a/tests/common/test_common.py
+++ b/tests/common/test_common.py
@@ -16,6 +16,7 @@ from conops.common import (
     body_vector_to_eci,
     scbodyvector,
 )
+from conops.common.vector import _quat_to_rot, attitude_to_quat
 
 
 class TestACSMode:
@@ -197,6 +198,35 @@ class TestBodyVectorTrackingAttitude:
         )
 
         assert recovered_body_vector == pytest.approx(body_vector, abs=1e-9)
+
+    @pytest.mark.parametrize(
+        "attitude",
+        [
+            (0.0, 0.0, 90.0),
+            (45.0, 30.0, 15.0),
+            (120.0, -20.0, 275.0),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "body_vector",
+        [
+            (1.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0),
+            (0.0, 0.0, 1.0),
+            (1.0 / np.sqrt(2.0), 1.0 / np.sqrt(2.0), 0.0),
+        ],
+    )
+    def test_attitude_quaternion_matches_body_vector_to_eci(
+        self, attitude, body_vector
+    ):
+        ra, dec, roll = attitude
+        q = attitude_to_quat(ra, dec, roll)
+        eci_to_body = _quat_to_rot(q)
+        quat_body_to_eci = eci_to_body.T @ np.asarray(body_vector, dtype=np.float64)
+
+        expected = body_vector_to_eci(ra, dec, roll, body_vector)
+        assert expected is not None
+        assert quat_body_to_eci == pytest.approx(expected, abs=1e-9)
 
     def test_legacy_minus_x_tracking_keeps_zero_roll(self):
         target = np.array([0.3, -0.4, 0.8660254])


### PR DESCRIPTION
## Summary
- Align `attitude_to_quat()` roll sign with the `scbodyvector()` / `body_vector_to_eci()` constraint convention.
- Update `quat_to_attitude()` to invert that convention.
- Add a regression comparing quaternion-derived body axes against `body_vector_to_eci()` for off-axis body vectors.

## Why
COAST planning and constraint validation use the RA/Dec/Roll convention implemented by `scbodyvector()` and `body_vector_to_eci()`. The quaternion export used the opposite roll sign, so exported quaternions could disagree with the attitude that COAST planned and validated even when RA/Dec/Roll were correct.

This keeps +X boresight unchanged, but fixes off-axis body vectors reconstructed from quaternions.

## Validation
- `MPLCONFIGDIR=/tmp/mplconfig-quat coastvenv/bin/python -m pytest tests/common/test_common.py tests/ditl/test_telemetry.py -q` -> 106 passed
- `MPLCONFIGDIR=/tmp/mplconfig-quat coastvenv/bin/python -m pytest tests/vector/test_vector.py tests/slew/test_slew.py tests/passes/test_passes.py -q` -> 170 passed
- `MPLCONFIGDIR=/tmp/mplconfig-quat coastvenv/bin/python -m pytest tests/scheduler_queue/test_queue_ditl.py -q` -> 250 passed
- `coastvenv/bin/ruff check conops/common/vector.py tests/common/test_common.py`
- `coastvenv/bin/ruff format --check conops/common/vector.py tests/common/test_common.py`
- `git diff --check`
- GitHub CI is passing for Python 3.10 through 3.14 plus lint/format.

## Follow-on
PR #206 is intentionally stacked on this fix so downstream exports can use COAST-native quaternions instead of reimplementing attitude math.