### PR TITLE
Export generic target attitudes

### DIFF
--- a/conops/common/vector.py
+++ b/conops/common/vector.py
@@ -339,7 +339,7 @@ def attitude_for_body_vector_tracking(
 # Convention: q = [w, x, y, z] (scalar-first).
 # Attitude quaternion represents the rotation from ECI to spacecraft body
 # frame, matching the direction-cosine convention used in scbodyvector():
-#   R = R_x(-roll) @ R_y(dec) @ R_z(-ra)   (all angles in radians)
+#   R = R_x(+roll) @ R_y(dec) @ R_z(-ra)   (all angles in radians)
 # Body X = boresight, Body Z = "up" (defines roll).
 
 
@@ -362,7 +362,7 @@ def attitude_to_quat(
 ) -> npt.NDArray[np.float64]:
     """Convert spacecraft attitude (RA, Dec, Roll) in degrees to quaternion [w, x, y, z].
 
-    The attitude quaternion encodes the rotation R = R_x(-roll) @ R_y(dec) @ R_z(-ra)
+    The attitude quaternion encodes the rotation R = R_x(+roll) @ R_y(dec) @ R_z(-ra)
     that transforms ECI vectors into spacecraft body frame.
     """
     ra = np.deg2rad(ra_deg)
@@ -376,8 +376,8 @@ def attitude_to_quat(
         [np.cos(dec / 2), 0.0, np.sin(dec / 2), 0.0], dtype=np.float64
     )  # R_y(+dec)
     q_x = np.array(
-        [np.cos(roll / 2), -np.sin(roll / 2), 0.0, 0.0], dtype=np.float64
-    )  # R_x(-roll)
+        [np.cos(roll / 2), np.sin(roll / 2), 0.0, 0.0], dtype=np.float64
+    )  # R_x(+roll)
     # Compose: q = q_x ⊗ q_y ⊗ q_z  (rightmost applied first)
     return _quat_mul(_quat_mul(q_x, q_y), q_z)
 
@@ -437,8 +437,8 @@ def quat_to_attitude(q: npt.NDArray[np.float64]) -> tuple[float, float, float]:
         n_proj = north - np.dot(north, b) * b
         n_norm = float(np.linalg.norm(n_proj))
     n_hat = n_proj / n_norm
-    e_hat = np.cross(b, n_hat)  # east direction in boresight-perpendicular plane
-    roll_rad = float(np.arctan2(np.dot(body_z_eci, e_hat), np.dot(body_z_eci, n_hat)))
+    y_hat = np.cross(n_hat, b)
+    roll_rad = float(np.arctan2(np.dot(body_z_eci, y_hat), np.dot(body_z_eci, n_hat)))
 
     return (
         float(np.rad2deg(ra_rad)),

--- a/conops/targets/__init__.py
+++ b/conops/targets/__init__.py
@@ -1,10 +1,13 @@
 from .plan import Plan, TargetList
 from .plan_entry import PlanEntry
 from .plan_schema import (
+    AttitudePointingSchema,
+    AttitudeRotationSchema,
     AttitudeSampleSchema,
     AttitudeTimeseriesSchema,
     PlanEntrySchema,
     PlanSchema,
+    TargetAttitudeSchema,
 )
 from .pointing import Pointing
 from .target_queue import Queue, TargetQueue, TargetSlewEstimate
@@ -13,6 +16,9 @@ __all__ = [
     "PlanEntry",
     "PlanEntrySchema",
     "PlanSchema",
+    "TargetAttitudeSchema",
+    "AttitudeRotationSchema",
+    "AttitudePointingSchema",
     "AttitudeSampleSchema",
     "AttitudeTimeseriesSchema",
     "Pointing",

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -24,7 +24,7 @@ import json
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Literal
 
 from pydantic import (
     BaseModel,
@@ -38,8 +38,41 @@ from pydantic import (
 
 from .._version import __version__
 from ..common.enums import ObsType
+from ..common.vector import attitude_to_quat
 from .plan import Plan
 from .plan_entry import PlanEntry
+
+BodyAxis = Literal["+X", "-X", "+Y", "-Y", "+Z", "-Z"]
+RollSource = Literal["planned", "defaulted_from_unconstrained_sentinel"]
+
+
+class AttitudeRotationSchema(BaseModel):
+    """Generic attitude rotation representation."""
+
+    representation: Literal["quaternion"] = "quaternion"
+    direction: Literal["inertial_to_body"] = "inertial_to_body"
+    order: Literal["wxyz"] = "wxyz"
+    values: tuple[float, float, float, float]
+
+
+class AttitudePointingSchema(BaseModel):
+    """Pointing parameters used to generate a target attitude."""
+
+    ra_deg: float
+    dec_deg: float
+    roll_deg: float
+    boresight_axis: BodyAxis = "+X"
+    roll_axis: BodyAxis = "+X"
+    roll_source: RollSource = "planned"
+
+
+class TargetAttitudeSchema(BaseModel):
+    """Commanded target attitude for a fixed-attitude plan entry."""
+
+    frame: Literal["GCRS"] = "GCRS"
+    body_frame: Literal["COAST_BODY"] = "COAST_BODY"
+    rotation: AttitudeRotationSchema
+    pointing: AttitudePointingSchema
 
 
 class PlanEntrySchema(BaseModel):
@@ -51,6 +84,9 @@ class PlanEntrySchema(BaseModel):
     """
 
     model_config = ConfigDict(from_attributes=True)
+    _STATIC_TARGET_OBSTYPES: ClassVar[frozenset[ObsType]] = frozenset(
+        {ObsType.PPT, ObsType.AT, ObsType.TOO}
+    )
 
     name: str = ""
     ra: float = 0.0
@@ -108,6 +144,37 @@ class PlanEntrySchema(BaseModel):
         if v is None:
             return None
         return datetime.fromtimestamp(v, tz=timezone.utc).isoformat()
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def target_attitude(self) -> TargetAttitudeSchema | None:
+        """Fixed target attitude generated from COAST's RA/Dec/Roll convention."""
+        if self.obstype not in self._STATIC_TARGET_OBSTYPES:
+            return None
+
+        roll_deg = float(self.roll)
+        roll_source: RollSource = "planned"
+        if roll_deg == -1.0:
+            roll_deg = 0.0
+            roll_source = "defaulted_from_unconstrained_sentinel"
+
+        quat = attitude_to_quat(self.ra, self.dec, roll_deg)
+        return TargetAttitudeSchema(
+            rotation=AttitudeRotationSchema(
+                values=(
+                    float(quat[0]),
+                    float(quat[1]),
+                    float(quat[2]),
+                    float(quat[3]),
+                )
+            ),
+            pointing=AttitudePointingSchema(
+                ra_deg=float(self.ra),
+                dec_deg=float(self.dec),
+                roll_deg=roll_deg,
+                roll_source=roll_source,
+            ),
+        )
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/common/test_common.py
+++ b/tests/common/test_common.py
@@ -16,6 +16,7 @@ from conops.common import (
     body_vector_to_eci,
     scbodyvector,
 )
+from conops.common.vector import _quat_to_rot, attitude_to_quat
 
 
 class TestACSMode:
@@ -197,6 +198,35 @@ class TestBodyVectorTrackingAttitude:
         )
 
         assert recovered_body_vector == pytest.approx(body_vector, abs=1e-9)
+
+    @pytest.mark.parametrize(
+        "attitude",
+        [
+            (0.0, 0.0, 90.0),
+            (45.0, 30.0, 15.0),
+            (120.0, -20.0, 275.0),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "body_vector",
+        [
+            (1.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0),
+            (0.0, 0.0, 1.0),
+            (1.0 / np.sqrt(2.0), 1.0 / np.sqrt(2.0), 0.0),
+        ],
+    )
+    def test_attitude_quaternion_matches_body_vector_to_eci(
+        self, attitude, body_vector
+    ):
+        ra, dec, roll = attitude
+        q = attitude_to_quat(ra, dec, roll)
+        eci_to_body = _quat_to_rot(q)
+        quat_body_to_eci = eci_to_body.T @ np.asarray(body_vector, dtype=np.float64)
+
+        expected = body_vector_to_eci(ra, dec, roll, body_vector)
+        assert expected is not None
+        assert quat_body_to_eci == pytest.approx(expected, abs=1e-9)
 
     def test_legacy_minus_x_tracking_keeps_zero_roll(self):
         target = np.array([0.3, -0.4, 0.8660254])

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -5,13 +5,18 @@ import pathlib
 from unittest.mock import Mock
 
 import pytest
+from pydantic import ValidationError
 
 from conops.common.enums import ObsType
+from conops.common.vector import attitude_to_quat
 from conops.targets import (
+    AttitudePointingSchema,
+    AttitudeRotationSchema,
     AttitudeSampleSchema,
     AttitudeTimeseriesSchema,
     PlanEntrySchema,
     PlanSchema,
+    TargetAttitudeSchema,
 )
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -108,6 +113,76 @@ class TestPlanEntrySchema:
         ):
             assert key in dumped, f"Missing key: {key}"
 
+    def test_static_entries_export_generic_target_attitude(self):
+        entry = PlanEntrySchema(**dict(_ENTRY_DICT, ra=15.0, dec=45.0, roll=10.0))
+
+        dumped = entry.model_dump(mode="json")
+
+        attitude = dumped["target_attitude"]
+        assert attitude["frame"] == "GCRS"
+        assert attitude["body_frame"] == "COAST_BODY"
+        assert attitude["rotation"]["representation"] == "quaternion"
+        assert attitude["rotation"]["direction"] == "inertial_to_body"
+        assert attitude["rotation"]["order"] == "wxyz"
+        assert attitude["rotation"]["values"] == pytest.approx(
+            attitude_to_quat(15.0, 45.0, 10.0).tolist()
+        )
+        assert attitude["pointing"] == {
+            "ra_deg": 15.0,
+            "dec_deg": 45.0,
+            "roll_deg": 10.0,
+            "boresight_axis": "+X",
+            "roll_axis": "+X",
+            "roll_source": "planned",
+        }
+
+    def test_target_attitude_metadata_fields_are_typed_literals(self):
+        rotation = AttitudeRotationSchema(values=(1.0, 0.0, 0.0, 0.0))
+        pointing = AttitudePointingSchema(
+            ra_deg=15.0,
+            dec_deg=45.0,
+            roll_deg=10.0,
+            boresight_axis="+Z",
+        )
+
+        attitude = TargetAttitudeSchema(rotation=rotation, pointing=pointing)
+
+        assert attitude.rotation.representation == "quaternion"
+        assert attitude.pointing.boresight_axis == "+Z"
+
+        with pytest.raises(ValidationError):
+            AttitudeRotationSchema(
+                representation="matrix",
+                values=(1.0, 0.0, 0.0, 0.0),
+            )
+        with pytest.raises(ValidationError):
+            AttitudePointingSchema(
+                ra_deg=15.0,
+                dec_deg=45.0,
+                roll_deg=10.0,
+                boresight_axis="Z",
+            )
+        with pytest.raises(ValidationError):
+            TargetAttitudeSchema(
+                frame="ICRF",
+                rotation=rotation,
+                pointing=pointing,
+            )
+
+    def test_unconstrained_roll_sentinel_exports_zero_roll_attitude(self):
+        entry = PlanEntrySchema(**dict(_ENTRY_DICT, roll=-1.0))
+
+        attitude = entry.model_dump(mode="json")["target_attitude"]
+
+        assert attitude["rotation"]["values"] == pytest.approx(
+            attitude_to_quat(_ENTRY_DICT["ra"], _ENTRY_DICT["dec"], 0.0).tolist()
+        )
+        assert attitude["pointing"]["roll_deg"] == 0.0
+        assert (
+            attitude["pointing"]["roll_source"]
+            == "defaulted_from_unconstrained_sentinel"
+        )
+
     def test_gsp_contact_metadata_roundtrips(self):
         entry = PlanEntrySchema(
             **dict(
@@ -146,6 +221,13 @@ class TestPlanEntrySchema:
         assert reloaded.track_end_ra == pytest.approx(48.75)
         assert reloaded.track_end_dec == pytest.approx(9.5)
         assert reloaded.track_end_roll == pytest.approx(13.0)
+
+    def test_dynamic_pass_entries_do_not_export_fixed_target_attitude(self):
+        entry = PlanEntrySchema(**dict(_ENTRY_DICT, obstype="GSP"))
+
+        dumped = entry.model_dump(mode="json", exclude_none=True)
+
+        assert "target_attitude" not in dumped
 
 
 # ── PlanSchema ─────────────────────────────────────────────────────────────────
@@ -225,6 +307,18 @@ class TestPlanSchema:
 
         raw = json.loads(dest.read_text())
         assert "metadata" not in raw
+
+    def test_save_writes_target_attitude_for_static_entries(self, tmp_path):
+        schema = _make_schema(1)
+        dest = tmp_path / "plan.json"
+
+        schema.save(dest)
+
+        raw = json.loads(dest.read_text())
+        attitude = raw["entries"][0]["target_attitude"]
+        assert attitude["rotation"]["direction"] == "inertial_to_body"
+        assert attitude["rotation"]["order"] == "wxyz"
+        assert attitude["pointing"]["boresight_axis"] == "+X"
 
     def test_save_produces_valid_json(self, tmp_path):
         schema = _make_schema(1)


### PR DESCRIPTION
Summary:
- Add a generic `target_attitude` export to fixed science plan entries.
- Export COAST-native inertial-to-body quaternions in `wxyz` order with frame/body-frame metadata.
- Include source pointing metadata: RA/Dec/Roll, +X boresight, +X roll axis, and roll source.
- Omit fixed `target_attitude` from dynamic ground-station-pass entries.

Why:
- Downstream needs the exact attitude COAST planned/validated without reimplementing coordinate conversions.
- Keeping the export generic avoids making COAST emit FlightJAS-specific fields while still centralizing attitude math in COAST.

Validation:
- `coastvenv/bin/python -m pytest tests/common/test_common.py tests/plan/test_plan_schema.py tests/plan/test_plan.py -q` -> 112 passed, 1 skipped
- `coastvenv/bin/ruff check conops/targets/plan_schema.py conops/targets/__init__.py tests/plan/test_plan_schema.py`
- `coastvenv/bin/ruff format --check conops/targets/plan_schema.py conops/targets/__init__.py tests/plan/test_plan_schema.py`
- `git diff --check`
- commit hooks passed

Note:
- This PR is stacked on `fix/quaternion-attitude-convention` so review can focus on the export surface. It intentionally exports COAST native `wxyz` quaternions; downstream tools should only format/reorder them.