### PR TITLE
Distinguish ground station tracking eligibility

### DIFF
--- a/conops/config/groundstation.py
+++ b/conops/config/groundstation.py
@@ -62,10 +62,12 @@ class GroundStation(ConfigModel):
             return max(rates) if rates else 0.0
         return None
 
+    @property
     def supports_downlink(self) -> bool:
         """Return whether this station has any configured downlink capability."""
         return any(bc.downlink_rate_mbps > 0.0 for bc in self.bands)
 
+    @property
     def supports_uplink(self) -> bool:
         """Return whether this station has any configured uplink capability."""
         return any(bc.uplink_rate_mbps > 0.0 for bc in self.bands)

--- a/conops/config/groundstation.py
+++ b/conops/config/groundstation.py
@@ -25,6 +25,14 @@ class GroundStation(ConfigModel):
         le=1.0,
         description="Probability of scheduling a pass when available",
     )
+    schedule_for_tracking: bool = Field(
+        default=True,
+        description=(
+            "Whether visible passes from this station may be scheduled as "
+            "spacecraft-tracking ground-station passes. Set false for "
+            "uplink-only contacts that should not drive GSP attitude planning."
+        ),
+    )
     # Moved from Antenna
     bands: list[BandCapability] = Field(
         default_factory=list,
@@ -53,6 +61,14 @@ class GroundStation(ConfigModel):
             rates = [bc.downlink_rate_mbps for bc in self.bands]
             return max(rates) if rates else 0.0
         return None
+
+    def supports_downlink(self) -> bool:
+        """Return whether this station has any configured downlink capability."""
+        return any(bc.downlink_rate_mbps > 0.0 for bc in self.bands)
+
+    def supports_uplink(self) -> bool:
+        """Return whether this station has any configured uplink capability."""
+        return any(bc.uplink_rate_mbps > 0.0 for bc in self.bands)
 
 
 class GroundStationRegistry(ConfigModel):

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -530,8 +530,12 @@ class PassTimes:
         begin_time = timestamps[0]
         end_time = timestamps[-1]
 
-        # Process each ground station
+        # Process stations that are allowed to drive spacecraft GSP tracking. RF
+        # uplink/downlink capability is modeled separately on each station.
         for station in self.ground_stations.stations:
+            if not getattr(station, "schedule_for_tracking", True):
+                continue
+
             # Create GroundEphemeris for this station (vectorized ground station ephemeris)
 
             gs_ephem = rust_ephem.GroundEphemeris(

--- a/tests/groundstation/test_groundstation.py
+++ b/tests/groundstation/test_groundstation.py
@@ -44,10 +44,10 @@ class TestGroundStationAntennaFields:
             ],
         )
 
-        assert uplink_only.supports_uplink() is True
-        assert uplink_only.supports_downlink() is False
-        assert downlink_only.supports_uplink() is False
-        assert downlink_only.supports_downlink() is True
+        assert uplink_only.supports_uplink is True
+        assert uplink_only.supports_downlink is False
+        assert downlink_only.supports_uplink is False
+        assert downlink_only.supports_downlink is True
 
 
 class TestGroundStation:

--- a/tests/groundstation/test_groundstation.py
+++ b/tests/groundstation/test_groundstation.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from conops import GroundStation
+from conops.config import BandCapability
 
 
 class TestGroundStationAntennaFields:
@@ -16,6 +17,37 @@ class TestGroundStationAntennaFields:
     def test_default_overall_max_downlink_none(self):
         gs = GroundStation(code="X", name="X", latitude_deg=0.0, longitude_deg=0.0)
         assert gs.get_overall_max_downlink() is None
+
+    def test_default_schedule_for_tracking_true(self):
+        gs = GroundStation(code="X", name="X", latitude_deg=0.0, longitude_deg=0.0)
+        assert gs.schedule_for_tracking is True
+
+    def test_supports_uplink_and_downlink_reflect_configured_rates(self):
+        uplink_only = GroundStation(
+            code="UL",
+            name="Uplink",
+            latitude_deg=0.0,
+            longitude_deg=0.0,
+            bands=[
+                BandCapability(band="S", uplink_rate_mbps=2.0, downlink_rate_mbps=0.0)
+            ],
+        )
+        downlink_only = GroundStation(
+            code="DL",
+            name="Downlink",
+            latitude_deg=0.0,
+            longitude_deg=0.0,
+            bands=[
+                BandCapability(
+                    band="Ka", uplink_rate_mbps=0.0, downlink_rate_mbps=58.64
+                )
+            ],
+        )
+
+        assert uplink_only.supports_uplink() is True
+        assert uplink_only.supports_downlink() is False
+        assert downlink_only.supports_uplink() is False
+        assert downlink_only.supports_downlink() is True
 
 
 class TestGroundStation:

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -572,6 +572,35 @@ class TestPassTimes:
 
         assert pt._gsp_antenna_boresight_body() is None
 
+    def test_get_skips_stations_not_scheduled_for_tracking(
+        self, mock_constraint, mock_config
+    ):
+        """RF-capable stations can be excluded from spacecraft GSP tracking."""
+        stations = GroundStationRegistry()
+        stations.add(
+            GroundStation(
+                code="RF",
+                name="RF-capable non-tracking station",
+                latitude_deg=0.0,
+                longitude_deg=0.0,
+                schedule_probability=1.0,
+                schedule_for_tracking=False,
+                bands=[
+                    BandCapability(
+                        band="S", uplink_rate_mbps=2.0, downlink_rate_mbps=10.0
+                    )
+                ],
+            )
+        )
+        mock_config.ground_stations = stations
+        pt = PassTimes(config=mock_config)
+
+        with patch("conops.simulation.passes.rust_ephem.GroundEphemeris") as gs_ephem:
+            pt.get(year=2025, day=227, length=1)
+
+        gs_ephem.assert_not_called()
+        assert pt.passes == []
+
     def test_passtimes_requires_ephemeris(self, mock_config):
         """Test PassTimes requires ephemeris."""
         constraint = Mock(spec=Constraint)


### PR DESCRIPTION
## Summary

- Add `GroundStation.schedule_for_tracking` to explicitly control whether a station can create spacecraft-tracking GSPs.
- Keep existing behavior backward-compatible by defaulting `schedule_for_tracking=True`.
- Add `supports_uplink()` and `supports_downlink()` helpers so RF capability can be inspected separately from tracking eligibility.
- Make `PassTimes.get()` skip stations with `schedule_for_tracking=False` before building ground-station ephemerides or GSP attitude profiles.

## Why

`schedule_probability=0.0` currently has to do two jobs:

- represent network/pass scheduling availability
- suppress spacecraft GSP tracking for stations that should only be modeled as uplink-only/non-downlink contacts

Those are different concepts. This lets configs keep real uplink/downlink capability on a station while independently saying whether COAST should command spacecraft attitude tracking for visible passes from that station.

For Tamalpais, this means non-Svalbard uplink-only stations can use `schedule_for_tracking: false` instead of overloading `schedule_probability: 0.0`; Svalbard Ka remains the scheduled/tracked downlink path.

## Validation

- `/home/aaron/Projects/Cosmic/ops/coast-sim/coastvenv/bin/python -m pytest tests/groundstation/test_groundstation.py tests/passes/test_passes.py -q`
- `/home/aaron/Projects/Cosmic/ops/coast-sim/coastvenv/bin/ruff check --extend-select I --fix conops/config/groundstation.py conops/simulation/passes.py tests/groundstation/test_groundstation.py tests/passes/test_passes.py`
- `/home/aaron/Projects/Cosmic/ops/coast-sim/coastvenv/bin/ruff format conops/config/groundstation.py conops/simulation/passes.py tests/groundstation/test_groundstation.py tests/passes/test_passes.py`
- `git diff --check`

Pre-commit note:

- Hook environment fetched and non-mypy hooks passed.
- The local mypy hook fails in this temp worktree because generated `conops/_version.py` is absent, causing `conops/targets/plan_schema.py:39: Cannot find implementation or library stub for module named "conops._version"`. The file is generated by `setuptools_scm` and ignored by git.
