### PR TITLE
fix: Enforce full-mission attitude constraints

### DIFF
--- a/conops/config/config.py
+++ b/conops/config/config.py
@@ -34,11 +34,11 @@ def _default_attitude_constraint_policy() -> dict[str, AttitudeConstraintPolicy]
     return {
         ACSMode.SCIENCE.name: AttitudeConstraintPolicy.FULL_MISSION,
         ACSMode.CHARGING.name: AttitudeConstraintPolicy.FULL_MISSION,
-        ACSMode.SLEWING.name: AttitudeConstraintPolicy.HARD_KEEPOUT,
-        ACSMode.PASS.name: AttitudeConstraintPolicy.HARD_KEEPOUT,
-        ACSMode.SAA.name: AttitudeConstraintPolicy.HARD_KEEPOUT,
-        ACSMode.SAFE.name: AttitudeConstraintPolicy.HARD_KEEPOUT,
-        ACSMode.IDLE.name: AttitudeConstraintPolicy.HARD_KEEPOUT,
+        ACSMode.SLEWING.name: AttitudeConstraintPolicy.FULL_MISSION,
+        ACSMode.PASS.name: AttitudeConstraintPolicy.FULL_MISSION,
+        ACSMode.SAA.name: AttitudeConstraintPolicy.FULL_MISSION,
+        ACSMode.SAFE.name: AttitudeConstraintPolicy.FULL_MISSION,
+        ACSMode.IDLE.name: AttitudeConstraintPolicy.FULL_MISSION,
     }
 
 

--- a/conops/config/star_tracker.py
+++ b/conops/config/star_tracker.py
@@ -403,6 +403,7 @@ class StarTrackerConfiguration(ConfigModel):
                 roll_deg=roll_deg,
                 pitch_deg=pitch_deg,
                 yaw_deg=yaw_deg,
+                roll_clockwise=True,
             )
 
             if combined is None:
@@ -442,6 +443,7 @@ class StarTrackerConfiguration(ConfigModel):
                 roll_deg=roll_deg,
                 pitch_deg=pitch_deg,
                 yaw_deg=yaw_deg,
+                roll_clockwise=True,
             )
             offset_constraints.append(offset_constraint)
 

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1463,71 +1463,73 @@ class QueueDITL(DITLMixin, DITLStats):
 
     def _initiate_charging(self, utime: float, ra: float, dec: float) -> None:
         """Initiate emergency charging by creating charging PPT and sending command to ACS."""
-        interrupted_ppt = self.ppt
-        interrupted_state = (
-            (interrupted_ppt.end, interrupted_ppt.done)
-            if interrupted_ppt is not None
-            else None
+        charging_ppt = self.emergency_charging.create_charging_pointing(
+            utime, self.ephem, ra, dec
         )
-        self.charging_ppt = self.emergency_charging.initiate_emergency_charging(
-            utime, self.ephem, ra, dec, self.ppt
-        )
+        if charging_ppt is None:
+            return
 
-        # If charging PPT created successfully, send command to ACS and replace current PPT
-        if self.charging_ppt is not None:
-            slew = Slew(config=self.config)
-            slew.ephem = self.acs.ephem
-            slew.slewrequest = utime
-            slew.slewstart = utime
-            slew.startra = ra
-            slew.startdec = dec
-            slew.startroll = self.acs.roll
-            slew.endra = self.charging_ppt.ra
-            slew.enddec = self.charging_ppt.dec
-            slew.endroll = self.charging_ppt.roll
-            slew.obstype = ObsType.CHARGE
-            slew.obsid = self.charging_ppt.obsid
-            slew.at = self.charging_ppt
-            slew.calc_slewtime()
-            violation = self._slew_attitude_constraint_violation(slew, ACSMode.SLEWING)
-            if violation is not None:
-                violation_time, constraint_name, policy = violation
-                self.log.log_event(
-                    utime=utime,
-                    event_type="CHARGING",
-                    description=(
-                        f"Skipping emergency charge slew - path violates "
-                        f"{constraint_name} ({policy}) at {unixtime2date(violation_time)}"
-                    ),
-                    obsid=self.charging_ppt.obsid,
-                    acs_mode=self.acs.acsmode,
-                )
-                if interrupted_ppt is not None and interrupted_state is not None:
-                    interrupted_ppt.end, interrupted_ppt.done = interrupted_state
-                self.emergency_charging.current_charging_ppt = None
-                self.charging_ppt = None
-                return
-
-            if interrupted_ppt is not None:
-                if (
-                    len(self.plan) > 0
-                    and self._entry_obstype(self.plan[-1]) == ObsType.AT
-                    and int(self.plan[-1].obsid) == int(interrupted_ppt.obsid)
-                ):
-                    self._close_last_plan_entry(utime)
-                if self._is_short_science_entry(interrupted_ppt):
-                    interrupted_ppt.done = False
-
-            command = ACSCommand(
-                command_type=ACSCommandType.START_BATTERY_CHARGE,
-                execution_time=utime,
-                ra=self.charging_ppt.ra,
-                dec=self.charging_ppt.dec,
-                roll=self.charging_ppt.roll,
-                obsid=self.charging_ppt.obsid,
+        slew = Slew(config=self.config)
+        slew.ephem = self.acs.ephem
+        slew.slewrequest = utime
+        slew.slewstart = utime
+        slew.startra = ra
+        slew.startdec = dec
+        slew.startroll = self.acs.roll
+        slew.endra = charging_ppt.ra
+        slew.enddec = charging_ppt.dec
+        slew.endroll = charging_ppt.roll
+        slew.obstype = ObsType.CHARGE
+        slew.obsid = charging_ppt.obsid
+        slew.at = charging_ppt
+        slew.calc_slewtime()
+        violation = self._slew_attitude_constraint_violation(slew, ACSMode.SLEWING)
+        if violation is not None:
+            violation_time, constraint_name, policy = violation
+            self.log.log_event(
+                utime=utime,
+                event_type="CHARGING",
+                description=(
+                    f"Skipping emergency charge slew - path violates "
+                    f"{constraint_name} ({policy}) at {unixtime2date(violation_time)}"
+                ),
+                obsid=charging_ppt.obsid,
+                acs_mode=self.acs.acsmode,
             )
-            self.acs.enqueue_command(command)
-            self.ppt = self.charging_ppt
+            self.emergency_charging.current_charging_ppt = None
+            return
+
+        interrupted_ppt = self.ppt
+        self.charging_ppt = charging_ppt
+        if interrupted_ppt is not None and not getattr(interrupted_ppt, "done", False):
+            self.log.log_event(
+                utime=utime,
+                event_type="ERROR",
+                description="BATTERY ALERT: Terminating science observation for emergency charging",
+            )
+            interrupted_ppt.end = utime
+            interrupted_ppt.done = True
+
+        if interrupted_ppt is not None:
+            if (
+                len(self.plan) > 0
+                and self._entry_obstype(self.plan[-1]) == ObsType.AT
+                and int(self.plan[-1].obsid) == int(interrupted_ppt.obsid)
+            ):
+                self._close_last_plan_entry(utime)
+            if self._is_short_science_entry(interrupted_ppt):
+                interrupted_ppt.done = False
+
+        command = ACSCommand(
+            command_type=ACSCommandType.START_BATTERY_CHARGE,
+            execution_time=utime,
+            ra=self.charging_ppt.ra,
+            dec=self.charging_ppt.dec,
+            roll=self.charging_ppt.roll,
+            obsid=self.charging_ppt.obsid,
+        )
+        self.acs.enqueue_command(command)
+        self.ppt = self.charging_ppt
 
     def _setup_simulation_timing(self) -> bool:
         """Set up timing aspect of simulation."""
@@ -1586,12 +1588,7 @@ class QueueDITL(DITLMixin, DITLStats):
                     ),
                 )
 
-            constraint_dropped_passes = getattr(
-                self.acs.passrequests, "dropped_constraint_passes", []
-            )
-            if not isinstance(constraint_dropped_passes, list):
-                constraint_dropped_passes = []
-            for dropped in constraint_dropped_passes:
+            for dropped in self.acs.passrequests.dropped_constraint_passes:
                 self.log.log_event(
                     utime=self.ustart,
                     event_type="PASS",

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1563,37 +1563,42 @@ class QueueDITL(DITLMixin, DITLStats):
             # Calculate length in days from begin/end
             length = int((self.end - self.begin).total_seconds() / 86400)
             self.acs.passrequests.get(year, day, length)
-            if self.acs.passrequests.passes:
-                for p in self.acs.passrequests.passes:
-                    self.log.log_event(
-                        utime=self.ustart,
-                        event_type="PASS",
-                        description=f"Scheduled pass: {p}",
-                    )
-                dropped_passes = self.acs.passrequests.dropped_overlapping_passes
-                for dropped, selected in dropped_passes:
-                    self.log.log_event(
-                        utime=self.ustart,
-                        event_type="PASS",
-                        description=(
-                            f"Skipped overlapping pass opportunity: {dropped} "
-                            f"overlaps selected pass {selected}"
-                        ),
-                    )
-                constraint_dropped_passes = getattr(
-                    self.acs.passrequests, "dropped_constraint_passes", []
+            scheduled_passes = self.acs.passrequests.passes or []
+            for p in scheduled_passes:
+                self.log.log_event(
+                    utime=self.ustart,
+                    event_type="PASS",
+                    description=f"Scheduled pass: {p}",
                 )
-                if not isinstance(constraint_dropped_passes, list):
-                    constraint_dropped_passes = []
-                for dropped in constraint_dropped_passes:
-                    self.log.log_event(
-                        utime=self.ustart,
-                        event_type="PASS",
-                        description=(
-                            f"Skipped constraint-unsafe pass opportunity: {dropped}"
-                        ),
-                    )
-            else:
+
+            dropped_passes = getattr(
+                self.acs.passrequests, "dropped_overlapping_passes", []
+            )
+            if not isinstance(dropped_passes, list):
+                dropped_passes = []
+            for dropped, selected in dropped_passes:
+                self.log.log_event(
+                    utime=self.ustart,
+                    event_type="PASS",
+                    description=(
+                        f"Skipped overlapping pass opportunity: {dropped} "
+                        f"overlaps selected pass {selected}"
+                    ),
+                )
+
+            constraint_dropped_passes = getattr(
+                self.acs.passrequests, "dropped_constraint_passes", []
+            )
+            if not isinstance(constraint_dropped_passes, list):
+                constraint_dropped_passes = []
+            for dropped in constraint_dropped_passes:
+                self.log.log_event(
+                    utime=self.ustart,
+                    event_type="PASS",
+                    description=f"Skipped constraint-unsafe pass opportunity: {dropped}",
+                )
+
+            if not scheduled_passes:
                 self.log.log_event(
                     utime=self.ustart,
                     event_type="INFO",

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -896,14 +896,15 @@ class QueueDITL(DITLMixin, DITLStats):
             return "Telescope Hard"
         return None
 
-    def _attitude_constraint_name_for_sample(
-        self, index: int, mode: ACSMode
+    def _attitude_constraint_name_for_attitude(
+        self,
+        ra: float,
+        dec: float,
+        roll: float,
+        utime: float,
+        mode: ACSMode,
     ) -> tuple[str, str] | None:
-        """Return the violated constraint name and policy for one attitude sample."""
-        ra = float(self.ra[index])
-        dec = float(self.dec[index])
-        roll = float(self.roll[index])
-        utime = self.utime[index]
+        """Return the violated constraint name and policy for one attitude."""
         policy = self.config.attitude_constraint_policy_for_mode(mode)
         if policy == AttitudeConstraintPolicy.NONE:
             return None
@@ -921,6 +922,18 @@ class QueueDITL(DITLMixin, DITLStats):
             if name is not None:
                 return name, policy.value
         return None
+
+    def _attitude_constraint_name_for_sample(
+        self, index: int, mode: ACSMode
+    ) -> tuple[str, str] | None:
+        """Return the violated constraint name and policy for one recorded sample."""
+        return self._attitude_constraint_name_for_attitude(
+            float(self.ra[index]),
+            float(self.dec[index]),
+            float(self.roll[index]),
+            self.utime[index],
+            mode,
+        )
 
     def _validate_attitude_constraints(self) -> list[PlanExecutionMismatch]:
         mismatches: list[PlanExecutionMismatch] = []
@@ -1451,12 +1464,50 @@ class QueueDITL(DITLMixin, DITLStats):
     def _initiate_charging(self, utime: float, ra: float, dec: float) -> None:
         """Initiate emergency charging by creating charging PPT and sending command to ACS."""
         interrupted_ppt = self.ppt
+        interrupted_state = (
+            (interrupted_ppt.end, interrupted_ppt.done)
+            if interrupted_ppt is not None
+            else None
+        )
         self.charging_ppt = self.emergency_charging.initiate_emergency_charging(
             utime, self.ephem, ra, dec, self.ppt
         )
 
         # If charging PPT created successfully, send command to ACS and replace current PPT
         if self.charging_ppt is not None:
+            slew = Slew(config=self.config)
+            slew.ephem = self.acs.ephem
+            slew.slewrequest = utime
+            slew.slewstart = utime
+            slew.startra = ra
+            slew.startdec = dec
+            slew.startroll = self.acs.roll
+            slew.endra = self.charging_ppt.ra
+            slew.enddec = self.charging_ppt.dec
+            slew.endroll = self.charging_ppt.roll
+            slew.obstype = ObsType.CHARGE
+            slew.obsid = self.charging_ppt.obsid
+            slew.at = self.charging_ppt
+            slew.calc_slewtime()
+            violation = self._slew_attitude_constraint_violation(slew, ACSMode.SLEWING)
+            if violation is not None:
+                violation_time, constraint_name, policy = violation
+                self.log.log_event(
+                    utime=utime,
+                    event_type="CHARGING",
+                    description=(
+                        f"Skipping emergency charge slew - path violates "
+                        f"{constraint_name} ({policy}) at {unixtime2date(violation_time)}"
+                    ),
+                    obsid=self.charging_ppt.obsid,
+                    acs_mode=self.acs.acsmode,
+                )
+                if interrupted_ppt is not None and interrupted_state is not None:
+                    interrupted_ppt.end, interrupted_ppt.done = interrupted_state
+                self.emergency_charging.current_charging_ppt = None
+                self.charging_ppt = None
+                return
+
             if interrupted_ppt is not None:
                 if (
                     len(self.plan) > 0
@@ -1527,6 +1578,19 @@ class QueueDITL(DITLMixin, DITLStats):
                         description=(
                             f"Skipped overlapping pass opportunity: {dropped} "
                             f"overlaps selected pass {selected}"
+                        ),
+                    )
+                constraint_dropped_passes = getattr(
+                    self.acs.passrequests, "dropped_constraint_passes", []
+                )
+                if not isinstance(constraint_dropped_passes, list):
+                    constraint_dropped_passes = []
+                for dropped in constraint_dropped_passes:
+                    self.log.log_event(
+                        utime=self.ustart,
+                        event_type="PASS",
+                        description=(
+                            f"Skipped constraint-unsafe pass opportunity: {dropped}"
                         ),
                     )
             else:
@@ -1770,6 +1834,20 @@ class QueueDITL(DITLMixin, DITLStats):
             slew.obstype = ObsType.GSP  # Ground Station Pass slew
             slew.obsid = next_pass.obsid
             slew.calc_slewtime()
+            violation = self._slew_attitude_constraint_violation(slew, ACSMode.PASS)
+            if violation is not None:
+                violation_time, constraint_name, policy = violation
+                self.log.log_event(
+                    utime=utime,
+                    event_type="PASS",
+                    description=(
+                        f"Skipping pass slew to {next_pass.station} - path violates "
+                        f"{constraint_name} ({policy}) at {unixtime2date(violation_time)}"
+                    ),
+                    obsid=next_pass.obsid,
+                    acs_mode=self.acs.acsmode,
+                )
+                return False
             command = ACSCommand(
                 command_type=ACSCommandType.SLEW_TO_TARGET,
                 execution_time=utime,
@@ -1982,6 +2060,34 @@ class QueueDITL(DITLMixin, DITLStats):
             if window[0] <= slew_end <= window[1]:
                 return window[1]
         return slew_end
+
+    def _slew_attitude_constraint_violation(
+        self, slew: Slew, mode: ACSMode
+    ) -> tuple[float, str, str] | None:
+        """Return first policy violation along a planned slew path, if any."""
+        if slew.slewtime <= 0:
+            return None
+
+        for sample_utime in self._ephem_utimes():
+            if sample_utime < slew.slewstart:
+                continue
+            if sample_utime >= slew.slewend:
+                break
+
+            sample_ra, sample_dec = slew.ra_dec(sample_utime)
+            sample_roll = slew.slew_roll(sample_utime)
+            violation = self._attitude_constraint_name_for_attitude(
+                float(sample_ra),
+                float(sample_dec),
+                float(sample_roll),
+                sample_utime,
+                mode,
+            )
+            if violation is not None:
+                constraint_name, policy = violation
+                return sample_utime, constraint_name, policy
+
+        return None
 
     def _next_pass_science_deadline(
         self, slew_end: float, target: Pointing | None = None
@@ -2379,6 +2485,21 @@ class QueueDITL(DITLMixin, DITLStats):
                         return
 
             self._complete_ppt_slew(slew, self.ppt, utime, execution_time)
+            violation = self._slew_attitude_constraint_violation(slew, ACSMode.SLEWING)
+            if violation is not None:
+                violation_time, constraint_name, policy = violation
+                self.log.log_event(
+                    utime=utime,
+                    event_type="QUEUE",
+                    description=(
+                        f"Target {self.ppt.obsid} skipped - slew path violates "
+                        f"{constraint_name} ({policy}) at {unixtime2date(violation_time)}"
+                    ),
+                    obsid=self.ppt.obsid,
+                    acs_mode=self.acs.acsmode,
+                )
+                self._retry_fetch_without_current_ppt(utime, ra, dec)
+                return
 
             # Validate that the locked roll satisfies constraints for at least
             # ss_min seconds after slew completion.  The ACS holds roll constant

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -7,7 +7,7 @@ import rust_ephem
 from pydantic import BaseModel, Field
 
 from ..common import ics_date_conv, unixtime2date
-from ..common.enums import AntennaType, ObsType, SlewAlgorithm
+from ..common.enums import ACSMode, AntennaType, ObsType, SlewAlgorithm
 from ..common.vector import (
     attitude_for_body_vector_tracking,
     body_vector_to_eci,
@@ -17,7 +17,12 @@ from ..common.vector import (
     separation,
     vec2radec,
 )
-from ..config import Constraint, GroundStationRegistry, MissionConfig
+from ..config import (
+    AttitudeConstraintPolicy,
+    Constraint,
+    GroundStationRegistry,
+    MissionConfig,
+)
 from ..config.constants import DTOR
 from .slew import Slew
 
@@ -424,6 +429,7 @@ class PassTimes:
         )
         self.passes = []
         self.dropped_overlapping_passes: list[tuple[Pass, Pass]] = []
+        self.dropped_constraint_passes: list[Pass] = []
         self.length = 1
 
         # Ground stations registry from config
@@ -493,6 +499,44 @@ class PassTimes:
         boresight = antenna.fixed_boresight_body
         return (float(boresight[0]), float(boresight[1]), float(boresight[2]))
 
+    def _pass_attitude_violates_policy(
+        self, ra: float, dec: float, roll: float, utime: float
+    ) -> bool:
+        policy = AttitudeConstraintPolicy(
+            self.config.attitude_constraint_policy_for_mode(ACSMode.PASS)
+        )
+        if policy == AttitudeConstraintPolicy.NONE:
+            return False
+        if policy == AttitudeConstraintPolicy.FULL_MISSION:
+            return bool(
+                self.constraint.in_constraint(
+                    ra, dec, utime, target_roll=roll, acs_mode=ACSMode.PASS
+                )
+            )
+        if policy == AttitudeConstraintPolicy.HARD_KEEPOUT:
+            return bool(
+                self.constraint.in_star_tracker_hard(
+                    ra, dec, utime, target_roll=roll, acs_mode=ACSMode.PASS
+                )
+                or self.constraint.in_radiator_hard(ra, dec, utime, target_roll=roll)
+                or self.constraint.in_telescope_hard(ra, dec, utime, target_roll=roll)
+            )
+        return False
+
+    def _pass_profile_violates_policy(
+        self,
+        utimes: list[float],
+        track_ra: list[float],
+        track_dec: list[float],
+        track_roll: list[float],
+    ) -> bool:
+        return any(
+            self._pass_attitude_violates_policy(ra, dec, roll, utime)
+            for utime, ra, dec, roll in zip(
+                utimes, track_ra, track_dec, track_roll, strict=True
+            )
+        )
+
     def _deconflict_overlapping_passes(self) -> None:
         selected: list[Pass] = []
         self.dropped_overlapping_passes = []
@@ -515,6 +559,7 @@ class PassTimes:
         """Calculate the passes using rust_ephem GroundEphemeris for vectorized operations."""
         ustart = ics_date_conv(f"{year}-{day:03d}-00:00:00")
         assert self.ephem is not None, "Ephemeris is not set"
+        self.dropped_constraint_passes = []
 
         # Use binary search instead of np.where for finding start index
         # Prefer adapter datetimes if available, otherwise use Time.unix
@@ -640,6 +685,9 @@ class PassTimes:
                         track_ra = [attitude[0] for attitude in attitude_profile]
                         track_dec = [attitude[1] for attitude in attitude_profile]
                         track_roll = [attitude[2] for attitude in attitude_profile]
+                        track_utime = timestamp_unix[
+                            startindex + start_idx : startindex + end_idx
+                        ].tolist()
 
                         gspass = Pass(
                             config=self.config,
@@ -657,14 +705,18 @@ class PassTimes:
                         )
 
                         # Record the path during the pass
-                        gspass.utime = timestamp_unix[
-                            startindex + start_idx : startindex + end_idx
-                        ].tolist()
+                        gspass.utime = track_utime
                         gspass.ra = track_ra
                         gspass.dec = track_dec
                         gspass.roll = track_roll
                         gspass.station_ra = target_ra.tolist()
                         gspass.station_dec = target_dec.tolist()
+
+                        if self._pass_profile_violates_policy(
+                            track_utime, track_ra, track_dec, track_roll
+                        ):
+                            self.dropped_constraint_passes.append(gspass)
+                            continue
 
                         self.passes.append(gspass)
 

--- a/conops/visualization/mpl/acs_mode_analysis.py
+++ b/conops/visualization/mpl/acs_mode_analysis.py
@@ -93,9 +93,7 @@ def plot_acs_mode_distribution(
         textprops={"fontsize": label_font_size, "fontfamily": font_family},
     )
     # Matplotlib returns a tuple in 3.10 and a PieContainer in 3.11+.
-    autotexts = getattr(pie_res, "autotexts", None)
-    if autotexts is None:
-        autotexts = pie_res[2] if len(pie_res) > 2 else []
+    autotexts = pie_res[2] if isinstance(pie_res, tuple) and len(pie_res) > 2 else []
     ax.set_title(
         "Percentage of Time Spent in Each ACS Mode", fontproperties=title_prop, pad=20
     )

--- a/conops/visualization/mpl/acs_mode_analysis.py
+++ b/conops/visualization/mpl/acs_mode_analysis.py
@@ -92,9 +92,10 @@ def plot_acs_mode_distribution(
         startangle=140,
         textprops={"fontsize": label_font_size, "fontfamily": font_family},
     )
-    # matplotlib's pie() can return 2 or 3 values depending on whether autopct is set/used.
-    # Be defensive: ensure we always have wedges, texts, and autotexts variables
-    autotexts = pie_res[2] if len(pie_res) > 2 else []
+    # Matplotlib returns a tuple in 3.10 and a PieContainer in 3.11+.
+    autotexts = getattr(pie_res, "autotexts", None)
+    if autotexts is None:
+        autotexts = pie_res[2] if len(pie_res) > 2 else []
     ax.set_title(
         "Percentage of Time Spent in Each ACS Mode", fontproperties=title_prop, pad=20
     )

--- a/tests/acs/conftest.py
+++ b/tests/acs/conftest.py
@@ -8,7 +8,6 @@ import pytest
 
 from conops import (
     ACS,
-    ACSMode,
     AttitudeConstraintPolicy,
     AttitudeControlSystem,
     Constraint,
@@ -88,11 +87,7 @@ def mock_config(mock_ephem: DummyEphemeris, mock_constraint: Mock) -> Mock:
     config.spacecraft_bus.radiators = Mock()
     config.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
     config.attitude_constraint_policy_for_mode = Mock(
-        side_effect=lambda mode: (
-            AttitudeConstraintPolicy.FULL_MISSION
-            if ACSMode(int(mode)) in (ACSMode.SCIENCE, ACSMode.CHARGING)
-            else AttitudeConstraintPolicy.HARD_KEEPOUT
-        )
+        return_value=AttitudeConstraintPolicy.FULL_MISSION
     )
     return config
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -71,18 +71,11 @@ class TestConfig:
     def test_attitude_constraint_policy_defaults_by_mode(self) -> None:
         """Test executed attitude validation policy defaults."""
         config = MissionConfig()
-        assert (
-            config.attitude_constraint_policy_for_mode(ACSMode.SCIENCE)
-            == AttitudeConstraintPolicy.FULL_MISSION
-        )
-        assert (
-            config.attitude_constraint_policy_for_mode(ACSMode.PASS)
-            == AttitudeConstraintPolicy.HARD_KEEPOUT
-        )
-        assert (
-            config.attitude_constraint_policy_for_mode(ACSMode.IDLE)
-            == AttitudeConstraintPolicy.HARD_KEEPOUT
-        )
+        for mode in ACSMode:
+            assert (
+                config.attitude_constraint_policy_for_mode(mode)
+                == AttitudeConstraintPolicy.FULL_MISSION
+            )
 
     def test_attitude_constraint_policy_accepts_mode_name_overrides(self) -> None:
         """Test mission config can override one ACS mode by name."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from astropy.time import Time  # type: ignore[import-untyped]
 
-from conops import ACSMode, AttitudeConstraintPolicy, SolarPanel, SolarPanelSet
+from conops import AttitudeConstraintPolicy, SolarPanel, SolarPanelSet
 
 
 @pytest.fixture(autouse=True)
@@ -108,11 +108,7 @@ def test_config_with_panels(mock_ephem_with_pv: Mock) -> tuple[Mock, SolarPanelS
     config.spacecraft_bus.radiators = Mock()
     config.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
     config.attitude_constraint_policy_for_mode = Mock(
-        side_effect=lambda mode: (
-            AttitudeConstraintPolicy.FULL_MISSION
-            if ACSMode(int(mode)) in (ACSMode.SCIENCE, ACSMode.CHARGING)
-            else AttitudeConstraintPolicy.HARD_KEEPOUT
-        )
+        return_value=AttitudeConstraintPolicy.FULL_MISSION
     )
 
     return config, panel_set

--- a/tests/passes/conftest.py
+++ b/tests/passes/conftest.py
@@ -72,6 +72,10 @@ def mock_constraint(mock_ephem):
     """Create a mock constraint."""
     constraint = Mock(spec=Constraint)
     constraint.ephem = mock_ephem
+    constraint.in_constraint = Mock(return_value=False)
+    constraint.in_star_tracker_hard = Mock(return_value=False)
+    constraint.in_radiator_hard = Mock(return_value=False)
+    constraint.in_telescope_hard = Mock(return_value=False)
     return constraint
 
 

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -13,9 +13,10 @@ from conops import (
     PassTimes,
 )
 from conops.common import attitude_for_body_vector_tracking, radec2vec
-from conops.common.enums import AntennaType, ObsType, SlewAlgorithm
+from conops.common.enums import ACSMode, AntennaType, ObsType, SlewAlgorithm
 from conops.config import (
     AntennaPointing,
+    AttitudeConstraintPolicy,
     AttitudeControlSystem,
     BandCapability,
     CommunicationsSystem,
@@ -527,6 +528,7 @@ class TestPassTimes:
         assert pt.config is mock_config
         assert pt.passes == []
         assert pt.length == 1
+        assert pt.dropped_constraint_passes == []
         assert pt.minelev == 10.0
         assert pt.minlen == 480
         assert pt.schedule_chance == 1.0
@@ -600,6 +602,33 @@ class TestPassTimes:
 
         gs_ephem.assert_not_called()
         assert pt.passes == []
+
+    def test_pass_profile_uses_full_mission_policy(self, mock_constraint, mock_config):
+        """PASS profiles should be filtered by the configured full mission policy."""
+        pt = PassTimes(config=mock_config)
+        mock_constraint.in_constraint = Mock(return_value=True)
+
+        assert pt._pass_profile_violates_policy([1000.0], [10.0], [20.0], [30.0])
+        mock_constraint.in_constraint.assert_called_once_with(
+            10.0, 20.0, 1000.0, target_roll=30.0, acs_mode=ACSMode.PASS
+        )
+
+    def test_pass_profile_respects_hard_keepout_override(
+        self, mock_constraint, mock_config
+    ):
+        """PASS profiles still honor explicit hard-keepout policy overrides."""
+        mock_config.attitude_constraint_policy = {
+            ACSMode.PASS.name: AttitudeConstraintPolicy.HARD_KEEPOUT
+        }
+        pt = PassTimes(config=mock_config)
+        mock_constraint.in_constraint = Mock(return_value=True)
+        mock_constraint.in_star_tracker_hard = Mock(return_value=True)
+
+        assert pt._pass_profile_violates_policy([1000.0], [10.0], [20.0], [30.0])
+        mock_constraint.in_constraint.assert_not_called()
+        mock_constraint.in_star_tracker_hard.assert_called_once_with(
+            10.0, 20.0, 1000.0, target_roll=30.0, acs_mode=ACSMode.PASS
+        )
 
     def test_passtimes_requires_ephemeris(self, mock_config):
         """Test PassTimes requires ephemeris."""

--- a/tests/scheduler_queue/conftest.py
+++ b/tests/scheduler_queue/conftest.py
@@ -11,7 +11,6 @@ from astropy.time import Time  # type: ignore[import-untyped]
 
 from conops import (
     DAY_SECONDS,
-    ACSMode,
     AttitudeConstraintPolicy,
     DumbQueueScheduler,
     QueueDITL,
@@ -85,11 +84,7 @@ def mock_config() -> Mock:
     config.constraint.in_telescope_hard = Mock(return_value=False)
     config.constraint.in_eclipse = Mock(return_value=False)
     config.attitude_constraint_policy_for_mode = Mock(
-        side_effect=lambda mode: (
-            AttitudeConstraintPolicy.FULL_MISSION
-            if ACSMode(int(mode)) in (ACSMode.SCIENCE, ACSMode.CHARGING)
-            else AttitudeConstraintPolicy.HARD_KEEPOUT
-        )
+        return_value=AttitudeConstraintPolicy.FULL_MISSION
     )
     config.constraint.instantaneous_field_of_regard = Mock(return_value=1.234)
 
@@ -120,6 +115,23 @@ def mock_config() -> Mock:
     config.spacecraft_bus.attitude_control.slew_time = Mock(
         return_value=100.0
     )  # Return slew time in seconds
+    config.spacecraft_bus.attitude_control.motion_time = Mock(
+        side_effect=lambda distance: float(
+            config.spacecraft_bus.attitude_control.slew_time(distance)
+        )
+    )
+    config.spacecraft_bus.attitude_control.s_of_t = Mock(
+        side_effect=lambda distance, tau: (
+            0.0
+            if config.spacecraft_bus.attitude_control.motion_time(distance) <= 0
+            else float(distance)
+            * min(
+                1.0,
+                float(tau)
+                / config.spacecraft_bus.attitude_control.motion_time(distance),
+            )
+        )
+    )
 
     # Mock payload
     config.payload = Mock()

--- a/tests/scheduler_queue/conftest.py
+++ b/tests/scheduler_queue/conftest.py
@@ -168,6 +168,7 @@ def queue_ditl(mock_config: Mock, mock_ephem: DummyEphemeris) -> QueueDITL:
         mock_pt = Mock()
         mock_pt.passes = []
         mock_pt.dropped_overlapping_passes = []
+        mock_pt.dropped_constraint_passes = []
         mock_pt.get = Mock()
         mock_pt.check_pass_timing = Mock(
             return_value={"start_pass": None, "end_pass": False, "updated_pass": None}
@@ -603,6 +604,7 @@ def queue_ditl_no_queue_log(
         # Mock PassTimes
         mock_pt = Mock()
         mock_pt.passes = []
+        mock_pt.dropped_constraint_passes = []
         mock_pt.get = Mock()
         mock_pt.check_pass_timing = Mock(
             return_value={"start_pass": None, "end_pass": False, "updated_pass": None}
@@ -681,6 +683,7 @@ def queue_ditl_acs_no_ephem(
         # Mock PassTimes
         mock_pt = Mock()
         mock_pt.passes = []
+        mock_pt.dropped_constraint_passes = []
         mock_pt.get = Mock()
         mock_pt.check_pass_timing = Mock(
             return_value={"start_pass": None, "end_pass": False, "updated_pass": None}

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -217,6 +217,28 @@ class TestScheduleGroundstationPasses:
         assert "Skipped overlapping pass opportunity: Dropped pass" in log_text
         assert "overlaps selected pass Selected pass" in log_text
 
+    def test_schedule_passes_logs_constraint_drops_when_no_pass_survives(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.acs.passrequests.passes = []
+
+        dropped = Mock()
+        dropped.__str__ = Mock(return_value="Constraint dropped pass")
+
+        def populate_drops(year: int, day: int, length: int) -> None:
+            queue_ditl.acs.passrequests.passes = []
+            queue_ditl.acs.passrequests.dropped_constraint_passes = [dropped]
+
+        cast(Mock, queue_ditl.acs.passrequests.get).side_effect = populate_drops
+        queue_ditl._schedule_groundstation_passes()
+
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert (
+            "Skipped constraint-unsafe pass opportunity: Constraint dropped pass"
+            in log_text
+        )
+        assert "No groundstation passes scheduled" in log_text
+
 
 class TestDetermineMode:
     """Test mode determination now handled by ACS.get_mode() - these tests use real ACS instance."""

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -1726,6 +1726,45 @@ class TestFetchNewPPT:
         assert queue_ditl.ppt is mock_ppt
         cast(Mock, queue_ditl.acs.enqueue_command).assert_called_once()
 
+    def test_fetch_ppt_rejects_constraint_unsafe_slew_path(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Target slews are rejected when the transient slew attitude is unsafe."""
+        queue_ditl.ephem.step_size = 60
+        queue_ditl.ephem.timestamp = [
+            datetime.fromtimestamp(1000.0 + 60.0 * index, timezone.utc)
+            for index in range(3)
+        ]
+
+        mock_ppt = Mock()
+        mock_ppt.ra = 45.0
+        mock_ppt.dec = 30.0
+        mock_ppt.obsid = 1003
+        mock_ppt.next_vis = Mock(return_value=1000.0)
+        mock_ppt.ss_max = 3600.0
+        mock_ppt.ss_min = 300.0
+        mock_ppt.windows = [[0.0, 1e12]]
+        queue_ditl.queue.targets = [mock_ppt]
+        cast(Mock, queue_ditl.queue).get = Mock(return_value=mock_ppt)
+        cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
+        cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(return_value=None)
+        queue_ditl.config.spacecraft_bus.attitude_control.slew_time = Mock(
+            return_value=120.0
+        )
+        queue_ditl.constraint.in_constraint = Mock(
+            side_effect=lambda ra, dec, utime, **kwargs: utime == 1060.0
+        )
+        queue_ditl.constraint.in_earth = Mock(
+            side_effect=lambda ra, dec, utime, **kwargs: utime == 1060.0
+        )
+
+        queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
+
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
+        assert queue_ditl.ppt is None
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "slew path violates Earth Limb" in log_text
+
 
 class TestRecordSpacecraftState:
     """Test _record_spacecraft_state helper method."""
@@ -2157,7 +2196,7 @@ class TestPlanExecutionValidation:
             40.0, 10.0, 1060.0, target_roll=5.0, acs_mode=ACSMode.CHARGING
         )
 
-    def test_validation_uses_hard_constraints_only_for_pass(
+    def test_validation_fails_for_default_full_constraint_policy_for_pass(
         self, queue_ditl: QueueDITL
     ) -> None:
         entry = PlanEntry(config=queue_ditl.config)
@@ -2188,10 +2227,15 @@ class TestPlanExecutionValidation:
         queue_ditl.dec = [20.0, 21.0]
         queue_ditl.roll = [0.0, 10.0]
         queue_ditl.constraint.in_constraint = Mock(return_value=True)
+        queue_ditl.constraint.in_sun = Mock(return_value=True)
         self._index_telemetry_by_time(queue_ditl)
 
-        assert queue_ditl.validate_plan_matches_execution() == []
-        queue_ditl.constraint.in_constraint.assert_not_called()
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any("mode PASS" in str(m) for m in mismatches)
+        assert any("Sun" in str(m) for m in mismatches)
+        assert any("full_mission" in str(m) for m in mismatches)
+        assert queue_ditl.constraint.in_constraint.call_count == 2
 
     def test_validation_uses_configured_full_constraint_policy_for_pass(
         self, queue_ditl: QueueDITL
@@ -2267,6 +2311,9 @@ class TestPlanExecutionValidation:
         queue_ditl.ra = [10.0]
         queue_ditl.dec = [20.0]
         queue_ditl.roll = [15.0]
+        queue_ditl.config.attitude_constraint_policy_for_mode = Mock(
+            return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+        )
         queue_ditl.constraint.in_star_tracker_hard = Mock(return_value=True)
         self._index_telemetry_by_time(queue_ditl)
 
@@ -2320,7 +2367,7 @@ class TestPlanExecutionValidation:
     @pytest.mark.parametrize(
         "mode", [ACSMode.SLEWING, ACSMode.SAA, ACSMode.SAFE, ACSMode.IDLE]
     )
-    def test_validation_fails_for_hard_constraint_violation_in_non_activity_modes(
+    def test_validation_fails_for_default_full_violation_in_non_activity_modes(
         self, queue_ditl: QueueDITL, mode: ACSMode
     ) -> None:
         queue_ditl.utime = [1000.0]
@@ -2329,6 +2376,32 @@ class TestPlanExecutionValidation:
         queue_ditl.ra = [10.0]
         queue_ditl.dec = [20.0]
         queue_ditl.roll = [30.0]
+        queue_ditl.constraint.in_constraint = Mock(return_value=True)
+        queue_ditl.constraint.in_earth = Mock(return_value=True)
+        self._index_telemetry_by_time(queue_ditl)
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any(f"mode {mode.name}" in str(m) for m in mismatches)
+        assert any("Earth" in str(m) for m in mismatches)
+        assert any("full_mission" in str(m) for m in mismatches)
+
+    @pytest.mark.parametrize(
+        "mode", [ACSMode.SLEWING, ACSMode.SAA, ACSMode.SAFE, ACSMode.IDLE]
+    )
+    def test_validation_respects_configured_hard_policy_in_non_activity_modes(
+        self, queue_ditl: QueueDITL, mode: ACSMode
+    ) -> None:
+        queue_ditl.utime = [1000.0]
+        queue_ditl.mode = [mode]
+        queue_ditl.obsid = [IDLE_OBSID]
+        queue_ditl.ra = [10.0]
+        queue_ditl.dec = [20.0]
+        queue_ditl.roll = [30.0]
+        queue_ditl.config.attitude_constraint_policy_for_mode = Mock(
+            return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+        )
+        queue_ditl.constraint.in_constraint = Mock(return_value=True)
         queue_ditl.constraint.in_radiator_hard = Mock(return_value=True)
         self._index_telemetry_by_time(queue_ditl)
 
@@ -2336,6 +2409,8 @@ class TestPlanExecutionValidation:
 
         assert any(f"mode {mode.name}" in str(m) for m in mismatches)
         assert any("Radiator Hard" in str(m) for m in mismatches)
+        assert any("hard_keepout" in str(m) for m in mismatches)
+        queue_ditl.constraint.in_constraint.assert_not_called()
 
     def test_validation_fails_for_idle_full_constraint_violation(
         self, queue_ditl: QueueDITL
@@ -2899,6 +2974,56 @@ class TestCalcMethod:
         assert plan_entry not in queue_ditl.plan
         assert queue_ditl.ppt is charging_ppt
         queue_ditl.acs.enqueue_command.assert_called_once()
+
+    def test_initiate_charging_rejects_constraint_unsafe_slew_path(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """Unsafe transient charge slews should not interrupt the science target."""
+        queue_ditl.ephem.step_size = 60
+        queue_ditl.ephem.timestamp = [
+            datetime.fromtimestamp(1000.0 + 60.0 * index, timezone.utc)
+            for index in range(3)
+        ]
+        queue_ditl.config.spacecraft_bus.attitude_control.slew_time = Mock(
+            return_value=120.0
+        )
+
+        science_ppt = Mock()
+        science_ppt.end = 5000.0
+        science_ppt.done = False
+        queue_ditl.ppt = science_ppt
+
+        charging_ppt = Mock()
+        charging_ppt.ra = 100.0
+        charging_ppt.dec = 50.0
+        charging_ppt.roll = 0.0
+        charging_ppt.obsid = 999001
+
+        def interrupt_for_charging(utime, ephem, ra, dec, current_ppt):
+            current_ppt.end = utime
+            current_ppt.done = True
+            return charging_ppt
+
+        queue_ditl.emergency_charging.initiate_emergency_charging = Mock(
+            side_effect=interrupt_for_charging
+        )
+        queue_ditl.constraint.in_constraint = Mock(
+            side_effect=lambda ra, dec, utime, **kwargs: utime == 1060.0
+        )
+        queue_ditl.constraint.in_earth = Mock(
+            side_effect=lambda ra, dec, utime, **kwargs: utime == 1060.0
+        )
+
+        queue_ditl._initiate_charging(1000.0, 10.0, 20.0)
+
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
+        assert queue_ditl.charging_ppt is None
+        assert queue_ditl.ppt is science_ppt
+        assert science_ppt.end == 5000.0
+        assert science_ppt.done is False
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Skipping emergency charge slew" in log_text
+        assert "Earth Limb" in log_text
 
     def test_calc_drops_short_science_entry_when_charging_interrupts(
         self, queue_ditl
@@ -3879,6 +4004,50 @@ class TestCheckAndManagePasses:
         assert command.slew.endra == pass_obj.gsstartra
         assert command.slew.enddec == pass_obj.gsstartdec
         assert command.slew.obsid == pass_obj.obsid
+
+    def test_check_and_manage_passes_rejects_constraint_unsafe_slew_path(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """GSP slew reservations are rejected when the slew path is unsafe."""
+        utime = 1000.0
+        ra, dec, roll = 10.0, 20.0, 42.0
+        queue_ditl.ephem.step_size = 60
+        queue_ditl.ephem.timestamp = [
+            datetime.fromtimestamp(utime + 60.0 * index, timezone.utc)
+            for index in range(3)
+        ]
+        queue_ditl.config.spacecraft_bus.attitude_control.slew_time = Mock(
+            return_value=120.0
+        )
+
+        pass_obj = Pass(
+            station="GS_TEST",
+            begin=1200.0,
+            length=600.0,
+            gsstartra=100.0,
+            gsstartdec=50.0,
+            gsstartroll=37.0,
+            obsid=4242,
+        )
+
+        queue_ditl.acs.passrequests.current_pass = Mock(return_value=None)
+        queue_ditl.acs.passrequests.next_pass = Mock(return_value=pass_obj)
+        queue_ditl.acs.acsmode = ACSMode.SCIENCE
+        queue_ditl.constraint.in_constraint = Mock(
+            side_effect=lambda ra, dec, utime, **kwargs: utime == 1060.0
+        )
+        queue_ditl.constraint.in_earth = Mock(
+            side_effect=lambda ra, dec, utime, **kwargs: utime == 1060.0
+        )
+
+        with patch.object(Pass, "time_to_slew", return_value=True):
+            assert not queue_ditl._check_and_manage_passes(utime, ra, dec, roll)
+
+        queue_ditl.acs.enqueue_command.assert_not_called()
+        assert len(queue_ditl.plan) == 0
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "Skipping pass slew to GS_TEST" in log_text
+        assert "Earth Limb" in log_text
 
     def test_check_and_manage_passes_exports_gsp_plan_entry_for_pass_slew(
         self, queue_ditl, tmp_path

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -2905,13 +2905,13 @@ class TestCalcMethod:
         mock_charging.copy.return_value.begin = 1543622400
         mock_charging.copy.return_value.end = 1543622400 + 86400
         queue_ditl.emergency_charging.should_initiate_charging = Mock(return_value=True)
-        queue_ditl.emergency_charging.initiate_emergency_charging = Mock(
+        queue_ditl.emergency_charging.create_charging_pointing = Mock(
             return_value=mock_charging
         )
         queue_ditl.acs.enqueue_command = Mock()
         result = queue_ditl.calc()
         assert result is True
-        assert queue_ditl.emergency_charging.initiate_emergency_charging.called
+        assert queue_ditl.emergency_charging.create_charging_pointing.called
 
     def test_calc_handles_emergency_charging_enqueue_command_and_type(
         self, queue_ditl
@@ -2932,7 +2932,7 @@ class TestCalcMethod:
         mock_charging.copy.return_value.begin = 1543622400
         mock_charging.copy.return_value.end = 1543622400 + 86400
         queue_ditl.emergency_charging.should_initiate_charging = Mock(return_value=True)
-        queue_ditl.emergency_charging.initiate_emergency_charging = Mock(
+        queue_ditl.emergency_charging.create_charging_pointing = Mock(
             return_value=mock_charging
         )
         queue_ditl.acs.enqueue_command = Mock()
@@ -2978,15 +2978,10 @@ class TestCalcMethod:
         charging_ppt.obsid = 999001
         charging_ppt.roll = 0.0
 
-        def interrupt_for_charging(utime, ephem, ra, dec, current_ppt):
-            current_ppt.end = utime
-            current_ppt.done = True
-            return charging_ppt
-
         queue_ditl.ppt = science_ppt
         queue_ditl.plan = [plan_entry]
-        queue_ditl.emergency_charging.initiate_emergency_charging = Mock(
-            side_effect=interrupt_for_charging
+        queue_ditl.emergency_charging.create_charging_pointing = Mock(
+            return_value=charging_ppt
         )
 
         queue_ditl._initiate_charging(1250.0, 10.0, 20.0)
@@ -3021,13 +3016,8 @@ class TestCalcMethod:
         charging_ppt.roll = 0.0
         charging_ppt.obsid = 999001
 
-        def interrupt_for_charging(utime, ephem, ra, dec, current_ppt):
-            current_ppt.end = utime
-            current_ppt.done = True
-            return charging_ppt
-
-        queue_ditl.emergency_charging.initiate_emergency_charging = Mock(
-            side_effect=interrupt_for_charging
+        queue_ditl.emergency_charging.create_charging_pointing = Mock(
+            return_value=charging_ppt
         )
         queue_ditl.constraint.in_constraint = Mock(
             side_effect=lambda ra, dec, utime, **kwargs: utime == 1060.0
@@ -3098,15 +3088,10 @@ class TestCalcMethod:
         charging_entry.roll = 0.0
         charging_entry.copy = Mock(return_value=charging_entry)
 
-        def interrupt_for_charging(utime, ephem, ra, dec, current_ppt):
-            current_ppt.end = utime
-            current_ppt.done = True
-            return charging_entry
-
         queue_ditl.ppt = science_entry
         queue_ditl.emergency_charging.should_initiate_charging = Mock(return_value=True)
-        queue_ditl.emergency_charging.initiate_emergency_charging = Mock(
-            side_effect=interrupt_for_charging
+        queue_ditl.emergency_charging.create_charging_pointing = Mock(
+            return_value=charging_entry
         )
 
         assert queue_ditl.calc() is True

--- a/tests/star_tracker/test_star_tracker.py
+++ b/tests/star_tracker/test_star_tracker.py
@@ -381,6 +381,7 @@ class TestStarTrackerComputedConstraint:
         assert c.type == "or"
         assert len(c.constraints) == 2
         assert all(child.type == "boresight_offset" for child in c.constraints)
+        assert all(child.roll_clockwise for child in c.constraints)
 
     def test_startracker_hard_constraint_min_functional_does_not_affect_hard(self):
         """min_functional_trackers has no effect on hard constraints — they are always OR."""
@@ -432,6 +433,7 @@ class TestStarTrackerComputedConstraint:
         assert c.constraints[0].roll_deg == pytest.approx(0.0)
         assert c.constraints[0].pitch_deg == pytest.approx(0.0)
         assert c.constraints[0].yaw_deg == pytest.approx(90.0)
+        assert c.constraints[0].roll_clockwise is True
 
     def test_startracker_constraint_multiple_soft_constraints_at_least_combined(self):
         from conops.config import Constraint, StarTrackerConfiguration
@@ -458,6 +460,7 @@ class TestStarTrackerComputedConstraint:
         assert c.min_violated == 2
         assert len(c.constraints) == 2
         assert all(child.type == "boresight_offset" for child in c.constraints)
+        assert all(child.roll_clockwise for child in c.constraints)
 
     def test_startracker_constraint_respects_min_functional_trackers_threshold(self):
         from conops.config import Constraint, StarTrackerConfiguration
@@ -486,6 +489,74 @@ class TestStarTrackerComputedConstraint:
         assert c.type == "at_least"
         assert c.min_violated == 1
         assert len(c.constraints) == 2
+
+    def test_combined_soft_constraint_matches_trackers_at_nonzero_roll(self):
+        """Combined planning constraint must match per-tracker telemetry checks."""
+        from datetime import datetime
+        from pathlib import Path
+
+        tle_path = Path(__file__).parents[2] / "examples" / "example.tle"
+        if not tle_path.exists():
+            pytest.skip("example.tle not available")
+
+        ephem = rust_ephem.TLEEphemeris(
+            begin=datetime(2025, 12, 1, 0, 0, 0),
+            end=datetime(2025, 12, 1, 1, 0, 0),
+            step_size=60,
+            tle=str(tle_path),
+        )
+        soft_constraint = Constraint(
+            sun_constraint=rust_ephem.SunConstraint(min_angle=22.0),
+            earth_constraint=rust_ephem.EarthLimbConstraint(min_angle=10.0),
+        )
+        cfg = StarTrackerConfiguration(
+            star_trackers=[
+                StarTracker(
+                    name="STR_pY",
+                    orientation=StarTrackerOrientation(
+                        boresight=(2**-0.5, 2**-0.5, 0.0)
+                    ),
+                    soft_constraint=soft_constraint,
+                ),
+                StarTracker(
+                    name="STR_nY",
+                    orientation=StarTrackerOrientation(
+                        boresight=(2**-0.5, -(2**-0.5), 0.0)
+                    ),
+                    soft_constraint=soft_constraint,
+                ),
+            ],
+            min_functional_trackers=2,
+            modes_require_lock=[0],
+        )
+        for tracker in cfg.star_trackers:
+            tracker.set_ephem(ephem)
+
+        combined = cfg.startracker_constraint
+        assert combined is not None
+        sample_time = ephem.timestamp[0]
+        sample_utime = sample_time.timestamp()
+        cases = [
+            (0.0, -60.0, -30.0),
+            (0.0, -60.0, 30.0),
+            (0.0, -45.0, -150.0),
+            (0.0, -45.0, 150.0),
+        ]
+
+        for ra, dec, roll in cases:
+            per_tracker_violations = sum(
+                tracker.in_soft_constraint(ra, dec, sample_utime, roll)
+                for tracker in cfg.star_trackers
+            )
+            expected = per_tracker_violations >= 1
+            actual = combined.in_constraint(
+                ephemeris=ephem,
+                target_ra=ra,
+                target_dec=dec,
+                time=sample_time,
+                target_roll=roll,
+            )
+            assert bool(actual) is expected
 
     def test_startracker_constraint_none_when_threshold_unreachable_from_soft_only(
         self,


### PR DESCRIPTION
## Summary
- Default ACS modes to the full-mission attitude constraint policy unless a mode opts into a narrower policy.
- Filter ground-station pass profiles against PASS attitude constraints before scheduling.
- Preflight science, charge, and ground-station slew paths against the relevant ACS-mode constraints at ephemeris-grid samples.
- Align combined star-tracker planning constraints with the per-tracker telemetry roll convention so planning and executed telemetry evaluate the same STR body vectors.
- Log constraint-dropped ground-station pass opportunities even when no passes survive filtering.
- Add tests covering mode policy defaults, pass filtering, slew rejection paths, and nonzero-roll STR planning/telemetry consistency.

## Validation
- `PYTHONPATH=. coastvenv/bin/python -m pytest tests/star_tracker tests/constraint` -> 167 passed.
- `PYTHONPATH=. coastvenv/bin/python -m pytest tests/scheduler_queue tests/passes` -> 390 passed.
- `PATH=coastvenv/bin:$PATH pre-commit run --files conops/config/star_tracker.py tests/star_tracker/test_star_tracker.py` -> passed.
- `PATH=coastvenv/bin:$PATH pre-commit run --files conops/ditl/queue_ditl.py tests/scheduler_queue/test_queue_ditl.py` -> passed.
- End-to-end tam-config plan generation completed in about 11 seconds on the current branches.
- Regenerated visualizer telemetry reports 0 `in_constraint` samples, 0 STR hard samples, 0 STR soft samples, and 0 samples with fewer than 2 functional star trackers.

## Notes
This is paired with tamalpais-configuration PR #21, which sets all configured ACS modes to full-mission constraints and regenerates the plan. The safety check is sampled on COAST's existing ephemeris grid; it is not a continuous between-sample proof.
