### PR TITLE
feat: Plan constraint-safe ground station roll phases

### DIFF
--- a/conops/config/acs.py
+++ b/conops/config/acs.py
@@ -51,6 +51,15 @@ class AttitudeControlSystem(ConfigModel):
             "avoidance during slews, or relaxed Sun angle limits for quick transits)."
         ),
     )
+    gsp_tracking_phase_step_deg: float = Field(
+        default=5.0,
+        gt=0.0,
+        le=180.0,
+        description=(
+            "Ground-station-pass roll phase search increment in degrees. "
+            "Smaller values search more candidate tracking attitudes at higher CPU cost."
+        ),
+    )
 
     def motion_time(self, angle_deg: float) -> float:
         """Time to complete the motion (excluding settle) under bang-bang control."""

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -613,12 +613,12 @@ class PassTimes:
             attitude_profile.append(attitude)
         return attitude_profile
 
-    def _constraint_safe_tracking_attitude_profile(
+    def _fixed_phase_tracking_attitude_profile(
         self,
         antenna_boresight: tuple[float, float, float],
         target_vectors: np.ndarray,
         track_utime: list[float],
-    ) -> tuple[list[tuple[float, float, float]], bool] | None:
+    ) -> tuple[list[tuple[float, float, float]] | None, bool]:
         fallback_profile: list[tuple[float, float, float]] | None = None
         for phase_deg in self._gsp_tracking_phase_candidates():
             attitude_profile = self._tracking_attitude_profile_for_phase(
@@ -635,6 +635,132 @@ class PassTimes:
                 track_utime, track_ra, track_dec, track_roll
             ):
                 return attitude_profile, True
+
+        return fallback_profile, False
+
+    def _safe_tracking_attitudes_by_sample(
+        self,
+        antenna_boresight: tuple[float, float, float],
+        target_vectors: np.ndarray,
+        track_utime: list[float],
+    ) -> list[dict[float, tuple[float, float, float]]] | None:
+        safe_attitudes: list[dict[float, tuple[float, float, float]]] = []
+        for target_vector, utime in zip(target_vectors, track_utime, strict=True):
+            sample_attitudes: dict[float, tuple[float, float, float]] = {}
+            for phase_deg in self._gsp_tracking_phase_candidates():
+                attitude_profile = self._tracking_attitude_profile_for_phase(
+                    antenna_boresight,
+                    np.array([target_vector], dtype=float),
+                    phase_deg,
+                )
+                if attitude_profile is None:
+                    continue
+                attitude = attitude_profile[0]
+                if not self._pass_attitude_violates_policy(*attitude, utime):
+                    sample_attitudes[phase_deg] = attitude
+            if not sample_attitudes:
+                return None
+            safe_attitudes.append(sample_attitudes)
+        return safe_attitudes
+
+    def _step_motion_feasible(
+        self,
+        previous_attitude: tuple[float, float, float],
+        attitude: tuple[float, float, float],
+        dt: float,
+    ) -> bool:
+        if dt <= 0.0:
+            return False
+        attitude_distance = quaternion_attitude_distance(
+            *previous_attitude,
+            *attitude,
+        )
+        acs = self.config.spacecraft_bus.attitude_control
+        return bool(acs.motion_time(attitude_distance) <= dt)
+
+    def _dynamic_phase_tracking_attitude_profile(
+        self,
+        safe_attitudes: list[dict[float, tuple[float, float, float]]],
+        track_utime: list[float],
+    ) -> list[tuple[float, float, float]] | None:
+        phase_rank = {
+            phase: index
+            for index, phase in enumerate(self._gsp_tracking_phase_candidates())
+        }
+        paths: dict[float, tuple[float, float, list[float]]] = {
+            phase: (0.0, 0.0, [phase]) for phase in safe_attitudes[0]
+        }
+
+        for sample_index in range(1, len(safe_attitudes)):
+            dt = float(track_utime[sample_index] - track_utime[sample_index - 1])
+            next_paths: dict[float, tuple[float, float, list[float]]] = {}
+            for phase, attitude in safe_attitudes[sample_index].items():
+                best: tuple[float, float, list[float]] | None = None
+                for previous_phase, (
+                    previous_max_step,
+                    previous_total_step,
+                    previous_path,
+                ) in paths.items():
+                    previous_attitude = safe_attitudes[sample_index - 1][previous_phase]
+                    if not self._step_motion_feasible(previous_attitude, attitude, dt):
+                        continue
+                    step_distance = quaternion_attitude_distance(
+                        *previous_attitude,
+                        *attitude,
+                    )
+                    candidate = (
+                        max(previous_max_step, step_distance),
+                        previous_total_step + step_distance,
+                        previous_path + [phase],
+                    )
+                    if best is None or (candidate[0], candidate[1]) < (
+                        best[0],
+                        best[1],
+                    ):
+                        best = candidate
+                if best is not None:
+                    next_paths[phase] = best
+            paths = next_paths
+            if not paths:
+                return None
+
+        _, (_, _, phase_path) = min(
+            paths.items(),
+            key=lambda item: (
+                item[1][0],
+                item[1][1],
+                [phase_rank[phase] for phase in item[1][2]],
+            ),
+        )
+        return [
+            safe_attitudes[sample_index][phase]
+            for sample_index, phase in enumerate(phase_path)
+        ]
+
+    def _constraint_safe_tracking_attitude_profile(
+        self,
+        antenna_boresight: tuple[float, float, float],
+        target_vectors: np.ndarray,
+        track_utime: list[float],
+    ) -> tuple[list[tuple[float, float, float]], bool] | None:
+        fallback_profile, fixed_phase_safe = (
+            self._fixed_phase_tracking_attitude_profile(
+                antenna_boresight, target_vectors, track_utime
+            )
+        )
+        if fixed_phase_safe:
+            assert fallback_profile is not None
+            return fallback_profile, True
+
+        safe_attitudes = self._safe_tracking_attitudes_by_sample(
+            antenna_boresight, target_vectors, track_utime
+        )
+        if safe_attitudes is not None:
+            dynamic_profile = self._dynamic_phase_tracking_attitude_profile(
+                safe_attitudes, track_utime
+            )
+            if dynamic_profile is not None:
+                return dynamic_profile, True
 
         if fallback_profile is None:
             return None

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -29,6 +29,7 @@ from .slew import Slew
 # Legacy ground-pass roll for profiles without explicit roll samples.
 GSP_TRACK_ROLL = 0.0
 LEGACY_GSP_ANTENNA_BODY_VECTOR = (-1.0, 0.0, 0.0)
+GSP_TRACK_PHASE_STEP_DEG = 5.0
 
 
 def pass_slew_trigger_buffer(step_size: float) -> float:
@@ -41,6 +42,50 @@ def _config_random_seed(config: MissionConfig) -> int | None:
     if seed is None or isinstance(seed, bool) or not isinstance(seed, Integral):
         return None
     return int(seed)
+
+
+def _unit_vector_or_none(vector: np.ndarray) -> np.ndarray | None:
+    norm = float(np.linalg.norm(vector))
+    if norm < 1e-12:
+        return None
+    return vector / norm
+
+
+def _perpendicular_reference(axis: np.ndarray) -> np.ndarray | None:
+    for candidate in (
+        np.array([0.0, 0.0, 1.0], dtype=float),
+        np.array([1.0, 0.0, 0.0], dtype=float),
+        np.array([0.0, 1.0, 0.0], dtype=float),
+    ):
+        projected = candidate - float(np.dot(candidate, axis)) * axis
+        reference = _unit_vector_or_none(projected)
+        if reference is not None:
+            return reference
+    return None
+
+
+def _rotate_about_axis(
+    vector: np.ndarray, axis: np.ndarray, angle_deg: float
+) -> np.ndarray:
+    angle_rad = np.deg2rad(angle_deg)
+    rotated = (
+        vector * np.cos(angle_rad)
+        + np.cross(axis, vector) * np.sin(angle_rad)
+        + axis * float(np.dot(axis, vector)) * (1.0 - np.cos(angle_rad))
+    )
+    return np.asarray(rotated, dtype=float)
+
+
+def _tracking_phase_reference_eci(
+    target_vector: np.ndarray, phase_deg: float
+) -> np.ndarray | None:
+    target_axis = _unit_vector_or_none(np.asarray(target_vector, dtype=float))
+    if target_axis is None:
+        return None
+    reference = _perpendicular_reference(target_axis)
+    if reference is None:
+        return None
+    return _rotate_about_axis(reference, target_axis, phase_deg)
 
 
 class RandomSource(Protocol):
@@ -537,6 +582,64 @@ class PassTimes:
             )
         )
 
+    def _gsp_tracking_phase_candidates(self) -> list[float]:
+        candidates = [0.0]
+        offset = GSP_TRACK_PHASE_STEP_DEG
+        while offset <= 180.0:
+            candidates.append(float(offset))
+            if offset < 180.0:
+                candidates.append(float(360.0 - offset))
+            offset += GSP_TRACK_PHASE_STEP_DEG
+        return candidates
+
+    def _tracking_attitude_profile_for_phase(
+        self,
+        antenna_boresight: tuple[float, float, float],
+        target_vectors: np.ndarray,
+        phase_deg: float,
+    ) -> list[tuple[float, float, float]] | None:
+        attitude_profile: list[tuple[float, float, float]] = []
+        for target_vector in target_vectors:
+            reference_eci = _tracking_phase_reference_eci(target_vector, phase_deg)
+            if reference_eci is None:
+                return None
+            attitude = attitude_for_body_vector_tracking(
+                antenna_boresight,
+                target_vector,
+                reference_eci=reference_eci,
+            )
+            if attitude is None:
+                return None
+            attitude_profile.append(attitude)
+        return attitude_profile
+
+    def _constraint_safe_tracking_attitude_profile(
+        self,
+        antenna_boresight: tuple[float, float, float],
+        target_vectors: np.ndarray,
+        track_utime: list[float],
+    ) -> tuple[list[tuple[float, float, float]], bool] | None:
+        fallback_profile: list[tuple[float, float, float]] | None = None
+        for phase_deg in self._gsp_tracking_phase_candidates():
+            attitude_profile = self._tracking_attitude_profile_for_phase(
+                antenna_boresight, target_vectors, phase_deg
+            )
+            if attitude_profile is None:
+                continue
+            if fallback_profile is None:
+                fallback_profile = attitude_profile
+            track_ra = [attitude[0] for attitude in attitude_profile]
+            track_dec = [attitude[1] for attitude in attitude_profile]
+            track_roll = [attitude[2] for attitude in attitude_profile]
+            if not self._pass_profile_violates_policy(
+                track_utime, track_ra, track_dec, track_roll
+            ):
+                return attitude_profile, True
+
+        if fallback_profile is None:
+            return None
+        return fallback_profile, False
+
     def _deconflict_overlapping_passes(self) -> None:
         selected: list[Pass] = []
         self.dropped_overlapping_passes = []
@@ -667,27 +770,23 @@ class PassTimes:
                         # Schedule this pass if the dice roll allows it
                         target_vectors = -gs_to_sat_unit[start_idx:end_idx]
                         target_ra, target_dec = np.degrees(vec2radec(target_vectors.T))
-                        antenna_boresight = self._gsp_antenna_boresight_body()
-                        if antenna_boresight is None:
-                            continue
-                        attitude_profile: list[tuple[float, float, float]] = []
-                        profile_valid = True
-                        for target_vector in target_vectors:
-                            attitude = attitude_for_body_vector_tracking(
-                                antenna_boresight, target_vector
-                            )
-                            if attitude is None:
-                                profile_valid = False
-                                break
-                            attitude_profile.append(attitude)
-                        if not profile_valid or not attitude_profile:
-                            continue
-                        track_ra = [attitude[0] for attitude in attitude_profile]
-                        track_dec = [attitude[1] for attitude in attitude_profile]
-                        track_roll = [attitude[2] for attitude in attitude_profile]
                         track_utime = timestamp_unix[
                             startindex + start_idx : startindex + end_idx
                         ].tolist()
+                        antenna_boresight = self._gsp_antenna_boresight_body()
+                        if antenna_boresight is None:
+                            continue
+                        profile_result = (
+                            self._constraint_safe_tracking_attitude_profile(
+                                antenna_boresight, target_vectors, track_utime
+                            )
+                        )
+                        if profile_result is None:
+                            continue
+                        attitude_profile, profile_safe = profile_result
+                        track_ra = [attitude[0] for attitude in attitude_profile]
+                        track_dec = [attitude[1] for attitude in attitude_profile]
+                        track_roll = [attitude[2] for attitude in attitude_profile]
 
                         gspass = Pass(
                             config=self.config,
@@ -712,9 +811,7 @@ class PassTimes:
                         gspass.station_ra = target_ra.tolist()
                         gspass.station_dec = target_dec.tolist()
 
-                        if self._pass_profile_violates_policy(
-                            track_utime, track_ra, track_dec, track_roll
-                        ):
+                        if not profile_safe:
                             self.dropped_constraint_passes.append(gspass)
                             continue
 

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -29,7 +29,6 @@ from .slew import Slew
 # Legacy ground-pass roll for profiles without explicit roll samples.
 GSP_TRACK_ROLL = 0.0
 LEGACY_GSP_ANTENNA_BODY_VECTOR = (-1.0, 0.0, 0.0)
-GSP_TRACK_PHASE_STEP_DEG = 5.0
 
 
 def pass_slew_trigger_buffer(step_size: float) -> float:
@@ -584,12 +583,15 @@ class PassTimes:
 
     def _gsp_tracking_phase_candidates(self) -> list[float]:
         candidates = [0.0]
-        offset = GSP_TRACK_PHASE_STEP_DEG
+        phase_step_deg = (
+            self.config.spacecraft_bus.attitude_control.gsp_tracking_phase_step_deg
+        )
+        offset = phase_step_deg
         while offset <= 180.0:
             candidates.append(float(offset))
             if offset < 180.0:
                 candidates.append(float(360.0 - offset))
-            offset += GSP_TRACK_PHASE_STEP_DEG
+            offset += phase_step_deg
         return candidates
 
     def _tracking_attitude_profile_for_phase(

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -21,6 +21,7 @@ from conops import (
     SpacecraftBus,
 )
 from conops.config import (
+    AttitudeControlSystem,
     DataGeneration,
     PowerDraw,
     StarTracker,
@@ -95,6 +96,19 @@ class TestConfig:
             config.attitude_constraint_policy_for_mode(ACSMode.SCIENCE)
             == AttitudeConstraintPolicy.FULL_MISSION
         )
+
+    def test_acs_gsp_tracking_phase_step_is_configurable(self) -> None:
+        """Test ground-station roll search granularity is an ACS config setting."""
+        acs = AttitudeControlSystem(gsp_tracking_phase_step_deg=10.0)
+
+        assert acs.gsp_tracking_phase_step_deg == 10.0
+
+    def test_acs_gsp_tracking_phase_step_rejects_invalid_values(self) -> None:
+        """Test ground-station roll search granularity must be positive."""
+        import pytest
+
+        with pytest.raises(ValueError):
+            AttitudeControlSystem(gsp_tracking_phase_step_deg=0.0)
 
     def test_config_default_name(self) -> None:
         """Test that Config uses default name."""

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -578,6 +578,15 @@ class TestPassTimes:
 
         assert pt._gsp_antenna_boresight_body() is None
 
+    def test_gsp_tracking_phase_candidates_use_acs_config(
+        self, mock_constraint, mock_config
+    ):
+        """GSP roll phase search granularity comes from ACS configuration."""
+        mock_config.spacecraft_bus.attitude_control.gsp_tracking_phase_step_deg = 90.0
+        pt = PassTimes(config=mock_config)
+
+        assert pt._gsp_tracking_phase_candidates() == [0.0, 90.0, 270.0, 180.0]
+
     def test_get_skips_stations_not_scheduled_for_tracking(
         self, mock_constraint, mock_config
     ):

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -680,6 +680,77 @@ class TestPassTimes:
         assert profile_safe is True
         assert profile[0][1] < -1.0
 
+    def test_constraint_safe_tracking_profile_uses_dynamic_phase_path(
+        self, mock_constraint, mock_config
+    ):
+        """GSP roll can move between safe phases when no fixed phase is safe."""
+        mock_config.spacecraft_bus.attitude_control = AttitudeControlSystem(
+            max_slew_rate=5.0,
+            slew_acceleration=5.0,
+            settle_time=0.0,
+        )
+        pt = PassTimes(config=mock_config)
+        pt._gsp_tracking_phase_candidates = Mock(return_value=[0.0, 90.0])
+        pt._tracking_attitude_profile_for_phase = Mock(
+            side_effect=lambda antenna, targets, phase_deg: [
+                (phase_deg, 0.0, phase_deg) for _target in targets
+            ]
+        )
+        mock_constraint.in_constraint = Mock(
+            side_effect=lambda ra, dec, utime, **kwargs: (
+                not (
+                    (utime == 1000.0 and kwargs["target_roll"] == 0.0)
+                    or (utime == 1060.0 and kwargs["target_roll"] == 90.0)
+                )
+            )
+        )
+
+        result = pt._constraint_safe_tracking_attitude_profile(
+            antenna_boresight=(0.0, 1.0, 0.0),
+            target_vectors=np.array([[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]], dtype=float),
+            track_utime=[1000.0, 1060.0],
+        )
+
+        assert result is not None
+        profile, profile_safe = result
+        assert profile_safe is True
+        assert [attitude[2] for attitude in profile] == [0.0, 90.0]
+
+    def test_constraint_safe_tracking_profile_rejects_infeasible_dynamic_phase_path(
+        self, mock_constraint, mock_config
+    ):
+        """A moving GSP roll path must fit within ACS motion limits."""
+        mock_config.spacecraft_bus.attitude_control = AttitudeControlSystem(
+            max_slew_rate=0.1,
+            slew_acceleration=0.1,
+            settle_time=0.0,
+        )
+        pt = PassTimes(config=mock_config)
+        pt._gsp_tracking_phase_candidates = Mock(return_value=[0.0, 180.0])
+        pt._tracking_attitude_profile_for_phase = Mock(
+            side_effect=lambda antenna, targets, phase_deg: [
+                (phase_deg, 0.0, phase_deg) for _target in targets
+            ]
+        )
+        mock_constraint.in_constraint = Mock(
+            side_effect=lambda ra, dec, utime, **kwargs: (
+                not (
+                    (utime == 1000.0 and kwargs["target_roll"] == 0.0)
+                    or (utime == 1060.0 and kwargs["target_roll"] == 180.0)
+                )
+            )
+        )
+
+        result = pt._constraint_safe_tracking_attitude_profile(
+            antenna_boresight=(0.0, 1.0, 0.0),
+            target_vectors=np.array([[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]], dtype=float),
+            track_utime=[1000.0, 1060.0],
+        )
+
+        assert result is not None
+        _profile, profile_safe = result
+        assert profile_safe is False
+
     def test_passtimes_requires_ephemeris(self, mock_config):
         """Test PassTimes requires ephemeris."""
         constraint = Mock(spec=Constraint)

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -12,7 +12,11 @@ from conops import (
     Pass,
     PassTimes,
 )
-from conops.common import attitude_for_body_vector_tracking, radec2vec
+from conops.common import (
+    attitude_for_body_vector_tracking,
+    body_vector_to_eci,
+    radec2vec,
+)
 from conops.common.enums import ACSMode, AntennaType, ObsType, SlewAlgorithm
 from conops.config import (
     AntennaPointing,
@@ -629,6 +633,52 @@ class TestPassTimes:
         mock_constraint.in_star_tracker_hard.assert_called_once_with(
             10.0, 20.0, 1000.0, target_roll=30.0, acs_mode=ACSMode.PASS
         )
+
+    def test_tracking_phase_profile_preserves_antenna_pointing(
+        self, mock_constraint, mock_config
+    ):
+        """Phase sweeps must keep the fixed antenna on the station line of sight."""
+        pt = PassTimes(config=mock_config)
+        antenna = (0.0, 1.0, 0.0)
+        target_vectors = np.array(
+            [
+                [0.0, 1.0, 0.0],
+                [1.0, 1.0, 0.0],
+            ],
+            dtype=float,
+        )
+
+        profile = pt._tracking_attitude_profile_for_phase(
+            antenna, target_vectors, phase_deg=90.0
+        )
+
+        assert profile is not None
+        for attitude, target_vector in zip(profile, target_vectors, strict=True):
+            ra, dec, roll = attitude
+            antenna_vector = body_vector_to_eci(ra, dec, roll, antenna)
+            assert antenna_vector is not None
+            target_unit = target_vector / np.linalg.norm(target_vector)
+            assert np.dot(antenna_vector, target_unit) == pytest.approx(1.0, abs=1e-9)
+
+    def test_constraint_safe_tracking_profile_uses_safe_phase(
+        self, mock_constraint, mock_config
+    ):
+        """Unsafe default GSP phase should be replaced by a safe tracking phase."""
+        pt = PassTimes(config=mock_config)
+        mock_constraint.in_constraint = Mock(
+            side_effect=lambda ra, dec, utime, **kwargs: dec > -1.0
+        )
+
+        result = pt._constraint_safe_tracking_attitude_profile(
+            antenna_boresight=(0.0, 1.0, 0.0),
+            target_vectors=np.array([[0.0, 1.0, 0.0]], dtype=float),
+            track_utime=[1000.0],
+        )
+
+        assert result is not None
+        profile, profile_safe = result
+        assert profile_safe is True
+        assert profile[0][1] < -1.0
 
     def test_passtimes_requires_ephemeris(self, mock_config):
         """Test PassTimes requires ephemeris."""


### PR DESCRIPTION
## Problem

Ground-station passes use a fixed body-frame antenna, so the spacecraft has one remaining attitude degree of freedom while tracking a station: roll about the station line of sight.

Before this PR, GSP attitude generation picked that roll from the default reference-vector convention. That preserved antenna pointing, but it did not search for a constraint-safe roll. With full-mission PASS attitude constraints enabled, a geometrically visible station pass could be dropped even when another roll about the same antenna line of sight would satisfy the attitude policy.

The current Tamalpais case showed this directly: Svalbard had two viable tracking opportunities, but one was rejected because no single default/fixed roll phase stayed constraint-safe for the whole contact.

## Solution

This PR makes GSP tracking roll an explicit planning variable.

- Generate candidate roll phases around the fixed antenna-to-station line of sight.
- Prefer the legacy/default phase first, then nearby phases, so existing behavior is preserved when it is already safe.
- Control the roll phase search granularity with `spacecraft_bus.attitude_control.gsp_tracking_phase_step_deg` (default `5.0` deg), so users can trade CPU cost against search resolution.
- First try to find one fixed phase that is safe for the whole pass.
- If no fixed phase works, fall back to a time-varying phase path across the pass samples.
- Accept a dynamic path only when every sampled attitude satisfies the PASS attitude policy and every adjacent sample-to-sample attitude change fits within ACS `motion_time()`.
- If no safe feasible path exists, keep dropping the pass and retain the default profile for diagnostics.

This keeps antenna pointing intact: phase changes only rotate the spacecraft about the station line of sight.

## Safety Bound

The guarantee is aligned with COAST discrete ephemeris-grid validation model:

- sampled GSP attitudes are checked against the configured PASS attitude policy;
- dynamic roll transitions are checked for ACS motion feasibility between adjacent samples;
- pass slews are still separately preflighted by the existing slew path constraint checks.

This does not claim a continuous-time proof between ephemeris samples. It makes GSP roll planning as safe as the current COAST pass/slew validation framework can verify.

## Validation

- `PYTHONPATH=. MPLCONFIGDIR=/tmp coastvenv/bin/python -m pytest tests/config/test_config.py -k 'gsp_tracking_phase_step'`
- `PYTHONPATH=. MPLCONFIGDIR=/tmp coastvenv/bin/python -m pytest tests/passes/test_passes.py`
- `coastvenv/bin/ruff check conops/config/acs.py conops/simulation/passes.py tests/config/test_config.py tests/passes/test_passes.py`
- `coastvenv/bin/ruff format --check conops/config/acs.py conops/simulation/passes.py tests/config/test_config.py tests/passes/test_passes.py`
- Previous non-exporting Tamalpais DITL: 2 SVAL GSP entries, 0 dropped passrequests, 0 constraint telemetry hits, 0 plan/execution mismatches

## Notes

- Depends on #209 / `feature/full-mission-attitude-constraints`.
- If #209 merges first, retarget this PR to `main`.
