### PR TITLE
fix: log recharge-threshold interruptions as charging

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1566,8 +1566,13 @@ class QueueDITL(DITLMixin, DITLStats):
         if interrupted_ppt is not None and not getattr(interrupted_ppt, "done", False):
             self.log.log_event(
                 utime=utime,
-                event_type="ERROR",
-                description="BATTERY ALERT: Terminating science observation for emergency charging",
+                event_type="CHARGING",
+                description=(
+                    "Battery below recharge threshold; interrupting science observation "
+                    "for charging"
+                ),
+                obsid=getattr(interrupted_ppt, "obsid", None),
+                acs_mode=self.acs.acsmode,
             )
             interrupted_ppt.end = utime
             interrupted_ppt.done = True

--- a/conops/simulation/emergency_charging.py
+++ b/conops/simulation/emergency_charging.py
@@ -86,14 +86,26 @@ class EmergencyCharging:
         self._charging_suppressed_due_to_eclipse = False
         self.log = log
 
-    def _log_or_print(self, utime: float, event_type: str, description: str) -> None:
+    def _log_or_print(
+        self,
+        utime: float,
+        event_type: str,
+        description: str,
+        obsid: int | None = None,
+        acs_mode: ACSMode | None = None,
+    ) -> None:
         """Log event to DITLLog if available, otherwise print."""
         if self.log is not None:
             self.log.log_event(
-                utime=utime, event_type=event_type, description=description
+                utime=utime,
+                event_type=event_type,
+                description=description,
+                obsid=obsid,
+                acs_mode=acs_mode,
             )
         else:
-            print(f"{unixtime2date(utime)} {description}")
+            suffix = f", obsid={obsid}" if obsid is not None else ""
+            print(f"{unixtime2date(utime)} {description}{suffix}")
 
     def create_charging_pointing(
         self,
@@ -190,6 +202,7 @@ class EmergencyCharging:
                 "CHARGING",
                 "Battery below recharge threshold; interrupting science observation "
                 "for charging",
+                obsid=getattr(current_ppt, "obsid", None),
             )
             current_ppt.end = utime
             current_ppt.done = True

--- a/conops/simulation/emergency_charging.py
+++ b/conops/simulation/emergency_charging.py
@@ -187,8 +187,9 @@ class EmergencyCharging:
         if current_ppt is not None and not getattr(current_ppt, "done", False):
             self._log_or_print(
                 utime,
-                "ERROR",
-                "BATTERY ALERT: Terminating science observation for emergency charging",
+                "CHARGING",
+                "Battery below recharge threshold; interrupting science observation "
+                "for charging",
             )
             current_ppt.end = utime
             current_ppt.done = True

--- a/tests/battery/test_battery_recharge.py
+++ b/tests/battery/test_battery_recharge.py
@@ -9,6 +9,7 @@ import pytest
 from conops import (
     ACSMode,
     Battery,
+    DITLLog,
     EmergencyCharging,
     Pointing,
     QueueDITL,
@@ -283,6 +284,38 @@ class TestEmergencyCharging:
             starting_obsid=555000,
         )
         assert ec.current_charging_ppt is None
+
+    def test_recharge_threshold_interrupt_logs_charging_event(
+        self, mock_config, utime
+    ) -> None:
+        log = DITLLog()
+        charging_ppt = Mock(spec=Pointing)
+        current_ppt = Mock(spec=Pointing)
+        current_ppt.done = False
+
+        ec = EmergencyCharging(
+            config=mock_config,
+            starting_obsid=555000,
+            log=log,
+        )
+        ec.create_charging_pointing = Mock(return_value=charging_ppt)
+
+        result = ec.initiate_emergency_charging(
+            utime,
+            ephem=Mock(),
+            lastra=1.0,
+            lastdec=2.0,
+            current_ppt=current_ppt,
+        )
+
+        assert result is charging_ppt
+        assert current_ppt.done is True
+        assert log.events[-1].event_type == "CHARGING"
+        assert (
+            log.events[-1].description
+            == "Battery below recharge threshold; interrupting science observation "
+            "for charging"
+        )
 
     def test_create_charging_pointing_success_returns_pointing(
         self, emergency_charging, mock_ephem, monkeypatch, utime

--- a/tests/battery/test_battery_recharge.py
+++ b/tests/battery/test_battery_recharge.py
@@ -292,6 +292,7 @@ class TestEmergencyCharging:
         charging_ppt = Mock(spec=Pointing)
         current_ppt = Mock(spec=Pointing)
         current_ppt.done = False
+        current_ppt.obsid = 12345
 
         ec = EmergencyCharging(
             config=mock_config,
@@ -316,6 +317,7 @@ class TestEmergencyCharging:
             == "Battery below recharge threshold; interrupting science observation "
             "for charging"
         )
+        assert log.events[-1].obsid == current_ppt.obsid
 
     def test_create_charging_pointing_success_returns_pointing(
         self, emergency_charging, mock_ephem, monkeypatch, utime

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -5474,6 +5474,45 @@ class TestQueueDITLCoverage:
     #     # NOTE: This test was removed due to patching issues with relative imports
     #     # The pass slewing logic is tested indirectly through integration tests
 
+    def test_recharge_threshold_interruption_logs_charging_event(
+        self, queue_ditl
+    ) -> None:
+        charging_ppt = Mock()
+        charging_ppt.ra = 45.0
+        charging_ppt.dec = 23.5
+        charging_ppt.roll = 90.0
+        charging_ppt.obsid = 999000
+
+        interrupted_ppt = Mock()
+        interrupted_ppt.done = False
+        interrupted_ppt.obsid = 12345
+        queue_ditl.ppt = interrupted_ppt
+        queue_ditl.emergency_charging.create_charging_pointing = Mock(
+            return_value=charging_ppt
+        )
+
+        with (
+            patch("conops.ditl.queue_ditl.Slew") as mock_slew_class,
+            patch.object(
+                queue_ditl, "_slew_attitude_constraint_violation", return_value=None
+            ),
+        ):
+            mock_slew_class.return_value.calc_slewtime = Mock()
+
+            queue_ditl.acs.acsmode = ACSMode.SCIENCE
+            queue_ditl._initiate_charging(1000.0, 10.0, 20.0)
+
+        event = queue_ditl.log.events[-1]
+        assert event.event_type == "CHARGING"
+        assert (
+            event.description
+            == "Battery below recharge threshold; interrupting science observation "
+            "for charging"
+        )
+        assert event.obsid == interrupted_ppt.obsid
+        assert event.acs_mode == ACSMode.SCIENCE
+        assert not any(event.event_type == "ERROR" for event in queue_ditl.log.events)
+
     def test_charging_ppt_constraint_check(self, mock_config, mock_ephem) -> None:
         """Test charging PPT constraint checking (lines 717-727)."""
         with (


### PR DESCRIPTION
## Summary
- classify recharge-threshold science interruptions as `CHARGING` events instead of `ERROR`
- replace the misleading `BATTERY ALERT` / `emergency charging` wording with `Battery below recharge threshold`
- keep scheduling behavior unchanged: recharge still starts when `battery_alert` is true and sunlight is available
- add tests for both the active `QueueDITL` path and the legacy `EmergencyCharging` wrapper

## Why
Plans were reporting `ERROR` events even though battery state of charge stayed well above the depth-of-discharge safety floor. The root cause is that `battery_alert` fires below the recharge threshold, currently 95%, not only near the safety floor. Those interruptions are normal recharge-window operations, so they should not inflate plan error counts.
