### PR TITLE
Use explicit attitude constraint scopes

### DIFF
--- a/conops/__init__.py
+++ b/conops/__init__.py
@@ -19,7 +19,7 @@ from .common import (
 from .config import (
     DAY_SECONDS,
     DTOR,
-    AttitudeConstraintPolicy,
+    AttitudeConstraintScope,
     AttitudeControlSystem,
     Battery,
     Constraint,
@@ -94,7 +94,7 @@ __all__ = [
     "AttitudeSampleSchema",
     "AttitudeTimeseriesSchema",
     "AttitudeControlSystem",
-    "AttitudeConstraintPolicy",
+    "AttitudeConstraintScope",
     "Battery",
     "ChargeState",
     "MissionConfig",

--- a/conops/config/__init__.py
+++ b/conops/config/__init__.py
@@ -5,9 +5,9 @@ from .communications import (
     BandCapability,
     CommunicationsSystem,
 )
-from .config import AttitudeConstraintPolicy, MissionConfig
+from .config import MissionConfig
 from .constants import DAY_SECONDS, DTOR
-from .constraint import Constraint, DefaultConstraint
+from .constraint import AttitudeConstraintScope, Constraint, DefaultConstraint
 from .data_generator import DataGeneration
 from .fault_management import (
     FaultConstraint,
@@ -44,7 +44,7 @@ from .visualization import VisualizationConfig
 __all__ = [
     "AntennaPointing",
     "AttitudeControlSystem",
-    "AttitudeConstraintPolicy",
+    "AttitudeConstraintScope",
     "BandCapability",
     "Battery",
     "CommunicationsSystem",

--- a/conops/config/config.py
+++ b/conops/config/config.py
@@ -25,9 +25,31 @@ from .visualization import VisualizationConfig
 class AttitudeConstraintPolicy(str, Enum):
     """Constraint validation policy applied to executed attitude samples."""
 
+    SCIENCE_PLUS_SAFETY = "science_plus_safety"
+    SCIENCE = "science"
+    SAFETY = "safety"
     FULL_MISSION = "full_mission"
     HARD_KEEPOUT = "hard_keepout"
     NONE = "none"
+
+    @property
+    def enforces_science(self) -> bool:
+        """True when image-quality / scheduling constraints must be satisfied."""
+        return self in {
+            AttitudeConstraintPolicy.SCIENCE_PLUS_SAFETY,
+            AttitudeConstraintPolicy.SCIENCE,
+            AttitudeConstraintPolicy.FULL_MISSION,
+        }
+
+    @property
+    def enforces_safety(self) -> bool:
+        """True when hardware-safety constraints must be satisfied."""
+        return self in {
+            AttitudeConstraintPolicy.SCIENCE_PLUS_SAFETY,
+            AttitudeConstraintPolicy.SAFETY,
+            AttitudeConstraintPolicy.FULL_MISSION,
+            AttitudeConstraintPolicy.HARD_KEEPOUT,
+        }
 
 
 def _default_attitude_constraint_policy() -> dict[str, AttitudeConstraintPolicy]:
@@ -78,8 +100,10 @@ class MissionConfig(ConfigModel):
         default_factory=_default_attitude_constraint_policy,
         description=(
             "Constraint validation policy by ACS mode for executed attitude samples. "
-            "Values are 'full_mission', 'hard_keepout', or 'none'. Omitted modes "
-            "use the default policy."
+            "Values are 'science_plus_safety', 'science', 'safety', or 'none'. "
+            "'full_mission' and 'hard_keepout' are accepted as compatibility "
+            "aliases for science_plus_safety and safety behavior. Omitted modes use "
+            "the default policy."
         ),
     )
     spacecraft_bus: SpacecraftBus = Field(

--- a/conops/config/config.py
+++ b/conops/config/config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from enum import Enum
 from typing import Any
 
 import yaml
@@ -10,7 +9,7 @@ from rust_ephem.constraints import ConstraintConfig
 from ..common.enums import ACSMode
 from ._base import ConfigModel
 from .battery import Battery
-from .constraint import Constraint, DefaultConstraint
+from .constraint import AttitudeConstraintScope, Constraint, DefaultConstraint
 from .fault_management import FaultManagement
 from .groundstation import GroundStationRegistry
 from .instrument import Payload
@@ -22,45 +21,29 @@ from .targets import TargetConfig
 from .visualization import VisualizationConfig
 
 
-class AttitudeConstraintPolicy(str, Enum):
-    """Constraint validation policy applied to executed attitude samples."""
-
-    SCIENCE_PLUS_SAFETY = "science_plus_safety"
-    SCIENCE = "science"
-    SAFETY = "safety"
-    FULL_MISSION = "full_mission"
-    HARD_KEEPOUT = "hard_keepout"
-    NONE = "none"
-
-    @property
-    def enforces_science(self) -> bool:
-        """True when image-quality / scheduling constraints must be satisfied."""
-        return self in {
-            AttitudeConstraintPolicy.SCIENCE_PLUS_SAFETY,
-            AttitudeConstraintPolicy.SCIENCE,
-            AttitudeConstraintPolicy.FULL_MISSION,
-        }
-
-    @property
-    def enforces_safety(self) -> bool:
-        """True when hardware-safety constraints must be satisfied."""
-        return self in {
-            AttitudeConstraintPolicy.SCIENCE_PLUS_SAFETY,
-            AttitudeConstraintPolicy.SAFETY,
-            AttitudeConstraintPolicy.FULL_MISSION,
-            AttitudeConstraintPolicy.HARD_KEEPOUT,
-        }
-
-
-def _default_attitude_constraint_policy() -> dict[str, AttitudeConstraintPolicy]:
+def _default_attitude_constraint_scopes() -> dict[str, list[AttitudeConstraintScope]]:
     return {
-        ACSMode.SCIENCE.name: AttitudeConstraintPolicy.FULL_MISSION,
-        ACSMode.CHARGING.name: AttitudeConstraintPolicy.FULL_MISSION,
-        ACSMode.SLEWING.name: AttitudeConstraintPolicy.FULL_MISSION,
-        ACSMode.PASS.name: AttitudeConstraintPolicy.FULL_MISSION,
-        ACSMode.SAA.name: AttitudeConstraintPolicy.FULL_MISSION,
-        ACSMode.SAFE.name: AttitudeConstraintPolicy.FULL_MISSION,
-        ACSMode.IDLE.name: AttitudeConstraintPolicy.FULL_MISSION,
+        ACSMode.SCIENCE.name: [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.IMAGING_QUALITY,
+            AttitudeConstraintScope.POWER_GENERATION,
+        ],
+        ACSMode.CHARGING.name: [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.POWER_GENERATION,
+        ],
+        ACSMode.SLEWING.name: [AttitudeConstraintScope.HARDWARE_SAFETY],
+        ACSMode.PASS.name: [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.POWER_GENERATION,
+            AttitudeConstraintScope.GROUND_CONTACT,
+        ],
+        ACSMode.SAA.name: [AttitudeConstraintScope.HARDWARE_SAFETY],
+        ACSMode.SAFE.name: [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.POWER_GENERATION,
+        ],
+        ACSMode.IDLE.name: [AttitudeConstraintScope.HARDWARE_SAFETY],
     }
 
 
@@ -75,15 +58,24 @@ def _mode_name(mode: ACSMode | int | str) -> str:
     return ACSMode(int(raw)).name
 
 
-def _normalize_attitude_constraint_policy(
-    value: dict[ACSMode | int | str, AttitudeConstraintPolicy | str] | None,
-) -> dict[str, AttitudeConstraintPolicy]:
-    policies = _default_attitude_constraint_policy()
+def _normalize_attitude_constraint_scopes(
+    value: dict[
+        ACSMode | int | str,
+        list[AttitudeConstraintScope | str] | tuple[AttitudeConstraintScope | str, ...],
+    ]
+    | None,
+) -> dict[str, list[AttitudeConstraintScope]]:
+    scopes = _default_attitude_constraint_scopes()
     if value is None:
-        return policies
-    for mode, policy in value.items():
-        policies[_mode_name(mode)] = AttitudeConstraintPolicy(policy)
-    return policies
+        return scopes
+    for mode, configured_scopes in value.items():
+        normalized: list[AttitudeConstraintScope] = []
+        for scope in configured_scopes:
+            enum_scope = AttitudeConstraintScope(scope)
+            if enum_scope not in normalized:
+                normalized.append(enum_scope)
+        scopes[_mode_name(mode)] = normalized
+    return scopes
 
 
 class MissionConfig(ConfigModel):
@@ -96,14 +88,13 @@ class MissionConfig(ConfigModel):
         default=None,
         description="Optional seed for stochastic planning decisions.",
     )
-    attitude_constraint_policy: dict[str, AttitudeConstraintPolicy] = Field(
-        default_factory=_default_attitude_constraint_policy,
+    attitude_constraint_scopes: dict[str, list[AttitudeConstraintScope]] = Field(
+        default_factory=_default_attitude_constraint_scopes,
         description=(
-            "Constraint validation policy by ACS mode for executed attitude samples. "
-            "Values are 'science_plus_safety', 'science', 'safety', or 'none'. "
-            "'full_mission' and 'hard_keepout' are accepted as compatibility "
-            "aliases for science_plus_safety and safety behavior. Omitted modes use "
-            "the default policy."
+            "Constraint validation scopes by ACS mode for executed attitude samples. "
+            "Values are lists containing 'hardware_safety', 'imaging_quality', "
+            "'power_generation', and/or 'ground_contact'. Omitted modes use "
+            "the default scopes."
         ),
     )
     spacecraft_bus: SpacecraftBus = Field(
@@ -152,20 +143,23 @@ class MissionConfig(ConfigModel):
         description="Target Configuration. Defines observational targets and scheduling parameters",
     )
 
-    @field_validator("attitude_constraint_policy", mode="before")
+    @field_validator("attitude_constraint_scopes", mode="before")
     @classmethod
-    def _validate_attitude_constraint_policy(
+    def _validate_attitude_constraint_scopes(
         cls,
-        value: dict[ACSMode | int | str, AttitudeConstraintPolicy | str] | None,
-    ) -> dict[str, AttitudeConstraintPolicy]:
-        return _normalize_attitude_constraint_policy(value)
+        value: dict[
+            ACSMode | int | str,
+            list[AttitudeConstraintScope | str]
+            | tuple[AttitudeConstraintScope | str, ...],
+        ]
+        | None,
+    ) -> dict[str, list[AttitudeConstraintScope]]:
+        return _normalize_attitude_constraint_scopes(value)
 
-    def attitude_constraint_policy_for_mode(
+    def attitude_constraint_scopes_for_mode(
         self, mode: ACSMode | int
-    ) -> AttitudeConstraintPolicy:
-        return self.attitude_constraint_policy.get(
-            _mode_name(mode), AttitudeConstraintPolicy.NONE
-        )
+    ) -> list[AttitudeConstraintScope]:
+        return self.attitude_constraint_scopes.get(_mode_name(mode), [])
 
     @model_validator(mode="after")
     def init_fault_management_defaults(self) -> MissionConfig:

--- a/conops/config/constraint.py
+++ b/conops/config/constraint.py
@@ -28,12 +28,14 @@ _TIME_PRECISION = 0  # round to nearest second
 _RA_DEC_ROUNDER = 10**_RA_DEC_PRECISION
 _TIME_ROUNDER = 10**_TIME_PRECISION
 
-_POLICY_SCIENCE_PLUS_SAFETY = "science_plus_safety"
-_POLICY_SCIENCE = "science"
-_POLICY_SAFETY = "safety"
-_POLICY_FULL_MISSION = "full_mission"
-_POLICY_HARD_KEEPOUT = "hard_keepout"
-_POLICY_NONE = "none"
+
+class AttitudeConstraintScope(str, Enum):
+    """Constraint scope applied to executed attitude samples."""
+
+    HARDWARE_SAFETY = "hardware_safety"
+    IMAGING_QUALITY = "imaging_quality"
+    POWER_GENERATION = "power_generation"
+    GROUND_CONTACT = "ground_contact"
 
 
 def _default_sun_constraint() -> ConstraintConfig:
@@ -124,14 +126,14 @@ class Constraint(ConfigModel):
     )
     panel_constraint: ConstraintConfig | None = Field(
         default=None,
-        description="Solar panel constraint configuration",
+        description="Power-generation / solar panel constraint configuration",
     )
     science_constraint: ConstraintConfig | None = Field(
         default=None,
         description=(
-            "Additional science-quality / scheduling constraint. Legacy top-level "
-            "sun, earth, moon, orbit, panel, anti-sun, and star-tracker soft "
-            "constraints are also treated as science constraints."
+            "Additional imaging-quality / science scheduling constraint. Top-level "
+            "sun, earth, moon, orbit, anti-sun, and star-tracker soft constraints "
+            "are also treated as imaging-quality constraints."
         ),
     )
     safety_constraint: ConstraintConfig | None = Field(
@@ -141,6 +143,10 @@ class Constraint(ConfigModel):
             "hard, and telescope hard constraints are also treated as safety "
             "constraints."
         ),
+    )
+    ground_contact_constraint: ConstraintConfig | None = Field(
+        default=None,
+        description="Additional ground-contact attitude constraint",
     )
     star_tracker_hard_constraint: ConstraintConfig | None = Field(
         default=None,
@@ -268,6 +274,10 @@ class Constraint(ConfigModel):
     def invalidate_combined_constraint_cache(self) -> None:
         """Invalidate cached combined constraint after component updates."""
         self.__dict__.pop("constraint", None)
+        self.__dict__.pop("hardware_safety_constraint_config", None)
+        self.__dict__.pop("imaging_quality_constraint_config", None)
+        self.__dict__.pop("power_generation_constraint_config", None)
+        self.__dict__.pop("ground_contact_constraint_config", None)
         self.__dict__.pop("science_constraint_config", None)
         self.__dict__.pop("safety_constraint_config", None)
         self.__dict__.pop("roll_independent_constraint", None)
@@ -290,15 +300,14 @@ class Constraint(ConfigModel):
         return combined
 
     @cached_property
-    def science_constraint_config(self) -> ConstraintConfig | None:
-        """Combined science-quality / scheduling constraints."""
+    def imaging_quality_constraint_config(self) -> ConstraintConfig | None:
+        """Combined imaging-quality / science scheduling constraints."""
         return self._combine_constraints(
             [
                 self.sun_constraint,
                 self.moon_constraint,
                 self.earth_constraint,
                 self.orbit_constraint,
-                self.panel_constraint,
                 self.anti_sun_constraint,
                 self.star_tracker_soft_constraint,
                 self.science_constraint,
@@ -306,7 +315,17 @@ class Constraint(ConfigModel):
         )
 
     @cached_property
-    def safety_constraint_config(self) -> ConstraintConfig | None:
+    def power_generation_constraint_config(self) -> ConstraintConfig | None:
+        """Combined power-generation constraints."""
+        return self._combine_constraints([self.panel_constraint])
+
+    @cached_property
+    def ground_contact_constraint_config(self) -> ConstraintConfig | None:
+        """Combined ground-contact attitude constraints."""
+        return self._combine_constraints([self.ground_contact_constraint])
+
+    @cached_property
+    def hardware_safety_constraint_config(self) -> ConstraintConfig | None:
         """Combined hardware-safety constraints."""
         return self._combine_constraints(
             [
@@ -319,10 +338,30 @@ class Constraint(ConfigModel):
 
     @cached_property
     def constraint(self) -> ConstraintConfig | None:
-        """Combined science-plus-safety constraint preserving legacy behavior."""
+        """Combined configured constraint across all built-in scopes."""
         return self._combine_constraints(
-            [self.science_constraint_config, self.safety_constraint_config]
+            [
+                self.hardware_safety_constraint_config,
+                self.imaging_quality_constraint_config,
+                self.power_generation_constraint_config,
+                self.ground_contact_constraint_config,
+            ]
         )
+
+    @cached_property
+    def science_constraint_config(self) -> ConstraintConfig | None:
+        """Combined constraints used by the historical science helper."""
+        return self._combine_constraints(
+            [
+                self.imaging_quality_constraint_config,
+                self.power_generation_constraint_config,
+            ]
+        )
+
+    @cached_property
+    def safety_constraint_config(self) -> ConstraintConfig | None:
+        """Combined constraints used by the historical safety helper."""
+        return self.hardware_safety_constraint_config
 
     @cached_property
     def roll_independent_constraint(self) -> ConstraintConfig | None:
@@ -394,6 +433,7 @@ class Constraint(ConfigModel):
             self.star_tracker_soft_constraint,
             self.radiator_hard_constraint,
             self.telescope_hard_constraint,
+            self.ground_contact_constraint,
             self.science_constraint,
             self.safety_constraint,
         ):
@@ -511,6 +551,21 @@ class Constraint(ConfigModel):
             target_roll=target_roll,
         )
 
+    def in_ground_contact(
+        self, ra: float, dec: float, time: float, target_roll: float | None = None
+    ) -> bool:
+        if self.ground_contact_constraint is None:
+            return False
+        assert self.ephem is not None, "Ephemeris must be set to use in_ground_contact"
+        return self._cached_check(
+            "ground_contact",
+            ra,
+            dec,
+            time,
+            self.ground_contact_constraint,
+            target_roll=target_roll,
+        )
+
     def in_star_tracker_hard(
         self,
         ra: float,
@@ -605,8 +660,56 @@ class Constraint(ConfigModel):
         target_roll: float | None = None,
         acs_mode: ACSMode | int | None = None,
     ) -> bool:
-        """Check image-quality / scheduling constraints only."""
-        return in_science_attitude_constraint(
+        """Check imaging-quality and power-generation constraints."""
+        return in_attitude_constraint_scopes(
+            self,
+            [
+                AttitudeConstraintScope.IMAGING_QUALITY,
+                AttitudeConstraintScope.POWER_GENERATION,
+            ],
+            ra,
+            dec,
+            utime,
+            target_roll=target_roll,
+            acs_mode=acs_mode,
+        )
+
+    def in_imaging_quality_constraint(
+        self,
+        ra: float,
+        dec: float,
+        utime: float,
+        target_roll: float | None = None,
+        acs_mode: ACSMode | int | None = None,
+    ) -> bool:
+        """Check imaging-quality / science scheduling constraints."""
+        return in_imaging_quality_attitude_constraint(
+            self, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+
+    def in_power_generation_constraint(
+        self,
+        ra: float,
+        dec: float,
+        utime: float,
+        target_roll: float | None = None,
+        acs_mode: ACSMode | int | None = None,
+    ) -> bool:
+        """Check power-generation attitude constraints."""
+        return in_power_generation_attitude_constraint(
+            self, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+
+    def in_ground_contact_constraint(
+        self,
+        ra: float,
+        dec: float,
+        utime: float,
+        target_roll: float | None = None,
+        acs_mode: ACSMode | int | None = None,
+    ) -> bool:
+        """Check ground-contact attitude constraints."""
+        return in_ground_contact_attitude_constraint(
             self, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
         )
 
@@ -619,11 +722,11 @@ class Constraint(ConfigModel):
         acs_mode: ACSMode | int | None = None,
     ) -> bool:
         """Check hardware-safety constraints only."""
-        return in_safety_attitude_constraint(
+        return in_hardware_safety_attitude_constraint(
             self, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
         )
 
-    def in_science_plus_safety_constraint(
+    def in_all_attitude_constraint_scopes(
         self,
         ra: float,
         dec: float,
@@ -631,8 +734,8 @@ class Constraint(ConfigModel):
         target_roll: float | None = None,
         acs_mode: ACSMode | int | None = None,
     ) -> bool:
-        """Check both scheduling and hardware-safety constraints."""
-        return in_science_plus_safety_attitude_constraint(
+        """Check all built-in attitude constraint scopes."""
+        return in_all_attitude_constraint_scopes(
             self, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
         )
 
@@ -644,8 +747,8 @@ class Constraint(ConfigModel):
         target_roll: float | None = None,
         acs_mode: ACSMode | int | None = None,
     ) -> bool:
-        """For a given time is a RA/Dec in any science or safety constraint?"""
-        return self.in_science_plus_safety_constraint(
+        """For a given time is a RA/Dec in any built-in attitude constraint?"""
+        return self.in_all_attitude_constraint_scopes(
             ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
         )
 
@@ -675,7 +778,7 @@ class Constraint(ConfigModel):
             self, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
         )
 
-    def science_plus_safety_constraint_name(
+    def all_attitude_constraint_name(
         self,
         ra: float,
         dec: float,
@@ -683,8 +786,8 @@ class Constraint(ConfigModel):
         target_roll: float | None = None,
         acs_mode: ACSMode | int | None = None,
     ) -> str | None:
-        """Return the first violated science or safety constraint name."""
-        return science_plus_safety_attitude_constraint_name(
+        """Return the first violated constraint name across all built-in scopes."""
+        return all_attitude_constraint_name(
             self, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
         )
 
@@ -762,7 +865,7 @@ class Constraint(ConfigModel):
         utime: float,
         target_rolls: list[float] | None = None,
     ) -> np.ndarray:
-        """Check science/scheduling constraints for multiple pointings."""
+        """Check imaging-quality and power-generation constraints."""
         return self._in_constraint_batch_for_components(
             ras,
             decs,
@@ -770,13 +873,69 @@ class Constraint(ConfigModel):
             [
                 self.sun_constraint,
                 self.earth_constraint,
+                self.moon_constraint,
+                self.anti_sun_constraint,
+                self.orbit_constraint,
+                self.star_tracker_soft_constraint,
+                self.science_constraint,
                 self.panel_constraint,
+            ],
+            target_rolls=target_rolls,
+        )
+
+    def in_imaging_quality_constraint_batch(
+        self,
+        ras: list[float],
+        decs: list[float],
+        utime: float,
+        target_rolls: list[float] | None = None,
+    ) -> np.ndarray:
+        """Check imaging-quality constraints for multiple pointings."""
+        return self._in_constraint_batch_for_components(
+            ras,
+            decs,
+            utime,
+            [
+                self.sun_constraint,
+                self.earth_constraint,
                 self.moon_constraint,
                 self.anti_sun_constraint,
                 self.orbit_constraint,
                 self.star_tracker_soft_constraint,
                 self.science_constraint,
             ],
+            target_rolls=target_rolls,
+        )
+
+    def in_power_generation_constraint_batch(
+        self,
+        ras: list[float],
+        decs: list[float],
+        utime: float,
+        target_rolls: list[float] | None = None,
+    ) -> np.ndarray:
+        """Check power-generation constraints for multiple pointings."""
+        return self._in_constraint_batch_for_components(
+            ras,
+            decs,
+            utime,
+            [self.panel_constraint],
+            target_rolls=target_rolls,
+        )
+
+    def in_ground_contact_constraint_batch(
+        self,
+        ras: list[float],
+        decs: list[float],
+        utime: float,
+        target_rolls: list[float] | None = None,
+    ) -> np.ndarray:
+        """Check ground-contact constraints for multiple pointings."""
+        return self._in_constraint_batch_for_components(
+            ras,
+            decs,
+            utime,
+            [self.ground_contact_constraint],
             target_rolls=target_rolls,
         )
 
@@ -801,6 +960,18 @@ class Constraint(ConfigModel):
             target_rolls=target_rolls,
         )
 
+    def in_hardware_safety_constraint_batch(
+        self,
+        ras: list[float],
+        decs: list[float],
+        utime: float,
+        target_rolls: list[float] | None = None,
+    ) -> np.ndarray:
+        """Check hardware-safety constraints for multiple pointings."""
+        return self.in_safety_constraint_batch(
+            ras, decs, utime, target_rolls=target_rolls
+        )
+
     def in_constraint_batch(
         self,
         ras: list[float],
@@ -808,7 +979,7 @@ class Constraint(ConfigModel):
         utime: float,
         target_rolls: list[float] | None = None,
     ) -> np.ndarray:
-        """Check science-plus-safety constraints for multiple pointings.
+        """Check all built-in attitude constraint scopes.
 
         Uses batch evaluation via rust_ephem's in_constraint_batch() API,
         which is much faster than repeated scalar calls for many candidates.
@@ -835,11 +1006,26 @@ class Constraint(ConfigModel):
         )
 
 
-def _attitude_policy_value(policy: str | Enum) -> str:
-    if isinstance(policy, Enum):
-        value = policy.value
+def _attitude_scope_value(scope: str | Enum) -> str:
+    if isinstance(scope, Enum):
+        value = scope.value
         return value if isinstance(value, str) else str(value)
-    return policy
+    return scope
+
+
+def _attitude_scope_values(scopes: list[str | Enum]) -> list[str]:
+    values: list[str] = []
+    for scope in scopes:
+        value = _attitude_scope_value(scope)
+        if value not in values:
+            values.append(value)
+    return values
+
+
+def attitude_constraint_scope_label(scopes: list[str | Enum]) -> str:
+    """Return a stable label for a mode's configured constraint scopes."""
+    values = _attitude_scope_values(scopes)
+    return "+".join(values) if values else "none"
 
 
 def _has_real_constraint_method(constraint: Constraint, method_name: str) -> bool:
@@ -847,7 +1033,7 @@ def _has_real_constraint_method(constraint: Constraint, method_name: str) -> boo
     return hasattr(type(constraint), method_name)
 
 
-def in_science_attitude_constraint(
+def in_imaging_quality_attitude_constraint(
     constraint: Constraint,
     ra: float,
     dec: float,
@@ -855,12 +1041,10 @@ def in_science_attitude_constraint(
     target_roll: float | None = None,
     acs_mode: ACSMode | int | None = None,
 ) -> bool:
-    """Return True if an attitude violates science/scheduling constraints."""
+    """Return True if an attitude violates imaging-quality constraints."""
     if constraint.in_sun(ra, dec, utime, target_roll=target_roll):
         return True
     if constraint.in_earth(ra, dec, utime, target_roll=target_roll):
-        return True
-    if constraint.in_panel(ra, dec, utime, target_roll=target_roll):
         return True
     if constraint.in_moon(ra, dec, utime, target_roll=target_roll):
         return True
@@ -879,7 +1063,31 @@ def in_science_attitude_constraint(
     return False
 
 
-def in_safety_attitude_constraint(
+def in_power_generation_attitude_constraint(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> bool:
+    """Return True if an attitude violates power-generation constraints."""
+    return constraint.in_panel(ra, dec, utime, target_roll=target_roll)
+
+
+def in_ground_contact_attitude_constraint(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> bool:
+    """Return True if an attitude violates ground-contact constraints."""
+    return constraint.in_ground_contact(ra, dec, utime, target_roll=target_roll)
+
+
+def in_hardware_safety_attitude_constraint(
     constraint: Constraint,
     ra: float,
     dec: float,
@@ -902,7 +1110,61 @@ def in_safety_attitude_constraint(
     return False
 
 
-def in_science_plus_safety_attitude_constraint(
+def in_attitude_constraint_scope(
+    constraint: Constraint,
+    scope: str | Enum,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> bool:
+    """Return True if an attitude violates one configured scope."""
+    scope_value = _attitude_scope_value(scope)
+    if scope_value == AttitudeConstraintScope.HARDWARE_SAFETY.value:
+        return in_hardware_safety_attitude_constraint(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if scope_value == AttitudeConstraintScope.IMAGING_QUALITY.value:
+        return in_imaging_quality_attitude_constraint(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if scope_value == AttitudeConstraintScope.POWER_GENERATION.value:
+        return in_power_generation_attitude_constraint(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if scope_value == AttitudeConstraintScope.GROUND_CONTACT.value:
+        return in_ground_contact_attitude_constraint(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    raise ValueError(f"Unknown attitude constraint scope: {scope_value!r}")
+
+
+def in_attitude_constraint_scopes(
+    constraint: Constraint,
+    scopes: list[str | Enum],
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> bool:
+    """Return True if an attitude violates any configured scope."""
+    return any(
+        in_attitude_constraint_scope(
+            constraint,
+            scope,
+            ra,
+            dec,
+            utime,
+            target_roll=target_roll,
+            acs_mode=acs_mode,
+        )
+        for scope in scopes
+    )
+
+
+def in_science_attitude_constraint(
     constraint: Constraint,
     ra: float,
     dec: float,
@@ -910,47 +1172,61 @@ def in_science_plus_safety_attitude_constraint(
     target_roll: float | None = None,
     acs_mode: ACSMode | int | None = None,
 ) -> bool:
-    """Return True if either science or safety constraints are violated."""
-    return in_science_attitude_constraint(
-        constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
-    ) or in_safety_attitude_constraint(
+    """Return True if an attitude violates science helper constraints."""
+    return in_attitude_constraint_scopes(
+        constraint,
+        [
+            AttitudeConstraintScope.IMAGING_QUALITY,
+            AttitudeConstraintScope.POWER_GENERATION,
+        ],
+        ra,
+        dec,
+        utime,
+        target_roll=target_roll,
+        acs_mode=acs_mode,
+    )
+
+
+def in_safety_attitude_constraint(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> bool:
+    """Return True if an attitude violates hardware-safety constraints."""
+    return in_hardware_safety_attitude_constraint(
         constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
     )
 
 
-def in_attitude_constraint_policy(
+def in_all_attitude_constraint_scopes(
     constraint: Constraint,
-    policy: str | Enum,
     ra: float,
     dec: float,
     utime: float,
     target_roll: float | None = None,
     acs_mode: ACSMode | int | None = None,
 ) -> bool:
-    """Return True if an attitude violates the configured policy scope."""
-    policy_value = _attitude_policy_value(policy)
-    if policy_value == _POLICY_NONE:
-        return False
-    if policy_value == _POLICY_FULL_MISSION:
-        return constraint.in_constraint(
-            ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
-        )
-    if policy_value == _POLICY_SCIENCE_PLUS_SAFETY:
-        return in_science_plus_safety_attitude_constraint(
-            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
-        )
-    if policy_value == _POLICY_SCIENCE:
-        return in_science_attitude_constraint(
-            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
-        )
-    if policy_value in {_POLICY_HARD_KEEPOUT, _POLICY_SAFETY}:
-        return in_safety_attitude_constraint(
-            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
-        )
-    raise ValueError(f"Unknown attitude constraint policy: {policy_value!r}")
+    """Return True if any built-in attitude scope is violated."""
+    return in_attitude_constraint_scopes(
+        constraint,
+        [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.IMAGING_QUALITY,
+            AttitudeConstraintScope.POWER_GENERATION,
+            AttitudeConstraintScope.GROUND_CONTACT,
+        ],
+        ra,
+        dec,
+        utime,
+        target_roll=target_roll,
+        acs_mode=acs_mode,
+    )
 
 
-def science_attitude_constraint_name(
+def imaging_quality_attitude_constraint_name(
     constraint: Constraint,
     ra: float,
     dec: float,
@@ -958,13 +1234,11 @@ def science_attitude_constraint_name(
     target_roll: float | None = None,
     acs_mode: ACSMode | int | None = None,
 ) -> str | None:
-    """Return the first violated science/scheduling constraint name."""
+    """Return the first violated imaging-quality constraint name."""
     if constraint.in_sun(ra, dec, utime, target_roll=target_roll):
         return "Sun"
     if constraint.in_earth(ra, dec, utime, target_roll=target_roll):
         return "Earth Limb"
-    if constraint.in_panel(ra, dec, utime, target_roll=target_roll):
-        return "Panel"
     if constraint.in_moon(ra, dec, utime, target_roll=target_roll):
         return "Moon"
     if constraint.in_anti_sun(ra, dec, utime, target_roll=target_roll):
@@ -981,7 +1255,35 @@ def science_attitude_constraint_name(
     return None
 
 
-def safety_attitude_constraint_name(
+def power_generation_attitude_constraint_name(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> str | None:
+    """Return the first violated power-generation constraint name."""
+    if constraint.in_panel(ra, dec, utime, target_roll=target_roll):
+        return "Panel"
+    return None
+
+
+def ground_contact_attitude_constraint_name(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> str | None:
+    """Return the first violated ground-contact constraint name."""
+    if constraint.in_ground_contact(ra, dec, utime, target_roll=target_roll):
+        return "Ground Contact"
+    return None
+
+
+def hardware_safety_attitude_constraint_name(
     constraint: Constraint,
     ra: float,
     dec: float,
@@ -1004,7 +1306,62 @@ def safety_attitude_constraint_name(
     return None
 
 
-def science_plus_safety_attitude_constraint_name(
+def attitude_constraint_name_for_scope(
+    constraint: Constraint,
+    scope: str | Enum,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> str | None:
+    """Return the violated constraint name for one configured scope."""
+    scope_value = _attitude_scope_value(scope)
+    if scope_value == AttitudeConstraintScope.HARDWARE_SAFETY.value:
+        return hardware_safety_attitude_constraint_name(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if scope_value == AttitudeConstraintScope.IMAGING_QUALITY.value:
+        return imaging_quality_attitude_constraint_name(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if scope_value == AttitudeConstraintScope.POWER_GENERATION.value:
+        return power_generation_attitude_constraint_name(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if scope_value == AttitudeConstraintScope.GROUND_CONTACT.value:
+        return ground_contact_attitude_constraint_name(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    raise ValueError(f"Unknown attitude constraint scope: {scope_value!r}")
+
+
+def attitude_constraint_name_for_scopes(
+    constraint: Constraint,
+    scopes: list[str | Enum],
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> str | None:
+    """Return the first violated constraint name for configured scopes."""
+    for scope in _attitude_scope_values(scopes):
+        name = attitude_constraint_name_for_scope(
+            constraint,
+            scope,
+            ra,
+            dec,
+            utime,
+            target_roll=target_roll,
+            acs_mode=acs_mode,
+        )
+        if name is not None:
+            return name
+    return None
+
+
+def science_attitude_constraint_name(
     constraint: Constraint,
     ra: float,
     dec: float,
@@ -1012,87 +1369,95 @@ def science_plus_safety_attitude_constraint_name(
     target_roll: float | None = None,
     acs_mode: ACSMode | int | None = None,
 ) -> str | None:
-    """Return the first violated science or safety constraint name."""
-    return science_attitude_constraint_name(
-        constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
-    ) or safety_attitude_constraint_name(
+    """Return the first violated science helper constraint name."""
+    return attitude_constraint_name_for_scopes(
+        constraint,
+        [
+            AttitudeConstraintScope.IMAGING_QUALITY,
+            AttitudeConstraintScope.POWER_GENERATION,
+        ],
+        ra,
+        dec,
+        utime,
+        target_roll=target_roll,
+        acs_mode=acs_mode,
+    )
+
+
+def safety_attitude_constraint_name(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> str | None:
+    """Return the first violated hardware-safety constraint name."""
+    return hardware_safety_attitude_constraint_name(
         constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
     )
 
 
-def attitude_constraint_name_for_policy(
+def all_attitude_constraint_name(
     constraint: Constraint,
-    policy: str | Enum,
     ra: float,
     dec: float,
     utime: float,
     target_roll: float | None = None,
     acs_mode: ACSMode | int | None = None,
 ) -> str | None:
-    """Return the violated constraint name for the configured policy scope."""
-    policy_value = _attitude_policy_value(policy)
-    if policy_value == _POLICY_NONE:
-        return None
-    if policy_value == _POLICY_FULL_MISSION:
-        if not constraint.in_constraint(
-            ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
-        ):
-            return None
-        return (
-            science_plus_safety_attitude_constraint_name(
-                constraint,
-                ra,
-                dec,
-                utime,
-                target_roll=target_roll,
-                acs_mode=acs_mode,
-            )
-            or "Unknown"
-        )
-    if policy_value == _POLICY_SCIENCE_PLUS_SAFETY:
-        return science_plus_safety_attitude_constraint_name(
-            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
-        )
-    if policy_value == _POLICY_SCIENCE:
-        return science_attitude_constraint_name(
-            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
-        )
-    if policy_value in {_POLICY_HARD_KEEPOUT, _POLICY_SAFETY}:
-        return safety_attitude_constraint_name(
-            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
-        )
-    raise ValueError(f"Unknown attitude constraint policy: {policy_value!r}")
+    """Return the first violated constraint name across all built-in scopes."""
+    return attitude_constraint_name_for_scopes(
+        constraint,
+        [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.IMAGING_QUALITY,
+            AttitudeConstraintScope.POWER_GENERATION,
+            AttitudeConstraintScope.GROUND_CONTACT,
+        ],
+        ra,
+        dec,
+        utime,
+        target_roll=target_roll,
+        acs_mode=acs_mode,
+    )
 
 
-def in_attitude_constraint_policy_batch(
+def in_attitude_constraint_scopes_batch(
     constraint: Constraint,
-    policy: str | Enum,
+    scopes: list[str | Enum],
     ras: list[float],
     decs: list[float],
     utime: float,
     target_rolls: list[float] | None = None,
 ) -> np.ndarray:
-    """Check multiple pointings against the configured policy scope."""
-    policy_value = _attitude_policy_value(policy)
-    if policy_value == _POLICY_NONE:
-        return np.zeros(len(ras), dtype=bool)
-    if policy_value in {_POLICY_FULL_MISSION, _POLICY_SCIENCE_PLUS_SAFETY}:
-        if target_rolls is None:
-            return constraint.in_constraint_batch(ras, decs, utime)
-        return constraint.in_constraint_batch(ras, decs, utime, target_rolls)
-    if policy_value == _POLICY_SCIENCE:
-        if target_rolls is None:
-            return constraint.in_science_constraint_batch(ras, decs, utime)
-        return constraint.in_science_constraint_batch(ras, decs, utime, target_rolls)
-    if policy_value in {_POLICY_HARD_KEEPOUT, _POLICY_SAFETY}:
-        if target_rolls is None:
-            return constraint.in_safety_constraint_batch(ras, decs, utime)
-        return constraint.in_safety_constraint_batch(ras, decs, utime, target_rolls)
-    raise ValueError(f"Unknown attitude constraint policy: {policy_value!r}")
+    """Check multiple pointings against configured scopes."""
+    violations = np.zeros(len(ras), dtype=bool)
+    for scope in _attitude_scope_values(scopes):
+        if scope == AttitudeConstraintScope.HARDWARE_SAFETY.value:
+            scoped = constraint.in_hardware_safety_constraint_batch(
+                ras, decs, utime, target_rolls=target_rolls
+            )
+        elif scope == AttitudeConstraintScope.IMAGING_QUALITY.value:
+            scoped = constraint.in_imaging_quality_constraint_batch(
+                ras, decs, utime, target_rolls=target_rolls
+            )
+        elif scope == AttitudeConstraintScope.POWER_GENERATION.value:
+            scoped = constraint.in_power_generation_constraint_batch(
+                ras, decs, utime, target_rolls=target_rolls
+            )
+        elif scope == AttitudeConstraintScope.GROUND_CONTACT.value:
+            scoped = constraint.in_ground_contact_constraint_batch(
+                ras, decs, utime, target_rolls=target_rolls
+            )
+        else:
+            raise ValueError(f"Unknown attitude constraint scope: {scope!r}")
+        violations = violations | scoped
+    return violations
 
 
 class DefaultConstraint(Constraint):
-    """Default mission constraint set preserving legacy COAST-Sim behavior."""
+    """Default mission imaging and power-generation constraint set."""
 
     sun_constraint: ConstraintConfig | None = Field(
         default_factory=_default_sun_constraint,

--- a/conops/config/constraint.py
+++ b/conops/config/constraint.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from functools import cached_property, lru_cache
 from typing import cast
 
@@ -26,6 +27,13 @@ _TIME_PRECISION = 0  # round to nearest second
 # Integer-based rounding multipliers for faster key generation
 _RA_DEC_ROUNDER = 10**_RA_DEC_PRECISION
 _TIME_ROUNDER = 10**_TIME_PRECISION
+
+_POLICY_SCIENCE_PLUS_SAFETY = "science_plus_safety"
+_POLICY_SCIENCE = "science"
+_POLICY_SAFETY = "safety"
+_POLICY_FULL_MISSION = "full_mission"
+_POLICY_HARD_KEEPOUT = "hard_keepout"
+_POLICY_NONE = "none"
 
 
 def _default_sun_constraint() -> ConstraintConfig:
@@ -117,6 +125,22 @@ class Constraint(ConfigModel):
     panel_constraint: ConstraintConfig | None = Field(
         default=None,
         description="Solar panel constraint configuration",
+    )
+    science_constraint: ConstraintConfig | None = Field(
+        default=None,
+        description=(
+            "Additional science-quality / scheduling constraint. Legacy top-level "
+            "sun, earth, moon, orbit, panel, anti-sun, and star-tracker soft "
+            "constraints are also treated as science constraints."
+        ),
+    )
+    safety_constraint: ConstraintConfig | None = Field(
+        default=None,
+        description=(
+            "Additional hardware-safety constraint. Star-tracker hard, radiator "
+            "hard, and telescope hard constraints are also treated as safety "
+            "constraints."
+        ),
     )
     star_tracker_hard_constraint: ConstraintConfig | None = Field(
         default=None,
@@ -244,24 +268,15 @@ class Constraint(ConfigModel):
     def invalidate_combined_constraint_cache(self) -> None:
         """Invalidate cached combined constraint after component updates."""
         self.__dict__.pop("constraint", None)
+        self.__dict__.pop("science_constraint_config", None)
+        self.__dict__.pop("safety_constraint_config", None)
         self.__dict__.pop("roll_independent_constraint", None)
         self.__dict__.pop("roll_dependent_constraint", None)
 
-    @cached_property
-    def constraint(self) -> ConstraintConfig | None:
-        """Combined constraint from all individual constraints"""
-        constraint_components = [
-            self.sun_constraint,
-            self.moon_constraint,
-            self.earth_constraint,
-            self.orbit_constraint,
-            self.panel_constraint,
-            self.anti_sun_constraint,
-            self.star_tracker_hard_constraint,
-            self.star_tracker_soft_constraint,
-            self.radiator_hard_constraint,
-            self.telescope_hard_constraint,
-        ]
+    @staticmethod
+    def _combine_constraints(
+        constraint_components: list[ConstraintConfig | None],
+    ) -> ConstraintConfig | None:
         active_constraints = [
             component for component in constraint_components if component is not None
         ]
@@ -273,6 +288,41 @@ class Constraint(ConfigModel):
         for component in active_constraints[1:]:
             combined = combined | component
         return combined
+
+    @cached_property
+    def science_constraint_config(self) -> ConstraintConfig | None:
+        """Combined science-quality / scheduling constraints."""
+        return self._combine_constraints(
+            [
+                self.sun_constraint,
+                self.moon_constraint,
+                self.earth_constraint,
+                self.orbit_constraint,
+                self.panel_constraint,
+                self.anti_sun_constraint,
+                self.star_tracker_soft_constraint,
+                self.science_constraint,
+            ]
+        )
+
+    @cached_property
+    def safety_constraint_config(self) -> ConstraintConfig | None:
+        """Combined hardware-safety constraints."""
+        return self._combine_constraints(
+            [
+                self.safety_constraint,
+                self.star_tracker_hard_constraint,
+                self.radiator_hard_constraint,
+                self.telescope_hard_constraint,
+            ]
+        )
+
+    @cached_property
+    def constraint(self) -> ConstraintConfig | None:
+        """Combined science-plus-safety constraint preserving legacy behavior."""
+        return self._combine_constraints(
+            [self.science_constraint_config, self.safety_constraint_config]
+        )
 
     @cached_property
     def roll_independent_constraint(self) -> ConstraintConfig | None:
@@ -300,13 +350,28 @@ class Constraint(ConfigModel):
             self.panel_constraint,
             self.anti_sun_constraint,
         ]
-        active = [c for c in components if c is not None]
-        if not active:
-            return None
-        combined = active[0]
-        for c in active[1:]:
-            combined = combined | c
-        return combined
+        components.extend(
+            constraint
+            for constraint in (self.science_constraint, self.safety_constraint)
+            if constraint is not None
+            and not self._boresight_offset_constraints(constraint)
+        )
+        return self._combine_constraints(components)
+
+    @staticmethod
+    def _boresight_offset_constraints(
+        constraint: ConstraintConfig,
+    ) -> list[ConstraintConfig]:
+        """Return roll-dependent boresight-offset leaves from a constraint tree."""
+        from rust_ephem.constraints import BoresightOffsetConstraint
+
+        if isinstance(constraint, BoresightOffsetConstraint):
+            return [constraint]
+        leaves: list[ConstraintConfig] = []
+        if hasattr(constraint, "constraints"):
+            for subconstraint in constraint.constraints:
+                leaves.extend(Constraint._boresight_offset_constraints(subconstraint))
+        return leaves
 
     @cached_property
     def roll_dependent_constraint(self) -> ConstraintConfig | None:
@@ -323,26 +388,17 @@ class Constraint(ConfigModel):
         contain no ``BoresightOffsetConstraint`` nodes and are therefore excluded
         automatically.
         """
-        from rust_ephem.constraints import BoresightOffsetConstraint
-
-        def _collect(c: ConstraintConfig) -> list[ConstraintConfig]:
-            if isinstance(c, BoresightOffsetConstraint):
-                return [c]
-            nodes: list[ConstraintConfig] = []
-            if hasattr(c, "constraints"):
-                for sub in c.constraints:
-                    nodes.extend(_collect(sub))
-            return nodes
-
         leaves: list[ConstraintConfig] = []
         for field in (
             self.star_tracker_hard_constraint,
             self.star_tracker_soft_constraint,
             self.radiator_hard_constraint,
             self.telescope_hard_constraint,
+            self.science_constraint,
+            self.safety_constraint,
         ):
             if field is not None:
-                leaves.extend(_collect(field))
+                leaves.extend(self._boresight_offset_constraints(field))
 
         if not leaves:
             return None
@@ -421,6 +477,38 @@ class Constraint(ConfigModel):
         assert self.ephem is not None, "Ephemeris must be set to use in_orbit method"
         return self._cached_check(
             "orbit", ra, dec, time, self.orbit_constraint, target_roll=target_roll
+        )
+
+    def in_explicit_science(
+        self, ra: float, dec: float, time: float, target_roll: float | None = None
+    ) -> bool:
+        if self.science_constraint is None:
+            return False
+        assert self.ephem is not None, (
+            "Ephemeris must be set to use in_explicit_science"
+        )
+        return self._cached_check(
+            "explicit_science",
+            ra,
+            dec,
+            time,
+            self.science_constraint,
+            target_roll=target_roll,
+        )
+
+    def in_explicit_safety(
+        self, ra: float, dec: float, time: float, target_roll: float | None = None
+    ) -> bool:
+        if self.safety_constraint is None:
+            return False
+        assert self.ephem is not None, "Ephemeris must be set to use in_explicit_safety"
+        return self._cached_check(
+            "explicit_safety",
+            ra,
+            dec,
+            time,
+            self.safety_constraint,
+            target_roll=target_roll,
         )
 
     def in_star_tracker_hard(
@@ -509,6 +597,45 @@ class Constraint(ConfigModel):
             target_roll=target_roll,
         )
 
+    def in_science_constraint(
+        self,
+        ra: float,
+        dec: float,
+        utime: float,
+        target_roll: float | None = None,
+        acs_mode: ACSMode | int | None = None,
+    ) -> bool:
+        """Check image-quality / scheduling constraints only."""
+        return in_science_attitude_constraint(
+            self, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+
+    def in_safety_constraint(
+        self,
+        ra: float,
+        dec: float,
+        utime: float,
+        target_roll: float | None = None,
+        acs_mode: ACSMode | int | None = None,
+    ) -> bool:
+        """Check hardware-safety constraints only."""
+        return in_safety_attitude_constraint(
+            self, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+
+    def in_science_plus_safety_constraint(
+        self,
+        ra: float,
+        dec: float,
+        utime: float,
+        target_roll: float | None = None,
+        acs_mode: ACSMode | int | None = None,
+    ) -> bool:
+        """Check both scheduling and hardware-safety constraints."""
+        return in_science_plus_safety_attitude_constraint(
+            self, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+
     def in_constraint(
         self,
         ra: float,
@@ -517,32 +644,49 @@ class Constraint(ConfigModel):
         target_roll: float | None = None,
         acs_mode: ACSMode | int | None = None,
     ) -> bool:
-        """For a given time is a RA/Dec in occult?"""
-        if self.in_sun(ra=ra, dec=dec, time=utime, target_roll=target_roll):
-            return True
-        if self.in_earth(ra=ra, dec=dec, time=utime, target_roll=target_roll):
-            return True
-        if self.in_panel(ra=ra, dec=dec, time=utime, target_roll=target_roll):
-            return True
-        if self.in_moon(ra=ra, dec=dec, time=utime, target_roll=target_roll):
-            return True
-        if self.in_anti_sun(ra=ra, dec=dec, time=utime, target_roll=target_roll):
-            return True
-        if self.in_orbit(ra=ra, dec=dec, time=utime, target_roll=target_roll):
-            return True
-        if self.in_star_tracker_hard(
-            ra=ra, dec=dec, time=utime, target_roll=target_roll, acs_mode=acs_mode
-        ):
-            return True
-        if self.in_star_tracker_soft(
-            ra=ra, dec=dec, time=utime, target_roll=target_roll, acs_mode=acs_mode
-        ):
-            return True
-        if self.in_radiator_hard(ra, dec, utime, target_roll=target_roll):
-            return True
-        if self.in_telescope_hard(ra, dec, utime, target_roll=target_roll):
-            return True
-        return False
+        """For a given time is a RA/Dec in any science or safety constraint?"""
+        return self.in_science_plus_safety_constraint(
+            ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+
+    def science_constraint_name(
+        self,
+        ra: float,
+        dec: float,
+        utime: float,
+        target_roll: float | None = None,
+        acs_mode: ACSMode | int | None = None,
+    ) -> str | None:
+        """Return the first violated science/scheduling constraint name."""
+        return science_attitude_constraint_name(
+            self, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+
+    def safety_constraint_name(
+        self,
+        ra: float,
+        dec: float,
+        utime: float,
+        target_roll: float | None = None,
+        acs_mode: ACSMode | int | None = None,
+    ) -> str | None:
+        """Return the first violated hardware-safety constraint name."""
+        return safety_attitude_constraint_name(
+            self, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+
+    def science_plus_safety_constraint_name(
+        self,
+        ra: float,
+        dec: float,
+        utime: float,
+        target_roll: float | None = None,
+        acs_mode: ACSMode | int | None = None,
+    ) -> str | None:
+        """Return the first violated science or safety constraint name."""
+        return science_plus_safety_attitude_constraint_name(
+            self, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
 
     def instantaneous_field_of_regard(self, utime: float) -> float:
         """Calculate the instantaneous field of regard (FOR) solid angle at a given time.
@@ -565,28 +709,14 @@ class Constraint(ConfigModel):
         )
         return field_of_regard
 
-    def in_constraint_batch(
+    def _in_constraint_batch_for_components(
         self,
         ras: list[float],
         decs: list[float],
         utime: float,
+        constraint_types: list[ConstraintConfig | None],
         target_rolls: list[float] | None = None,
     ) -> np.ndarray:
-        """Check constraints for multiple pointings at a single time.
-
-        Uses batch evaluation via rust_ephem's in_constraint_batch() API,
-        which is much faster than repeated scalar calls for many candidates.
-
-        Args:
-            ras: List of right ascension values in degrees
-            decs: List of declination values in degrees
-            utime: Unix timestamp
-            target_rolls: Optional roll angles in degrees aligned element-wise with
-                ``ras`` and ``decs``
-
-        Returns:
-            Boolean array where True means constraint is violated
-        """
         if not ras:
             return np.zeros(0, dtype=bool)
 
@@ -606,18 +736,6 @@ class Constraint(ConfigModel):
 
         # Check all constraint types and OR the results
         violations: np.ndarray | None = None
-        constraint_types = [
-            self.sun_constraint,
-            self.earth_constraint,
-            self.panel_constraint,
-            self.moon_constraint,
-            self.anti_sun_constraint,
-            self.orbit_constraint,
-            self.star_tracker_hard_constraint,
-            self.star_tracker_soft_constraint,
-            self.radiator_hard_constraint,
-            self.telescope_hard_constraint,
-        ]
         for constraint_func in constraint_types:
             if constraint_func is None:
                 continue
@@ -636,6 +754,341 @@ class Constraint(ConfigModel):
                 violations = violations | result_flat
 
         return violations if violations is not None else np.zeros(len(ras), dtype=bool)
+
+    def in_science_constraint_batch(
+        self,
+        ras: list[float],
+        decs: list[float],
+        utime: float,
+        target_rolls: list[float] | None = None,
+    ) -> np.ndarray:
+        """Check science/scheduling constraints for multiple pointings."""
+        return self._in_constraint_batch_for_components(
+            ras,
+            decs,
+            utime,
+            [
+                self.sun_constraint,
+                self.earth_constraint,
+                self.panel_constraint,
+                self.moon_constraint,
+                self.anti_sun_constraint,
+                self.orbit_constraint,
+                self.star_tracker_soft_constraint,
+                self.science_constraint,
+            ],
+            target_rolls=target_rolls,
+        )
+
+    def in_safety_constraint_batch(
+        self,
+        ras: list[float],
+        decs: list[float],
+        utime: float,
+        target_rolls: list[float] | None = None,
+    ) -> np.ndarray:
+        """Check hardware-safety constraints for multiple pointings."""
+        return self._in_constraint_batch_for_components(
+            ras,
+            decs,
+            utime,
+            [
+                self.safety_constraint,
+                self.star_tracker_hard_constraint,
+                self.radiator_hard_constraint,
+                self.telescope_hard_constraint,
+            ],
+            target_rolls=target_rolls,
+        )
+
+    def in_constraint_batch(
+        self,
+        ras: list[float],
+        decs: list[float],
+        utime: float,
+        target_rolls: list[float] | None = None,
+    ) -> np.ndarray:
+        """Check science-plus-safety constraints for multiple pointings.
+
+        Uses batch evaluation via rust_ephem's in_constraint_batch() API,
+        which is much faster than repeated scalar calls for many candidates.
+        """
+        return self._in_constraint_batch_for_components(
+            ras,
+            decs,
+            utime,
+            [
+                self.sun_constraint,
+                self.earth_constraint,
+                self.panel_constraint,
+                self.moon_constraint,
+                self.anti_sun_constraint,
+                self.orbit_constraint,
+                self.safety_constraint,
+                self.star_tracker_hard_constraint,
+                self.star_tracker_soft_constraint,
+                self.radiator_hard_constraint,
+                self.telescope_hard_constraint,
+                self.science_constraint,
+            ],
+            target_rolls=target_rolls,
+        )
+
+
+def _attitude_policy_value(policy: str | Enum) -> str:
+    if isinstance(policy, Enum):
+        value = policy.value
+        return value if isinstance(value, str) else str(value)
+    return policy
+
+
+def _has_real_constraint_method(constraint: Constraint, method_name: str) -> bool:
+    """Return True for real Constraint methods without triggering Mock attributes."""
+    return hasattr(type(constraint), method_name)
+
+
+def in_science_attitude_constraint(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> bool:
+    """Return True if an attitude violates science/scheduling constraints."""
+    if constraint.in_sun(ra, dec, utime, target_roll=target_roll):
+        return True
+    if constraint.in_earth(ra, dec, utime, target_roll=target_roll):
+        return True
+    if constraint.in_panel(ra, dec, utime, target_roll=target_roll):
+        return True
+    if constraint.in_moon(ra, dec, utime, target_roll=target_roll):
+        return True
+    if constraint.in_anti_sun(ra, dec, utime, target_roll=target_roll):
+        return True
+    if constraint.in_orbit(ra, dec, utime, target_roll=target_roll):
+        return True
+    if constraint.in_star_tracker_soft(
+        ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+    ):
+        return True
+    if _has_real_constraint_method(constraint, "in_explicit_science"):
+        return bool(
+            constraint.in_explicit_science(ra, dec, utime, target_roll=target_roll)
+        )
+    return False
+
+
+def in_safety_attitude_constraint(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> bool:
+    """Return True if an attitude violates hardware-safety constraints."""
+    if _has_real_constraint_method(constraint, "in_explicit_safety"):
+        if constraint.in_explicit_safety(ra, dec, utime, target_roll=target_roll):
+            return True
+    if constraint.in_star_tracker_hard(
+        ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+    ):
+        return True
+    if constraint.in_radiator_hard(ra, dec, utime, target_roll=target_roll):
+        return True
+    if constraint.in_telescope_hard(ra, dec, utime, target_roll=target_roll):
+        return True
+    return False
+
+
+def in_science_plus_safety_attitude_constraint(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> bool:
+    """Return True if either science or safety constraints are violated."""
+    return in_science_attitude_constraint(
+        constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+    ) or in_safety_attitude_constraint(
+        constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+    )
+
+
+def in_attitude_constraint_policy(
+    constraint: Constraint,
+    policy: str | Enum,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> bool:
+    """Return True if an attitude violates the configured policy scope."""
+    policy_value = _attitude_policy_value(policy)
+    if policy_value == _POLICY_NONE:
+        return False
+    if policy_value == _POLICY_FULL_MISSION:
+        return constraint.in_constraint(
+            ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if policy_value == _POLICY_SCIENCE_PLUS_SAFETY:
+        return in_science_plus_safety_attitude_constraint(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if policy_value == _POLICY_SCIENCE:
+        return in_science_attitude_constraint(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if policy_value in {_POLICY_HARD_KEEPOUT, _POLICY_SAFETY}:
+        return in_safety_attitude_constraint(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    raise ValueError(f"Unknown attitude constraint policy: {policy_value!r}")
+
+
+def science_attitude_constraint_name(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> str | None:
+    """Return the first violated science/scheduling constraint name."""
+    if constraint.in_sun(ra, dec, utime, target_roll=target_roll):
+        return "Sun"
+    if constraint.in_earth(ra, dec, utime, target_roll=target_roll):
+        return "Earth Limb"
+    if constraint.in_panel(ra, dec, utime, target_roll=target_roll):
+        return "Panel"
+    if constraint.in_moon(ra, dec, utime, target_roll=target_roll):
+        return "Moon"
+    if constraint.in_anti_sun(ra, dec, utime, target_roll=target_roll):
+        return "Anti-Sun"
+    if constraint.in_orbit(ra, dec, utime, target_roll=target_roll):
+        return "Orbit"
+    if constraint.in_star_tracker_soft(
+        ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+    ):
+        return "ST Soft"
+    if _has_real_constraint_method(constraint, "in_explicit_science"):
+        if constraint.in_explicit_science(ra, dec, utime, target_roll=target_roll):
+            return "Science"
+    return None
+
+
+def safety_attitude_constraint_name(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> str | None:
+    """Return the first violated hardware-safety constraint name."""
+    if _has_real_constraint_method(constraint, "in_explicit_safety"):
+        if constraint.in_explicit_safety(ra, dec, utime, target_roll=target_roll):
+            return "Safety"
+    if constraint.in_star_tracker_hard(
+        ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+    ):
+        return "ST Hard"
+    if constraint.in_radiator_hard(ra, dec, utime, target_roll=target_roll):
+        return "Radiator Hard"
+    if constraint.in_telescope_hard(ra, dec, utime, target_roll=target_roll):
+        return "Telescope Hard"
+    return None
+
+
+def science_plus_safety_attitude_constraint_name(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> str | None:
+    """Return the first violated science or safety constraint name."""
+    return science_attitude_constraint_name(
+        constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+    ) or safety_attitude_constraint_name(
+        constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+    )
+
+
+def attitude_constraint_name_for_policy(
+    constraint: Constraint,
+    policy: str | Enum,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> str | None:
+    """Return the violated constraint name for the configured policy scope."""
+    policy_value = _attitude_policy_value(policy)
+    if policy_value == _POLICY_NONE:
+        return None
+    if policy_value == _POLICY_FULL_MISSION:
+        if not constraint.in_constraint(
+            ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        ):
+            return None
+        return (
+            science_plus_safety_attitude_constraint_name(
+                constraint,
+                ra,
+                dec,
+                utime,
+                target_roll=target_roll,
+                acs_mode=acs_mode,
+            )
+            or "Unknown"
+        )
+    if policy_value == _POLICY_SCIENCE_PLUS_SAFETY:
+        return science_plus_safety_attitude_constraint_name(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if policy_value == _POLICY_SCIENCE:
+        return science_attitude_constraint_name(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if policy_value in {_POLICY_HARD_KEEPOUT, _POLICY_SAFETY}:
+        return safety_attitude_constraint_name(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    raise ValueError(f"Unknown attitude constraint policy: {policy_value!r}")
+
+
+def in_attitude_constraint_policy_batch(
+    constraint: Constraint,
+    policy: str | Enum,
+    ras: list[float],
+    decs: list[float],
+    utime: float,
+    target_rolls: list[float] | None = None,
+) -> np.ndarray:
+    """Check multiple pointings against the configured policy scope."""
+    policy_value = _attitude_policy_value(policy)
+    if policy_value == _POLICY_NONE:
+        return np.zeros(len(ras), dtype=bool)
+    if policy_value in {_POLICY_FULL_MISSION, _POLICY_SCIENCE_PLUS_SAFETY}:
+        if target_rolls is None:
+            return constraint.in_constraint_batch(ras, decs, utime)
+        return constraint.in_constraint_batch(ras, decs, utime, target_rolls)
+    if policy_value == _POLICY_SCIENCE:
+        if target_rolls is None:
+            return constraint.in_science_constraint_batch(ras, decs, utime)
+        return constraint.in_science_constraint_batch(ras, decs, utime, target_rolls)
+    if policy_value in {_POLICY_HARD_KEEPOUT, _POLICY_SAFETY}:
+        if target_rolls is None:
+            return constraint.in_safety_constraint_batch(ras, decs, utime)
+        return constraint.in_safety_constraint_batch(ras, decs, utime, target_rolls)
+    raise ValueError(f"Unknown attitude constraint policy: {policy_value!r}")
 
 
 class DefaultConstraint(Constraint):
@@ -682,6 +1135,10 @@ class DefaultConstraint(Constraint):
         if self.in_earth(ra=ra, dec=dec, time=time, target_roll=target_roll):
             count += 2
         if self.in_panel(ra=ra, dec=dec, time=time, target_roll=target_roll):
+            count += 2
+        if self.in_explicit_science(ra=ra, dec=dec, time=time, target_roll=target_roll):
+            count += 2
+        if self.in_explicit_safety(ra=ra, dec=dec, time=time, target_roll=target_roll):
             count += 2
         if self.in_star_tracker_hard(
             ra=ra, dec=dec, time=time, target_roll=target_roll, acs_mode=acs_mode

--- a/conops/config/constraint.py
+++ b/conops/config/constraint.py
@@ -146,7 +146,12 @@ class Constraint(ConfigModel):
     )
     ground_contact_constraint: ConstraintConfig | None = Field(
         default=None,
-        description="Additional ground-contact attitude constraint",
+        description=(
+            "Keepout constraint applied during ground-contact (PASS) attitudes. "
+            "Violated (returns True) when the pointing direction would interfere "
+            "with ground-station contact, e.g. an Earth-limb or antenna-exclusion "
+            "zone. Included in the 'ground_contact' scope."
+        ),
     )
     star_tracker_hard_constraint: ConstraintConfig | None = Field(
         default=None,
@@ -391,7 +396,11 @@ class Constraint(ConfigModel):
         ]
         components.extend(
             constraint
-            for constraint in (self.science_constraint, self.safety_constraint)
+            for constraint in (
+                self.science_constraint,
+                self.safety_constraint,
+                self.ground_contact_constraint,
+            )
             if constraint is not None
             and not self._boresight_offset_constraints(constraint)
         )
@@ -1504,6 +1513,8 @@ class DefaultConstraint(Constraint):
         if self.in_explicit_science(ra=ra, dec=dec, time=time, target_roll=target_roll):
             count += 2
         if self.in_explicit_safety(ra=ra, dec=dec, time=time, target_roll=target_roll):
+            count += 2
+        if self.in_ground_contact(ra=ra, dec=dec, time=time, target_roll=target_roll):
             count += 2
         if self.in_star_tracker_hard(
             ra=ra, dec=dec, time=time, target_roll=target_roll, acs_mode=acs_mode

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -20,8 +20,9 @@ from ..common.enums import ACSCommandType
 from ..common.vector import attitude_to_quat, quaternion_attitude_distance
 from ..config import DAY_SECONDS, MissionConfig
 from ..config.constraint import (
-    attitude_constraint_name_for_policy,
-    science_plus_safety_attitude_constraint_name,
+    all_attitude_constraint_name,
+    attitude_constraint_name_for_scopes,
+    attitude_constraint_scope_label,
 )
 from ..simulation.acs_command import ACSCommand
 from ..simulation.emergency_charging import EmergencyCharging
@@ -712,7 +713,7 @@ class QueueDITL(DITLMixin, DITLStats):
         )
 
     def _attitude_constraint_mismatch(
-        self, index: int, constraint_name: str, policy: str
+        self, index: int, constraint_name: str, scope_label: str
     ) -> PlanExecutionMismatch:
         mode = self._mode_at_index(index)
         obsid = int(self.obsid[index])
@@ -722,7 +723,7 @@ class QueueDITL(DITLMixin, DITLStats):
             "constraint_violation",
             (
                 f"mode {mode.name if mode is not None else self.mode[index]} "
-                f"obsid {obsid} violates {constraint_name} ({policy}); "
+                f"obsid {obsid} violates {constraint_name} ({scope_label}); "
                 f"ra={float(self.ra[index]):.3f} "
                 f"dec={float(self.dec[index]):.3f} "
                 f"roll={float(self.roll[index]):.3f}"
@@ -735,7 +736,7 @@ class QueueDITL(DITLMixin, DITLStats):
             self.utime[index],
             "attitude",
             "unknown_mode",
-            f"cannot apply constraint policy for mode {self.mode[index]}",
+            f"cannot apply constraint scopes for mode {self.mode[index]}",
             obsid=int(self.obsid[index]),
         )
 
@@ -914,11 +915,11 @@ class QueueDITL(DITLMixin, DITLStats):
         utime: float,
         mode: ACSMode,
     ) -> tuple[str, str] | None:
-        """Return the violated constraint name and policy for one attitude."""
-        policy = self.config.attitude_constraint_policy_for_mode(mode)
-        name = attitude_constraint_name_for_policy(
+        """Return the violated constraint name and scope label for one attitude."""
+        scopes = self.config.attitude_constraint_scopes_for_mode(mode)
+        name = attitude_constraint_name_for_scopes(
             self.constraint,
-            policy,
+            scopes,
             ra,
             dec,
             utime,
@@ -926,13 +927,13 @@ class QueueDITL(DITLMixin, DITLStats):
             acs_mode=mode,
         )
         if name is not None:
-            return name, policy.value
+            return name, attitude_constraint_scope_label(scopes)
         return None
 
     def _attitude_constraint_name_for_sample(
         self, index: int, mode: ACSMode
     ) -> tuple[str, str] | None:
-        """Return the violated constraint name and policy for one recorded sample."""
+        """Return the violated constraint name and scope label for one sample."""
         return self._attitude_constraint_name_for_attitude(
             float(self.ra[index]),
             float(self.dec[index]),
@@ -946,15 +947,8 @@ class QueueDITL(DITLMixin, DITLStats):
 
         Reports telemetry samples where the commanded attitude violated a constraint
         the planner was expected to enforce. The check is gated by each mode's
-        configured AttitudeConstraintPolicy:
-
-        - FULL_MISSION / SCIENCE_PLUS_SAFETY: planner guarantees full constraint
-          compliance; any violation (including safety keepouts) is a scheduling
-          failure and generates a mismatch.
-        - SCIENCE: planner guarantees image-quality / scheduling constraints only.
-        - HARD_KEEPOUT / SAFETY: planner guarantees only instrument-safety
-          keepouts; only safety violations generate a mismatch.
-        - NONE: no attitude constraint is enforced for this mode.
+        configured attitude constraint scopes. An empty scope list disables
+        validation for that mode.
         """
         mismatches: list[PlanExecutionMismatch] = []
         use_cached = len(self._attitude_constraint_violations) == len(self.utime)
@@ -972,9 +966,9 @@ class QueueDITL(DITLMixin, DITLStats):
             if violation is None:
                 continue
 
-            constraint_name, policy = violation
+            constraint_name, scope_label = violation
             mismatches.append(
-                self._attitude_constraint_mismatch(i, constraint_name, policy)
+                self._attitude_constraint_mismatch(i, constraint_name, scope_label)
             )
         return mismatches
 
@@ -1171,12 +1165,12 @@ class QueueDITL(DITLMixin, DITLStats):
             else None
         )
 
-        # Pre-compute policy-scoped attitude constraint violations for
+        # Pre-compute scope-scoped attitude constraint violations for
         # post-simulation validation.
-        policy = self.config.attitude_constraint_policy_for_mode(mode)
-        policy_constraint_name = attitude_constraint_name_for_policy(
+        scopes = self.config.attitude_constraint_scopes_for_mode(mode)
+        scope_constraint_name = attitude_constraint_name_for_scopes(
             self.constraint,
-            policy,
+            scopes,
             ra,
             dec,
             utime,
@@ -1184,8 +1178,8 @@ class QueueDITL(DITLMixin, DITLStats):
             acs_mode=mode,
         )
         _constraint_violation = (
-            (policy_constraint_name, policy.value)
-            if policy_constraint_name is not None
+            (scope_constraint_name, attitude_constraint_scope_label(scopes))
+            if scope_constraint_name is not None
             else None
         )
         self._attitude_constraint_violations.append(_constraint_violation)
@@ -1531,13 +1525,14 @@ class QueueDITL(DITLMixin, DITLStats):
         slew.calc_slewtime()
         violation = self._slew_attitude_constraint_violation(slew, ACSMode.SLEWING)
         if violation is not None:
-            violation_time, constraint_name, policy = violation
+            violation_time, constraint_name, scope_label = violation
             self.log.log_event(
                 utime=utime,
                 event_type="CHARGING",
                 description=(
                     f"Skipping emergency charge slew - path violates "
-                    f"{constraint_name} ({policy}) at {unixtime2date(violation_time)}"
+                    f"{constraint_name} ({scope_label}) at "
+                    f"{unixtime2date(violation_time)}"
                 ),
                 obsid=charging_ppt.obsid,
                 acs_mode=self.acs.acsmode,
@@ -1886,13 +1881,14 @@ class QueueDITL(DITLMixin, DITLStats):
             slew.calc_slewtime()
             violation = self._slew_attitude_constraint_violation(slew, ACSMode.PASS)
             if violation is not None:
-                violation_time, constraint_name, policy = violation
+                violation_time, constraint_name, scope_label = violation
                 self.log.log_event(
                     utime=utime,
                     event_type="PASS",
                     description=(
                         f"Skipping pass slew to {next_pass.station} - path violates "
-                        f"{constraint_name} ({policy}) at {unixtime2date(violation_time)}"
+                        f"{constraint_name} ({scope_label}) at "
+                        f"{unixtime2date(violation_time)}"
                     ),
                     obsid=next_pass.obsid,
                     acs_mode=self.acs.acsmode,
@@ -1956,8 +1952,8 @@ class QueueDITL(DITLMixin, DITLStats):
                 ACSMode.CHARGING,
             )
             if violation is not None:
-                constraint_name, policy = violation
-                constraint_text = f"{constraint_name} ({policy})"
+                constraint_name, scope_label = violation
+                constraint_text = f"{constraint_name} ({scope_label})"
                 self.log.log_event(
                     utime=utime,
                     event_type="CHARGING",
@@ -1988,23 +1984,19 @@ class QueueDITL(DITLMixin, DITLStats):
         """Check if PPT should terminate due to constraints, completion, or timeout."""
         assert self.ppt is not None
 
-        if self.constraint.in_constraint(
+        violation = self._attitude_constraint_name_for_attitude(
             self.ppt.ra,
             self.ppt.dec,
+            self.acs.roll,
             utime,
-            target_roll=self.acs.roll,
-            acs_mode=ACSMode.SCIENCE,
-        ):
-            constraint_name = self._get_constraint_name(
-                self.ppt.ra,
-                self.ppt.dec,
-                utime,
-                roll=self.acs.roll,
-                mode=ACSMode.SCIENCE,
-            )
+            ACSMode.SCIENCE,
+        )
+        if violation is not None:
+            constraint_name, scope_label = violation
+            constraint_text = f"{constraint_name} ({scope_label})"
             self._terminate_ppt(
                 utime,
-                reason=f"Target {constraint_name} constrained, ending observation",
+                reason=f"Target {constraint_text} constrained, ending observation",
             )
         elif self.ppt.exptime is None or self.ppt.exptime <= 0:
             self._terminate_ppt(
@@ -2012,6 +2004,42 @@ class QueueDITL(DITLMixin, DITLStats):
             )
         elif utime >= self.ppt.end:
             self._terminate_ppt(utime, reason="Time window elapsed, ending observation")
+
+    def _constraint_name_for_science_attitude(
+        self,
+        ra: float,
+        dec: float,
+        roll: float,
+        utime: float,
+    ) -> tuple[str, str] | None:
+        return self._attitude_constraint_name_for_attitude(
+            ra, dec, roll, utime, ACSMode.SCIENCE
+        )
+
+    def _check_locked_roll_window(
+        self,
+        obs_start_time: float,
+        obs_val_end: float,
+        target_roll: float,
+    ) -> tuple[float, str, str] | None:
+        assert self.ppt is not None
+        ephem = self.acs.ephem
+        begin_idx = max(0, ephem.index(dtutcfromtimestamp(obs_start_time)))
+        end_idx = min(
+            len(ephem.timestamp), ephem.index(dtutcfromtimestamp(obs_val_end)) + 1
+        )
+        for t in ephem.timestamp[begin_idx:end_idx]:
+            t_unix = t.timestamp() if hasattr(t, "timestamp") else float(t)
+            violation = self._constraint_name_for_science_attitude(
+                self.ppt.ra,
+                self.ppt.dec,
+                target_roll,
+                t_unix,
+            )
+            if violation is not None:
+                constraint_name, scope_label = violation
+                return t_unix, constraint_name, scope_label
+        return None
 
     def _terminate_ppt(
         self, utime: float, reason: str, mark_done: bool = False
@@ -2065,7 +2093,7 @@ class QueueDITL(DITLMixin, DITLStats):
         with the one that actually triggered termination.
         """
         return (
-            science_plus_safety_attitude_constraint_name(
+            all_attitude_constraint_name(
                 self.constraint,
                 ra,
                 dec,
@@ -2096,7 +2124,7 @@ class QueueDITL(DITLMixin, DITLStats):
     def _slew_attitude_constraint_violation(
         self, slew: Slew, mode: ACSMode
     ) -> tuple[float, str, str] | None:
-        """Return first policy violation along a planned slew path, if any."""
+        """Return first scoped violation along a planned slew path, if any."""
         if slew.slewtime <= 0:
             return None
 
@@ -2116,8 +2144,8 @@ class QueueDITL(DITLMixin, DITLStats):
                 mode,
             )
             if violation is not None:
-                constraint_name, policy = violation
-                return sample_utime, constraint_name, policy
+                constraint_name, scope_label = violation
+                return sample_utime, constraint_name, scope_label
 
         return None
 
@@ -2519,13 +2547,14 @@ class QueueDITL(DITLMixin, DITLStats):
             self._complete_ppt_slew(slew, self.ppt, utime, execution_time)
             violation = self._slew_attitude_constraint_violation(slew, ACSMode.SLEWING)
             if violation is not None:
-                violation_time, constraint_name, policy = violation
+                violation_time, constraint_name, scope_label = violation
                 self.log.log_event(
                     utime=utime,
                     event_type="QUEUE",
                     description=(
                         f"Target {self.ppt.obsid} skipped - slew path violates "
-                        f"{constraint_name} ({policy}) at {unixtime2date(violation_time)}"
+                        f"{constraint_name} ({scope_label}) at "
+                        f"{unixtime2date(violation_time)}"
                     ),
                     obsid=self.ppt.obsid,
                     acs_mode=self.acs.acsmode,
@@ -2546,32 +2575,27 @@ class QueueDITL(DITLMixin, DITLStats):
                 else float(ephem.timestamp[-1])
             )
             obs_val_end = min(obs_start_time + self.ppt.ss_min, ephem_end)
-            begin_idx = max(0, ephem.index(dtutcfromtimestamp(obs_start_time)))
-            end_idx = min(
-                len(ephem.timestamp), ephem.index(dtutcfromtimestamp(obs_val_end)) + 1
+            violation = self._check_locked_roll_window(
+                obs_start_time,
+                obs_val_end,
+                slew.endroll,
             )
-            for t in ephem.timestamp[begin_idx:end_idx]:
-                t_unix = t.timestamp() if hasattr(t, "timestamp") else float(t)
-                if self.constraint.in_constraint(
-                    self.ppt.ra,
-                    self.ppt.dec,
-                    t_unix,
-                    target_roll=slew.endroll,
-                    acs_mode=ACSMode.SCIENCE,
-                ):
-                    self.log.log_event(
-                        utime=utime,
-                        event_type="QUEUE",
-                        description=(
-                            f"Target {self.ppt.obsid} skipped — locked roll "
-                            f"{slew.endroll:.1f}° violates constraint "
-                            f"within minimum observation window (at t+{t_unix - obs_start_time:.0f}s)"
-                        ),
-                        obsid=self.ppt.obsid,
-                        acs_mode=self.acs.acsmode,
-                    )
-                    self._retry_fetch_without_current_ppt(utime, ra, dec)
-                    return
+            if violation is not None:
+                t_unix, constraint_name, scope_label = violation
+                self.log.log_event(
+                    utime=utime,
+                    event_type="QUEUE",
+                    description=(
+                        f"Target {self.ppt.obsid} skipped — locked roll "
+                        f"{slew.endroll:.1f}° violates {constraint_name} "
+                        f"({scope_label}) within minimum observation window "
+                        f"(at t+{t_unix - obs_start_time:.0f}s)"
+                    ),
+                    obsid=self.ppt.obsid,
+                    acs_mode=self.acs.acsmode,
+                )
+                self._retry_fetch_without_current_ppt(utime, ra, dec)
+                return
 
             # Verify slew won't overlap with a pass - check both start and end
             slew_end = execution_time + slew.slewtime

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -18,7 +18,11 @@ from ..common import (
 )
 from ..common.enums import ACSCommandType
 from ..common.vector import attitude_to_quat, quaternion_attitude_distance
-from ..config import DAY_SECONDS, AttitudeConstraintPolicy, MissionConfig
+from ..config import DAY_SECONDS, MissionConfig
+from ..config.constraint import (
+    attitude_constraint_name_for_policy,
+    science_plus_safety_attitude_constraint_name,
+)
 from ..simulation.acs_command import ACSCommand
 from ..simulation.emergency_charging import EmergencyCharging
 from ..simulation.passes import Pass, pass_slew_trigger_buffer
@@ -902,24 +906,6 @@ class QueueDITL(DITLMixin, DITLStats):
             for start, end, dropped_obsid in self._dropped_science_windows
         )
 
-    def _hard_attitude_constraint_name(
-        self,
-        ra: float,
-        dec: float,
-        utime: float,
-        roll: float,
-        mode: ACSMode,
-    ) -> str | None:
-        if self.constraint.in_star_tracker_hard(
-            ra, dec, utime, target_roll=roll, acs_mode=mode
-        ):
-            return "ST Hard"
-        if self.constraint.in_radiator_hard(ra, dec, utime, target_roll=roll):
-            return "Radiator Hard"
-        if self.constraint.in_telescope_hard(ra, dec, utime, target_roll=roll):
-            return "Telescope Hard"
-        return None
-
     def _attitude_constraint_name_for_attitude(
         self,
         ra: float,
@@ -930,21 +916,17 @@ class QueueDITL(DITLMixin, DITLStats):
     ) -> tuple[str, str] | None:
         """Return the violated constraint name and policy for one attitude."""
         policy = self.config.attitude_constraint_policy_for_mode(mode)
-        if policy == AttitudeConstraintPolicy.NONE:
-            return None
-        if policy == AttitudeConstraintPolicy.FULL_MISSION:
-            if self.constraint.in_constraint(
-                ra, dec, utime, target_roll=roll, acs_mode=mode
-            ):
-                return (
-                    self._get_constraint_name(ra, dec, utime, roll=roll, mode=mode),
-                    policy.value,
-                )
-            return None
-        if policy == AttitudeConstraintPolicy.HARD_KEEPOUT:
-            name = self._hard_attitude_constraint_name(ra, dec, utime, roll, mode)
-            if name is not None:
-                return name, policy.value
+        name = attitude_constraint_name_for_policy(
+            self.constraint,
+            policy,
+            ra,
+            dec,
+            utime,
+            target_roll=roll,
+            acs_mode=mode,
+        )
+        if name is not None:
+            return name, policy.value
         return None
 
     def _attitude_constraint_name_for_sample(
@@ -966,10 +948,12 @@ class QueueDITL(DITLMixin, DITLStats):
         the planner was expected to enforce. The check is gated by each mode's
         configured AttitudeConstraintPolicy:
 
-        - FULL_MISSION: planner guarantees full constraint compliance; any violation
-          (including hard keepouts) is a scheduling failure and generates a mismatch.
-        - HARD_KEEPOUT: planner guarantees only instrument-safety keepouts; only
-          hard keepout violations generate a mismatch.
+        - FULL_MISSION / SCIENCE_PLUS_SAFETY: planner guarantees full constraint
+          compliance; any violation (including safety keepouts) is a scheduling
+          failure and generates a mismatch.
+        - SCIENCE: planner guarantees image-quality / scheduling constraints only.
+        - HARD_KEEPOUT / SAFETY: planner guarantees only instrument-safety
+          keepouts; only safety violations generate a mismatch.
         - NONE: no attitude constraint is enforced for this mode.
         """
         mismatches: list[PlanExecutionMismatch] = []
@@ -1187,23 +1171,23 @@ class QueueDITL(DITLMixin, DITLStats):
             else None
         )
 
-        # Pre-compute attitude constraint violation for post-sim validation, reusing
-        # the already-computed violated/in_constraint_name for FULL_MISSION modes so
-        # _validate_attitude_constraints does not need to re-call in_constraint().
+        # Pre-compute policy-scoped attitude constraint violations for
+        # post-simulation validation.
         policy = self.config.attitude_constraint_policy_for_mode(mode)
-        if policy == AttitudeConstraintPolicy.NONE:
-            _constraint_violation: tuple[str, str] | None = None
-        elif policy == AttitudeConstraintPolicy.FULL_MISSION:
-            _constraint_violation = (
-                (in_constraint_name or "Unknown", policy.value) if violated else None
-            )
-        elif policy == AttitudeConstraintPolicy.HARD_KEEPOUT:
-            hard_name = self._hard_attitude_constraint_name(ra, dec, utime, roll, mode)
-            _constraint_violation = (
-                (hard_name, policy.value) if hard_name is not None else None
-            )
-        else:
-            _constraint_violation = None
+        policy_constraint_name = attitude_constraint_name_for_policy(
+            self.constraint,
+            policy,
+            ra,
+            dec,
+            utime,
+            target_roll=roll,
+            acs_mode=mode,
+        )
+        _constraint_violation = (
+            (policy_constraint_name, policy.value)
+            if policy_constraint_name is not None
+            else None
+        )
         self._attitude_constraint_violations.append(_constraint_violation)
 
         ei = self.ephem.index(dtutcfromtimestamp(utime))
@@ -1964,24 +1948,20 @@ class QueueDITL(DITLMixin, DITLStats):
         # Handle charging PPT constraint checks (regardless of mode)
         if self.ppt == self.charging_ppt:
             # Check constraints for charging PPT even if mode hasn't transitioned yet
-            if self.constraint.in_constraint(
+            violation = self._attitude_constraint_name_for_attitude(
                 self.ppt.ra,
                 self.ppt.dec,
+                self.acs.roll,
                 utime,
-                target_roll=self.acs.roll,
-                acs_mode=ACSMode.CHARGING,
-            ):
-                constraint_name = self._get_constraint_name(
-                    self.ppt.ra,
-                    self.ppt.dec,
-                    utime,
-                    roll=self.acs.roll,
-                    mode=ACSMode.CHARGING,
-                )
+                ACSMode.CHARGING,
+            )
+            if violation is not None:
+                constraint_name, policy = violation
+                constraint_text = f"{constraint_name} ({policy})"
                 self.log.log_event(
                     utime=utime,
                     event_type="CHARGING",
-                    description=f"Charging PPT {constraint_name} constrained, terminating",
+                    description=f"Charging PPT {constraint_text} constrained, terminating",
                     obsid=self.ppt.obsid,
                     acs_mode=self.acs.acsmode,
                 )
@@ -2084,31 +2064,17 @@ class QueueDITL(DITLMixin, DITLStats):
         constraints are simultaneously active the reported name is consistent
         with the one that actually triggered termination.
         """
-        if self.constraint.in_sun(ra, dec, utime, target_roll=roll):
-            return "Sun"
-        elif self.constraint.in_earth(ra, dec, utime, target_roll=roll):
-            return "Earth Limb"
-        elif self.constraint.in_panel(ra, dec, utime, target_roll=roll):
-            return "Panel"
-        elif self.constraint.in_moon(ra, dec, utime, target_roll=roll):
-            return "Moon"
-        elif self.constraint.in_anti_sun(ra, dec, utime, target_roll=roll):
-            return "Anti-Sun"
-        elif self.constraint.in_orbit(ra, dec, utime, target_roll=roll):
-            return "Orbit"
-        elif self.constraint.in_star_tracker_hard(
-            ra, dec, utime, target_roll=roll, acs_mode=mode
-        ):
-            return "ST Hard"
-        elif self.constraint.in_star_tracker_soft(
-            ra, dec, utime, target_roll=roll, acs_mode=mode
-        ):
-            return "ST Soft"
-        elif self.constraint.in_radiator_hard(ra, dec, utime, target_roll=roll):
-            return "Radiator Hard"
-        elif self.constraint.in_telescope_hard(ra, dec, utime, target_roll=roll):
-            return "Telescope Hard"
-        return "Unknown"
+        return (
+            science_plus_safety_attitude_constraint_name(
+                self.constraint,
+                ra,
+                dec,
+                utime,
+                target_roll=roll,
+                acs_mode=mode,
+            )
+            or "Unknown"
+        )
 
     def _simulation_end_deadline(self) -> float:
         """Return the Unix timestamp for the end of the simulation."""

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -12,6 +12,7 @@ from ..common import (
 )
 from ..common.vector import angular_separation
 from ..config import AttitudeConstraintPolicy, FaultEvent, MissionConfig
+from ..config.constraint import in_attitude_constraint_policy
 from ..simulation.passes import PassTimes
 from ..simulation.roll import optimum_roll
 from .acs_command import ACSCommand
@@ -770,31 +771,21 @@ class ACS:
         "should the ACS repoint to protect hardware?" not "did the planner break a
         scheduling contract?"
 
-        FULL_MISSION checks every mission constraint (used when science-quality idle
-        holds are required). Any other configured policy uses hard keepouts as the
-        minimum safety floor — the instrument-protection limits that must not be
-        sustained regardless of mission phase. NONE skips all checking.
+        FULL_MISSION preserves the legacy combined constraint check.
+        SCIENCE_PLUS_SAFETY checks both scoped constraint groups. SCIENCE checks
+        only image-quality constraints. SAFETY and HARD_KEEPOUT check only the
+        hardware-protection limits that must not be sustained regardless of
+        mission phase. NONE skips all checking.
         """
-        if policy == AttitudeConstraintPolicy.FULL_MISSION:
-            return self.constraint.in_constraint(
-                ra, dec, utime, target_roll=roll, acs_mode=ACSMode.IDLE
-            )
-        if policy == AttitudeConstraintPolicy.NONE:
-            return False
-        return self._idle_attitude_violates_hard_keepout(ra, dec, roll, utime)
-
-    def _idle_attitude_violates_hard_keepout(
-        self, ra: float, dec: float, roll: float, utime: float
-    ) -> bool:
-        if self.constraint.in_star_tracker_hard(
-            ra, dec, utime, target_roll=roll, acs_mode=ACSMode.IDLE
-        ):
-            return True
-        if self.constraint.in_radiator_hard(ra, dec, utime, target_roll=roll):
-            return True
-        if self.constraint.in_telescope_hard(ra, dec, utime, target_roll=roll):
-            return True
-        return False
+        return in_attitude_constraint_policy(
+            self.constraint,
+            policy,
+            ra,
+            dec,
+            utime,
+            target_roll=roll,
+            acs_mode=ACSMode.IDLE,
+        )
 
     @staticmethod
     def _idle_safe_roll_candidates(optimal_roll: float) -> list[float]:

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -11,8 +11,11 @@ from ..common import (
     unixtime2yearday,
 )
 from ..common.vector import angular_separation
-from ..config import AttitudeConstraintPolicy, FaultEvent, MissionConfig
-from ..config.constraint import in_attitude_constraint_policy
+from ..config import AttitudeConstraintScope, FaultEvent, MissionConfig
+from ..config.constraint import (
+    attitude_constraint_scope_label,
+    in_attitude_constraint_scopes,
+)
 from ..simulation.passes import PassTimes
 from ..simulation.roll import optimum_roll
 from .acs_command import ACSCommand
@@ -583,7 +586,7 @@ class ACS:
 
         # Idle is an executed attitude, not a constraint-free gap. If a completed
         # observation is being held after science ends, move the hold to an
-        # attitude that satisfies the configured IDLE policy before recording.
+        # attitude that satisfies the configured IDLE scopes before recording.
         self._enforce_idle_constraint_safe_attitude(utime)
 
         # Check current constraints (must run after roll is updated)
@@ -679,24 +682,25 @@ class ACS:
         )
 
     def _enforce_idle_constraint_safe_attitude(self, utime: float) -> None:
-        """Replace unsafe idle holds with an attitude that satisfies IDLE policy."""
+        """Replace unsafe idle holds with an attitude that satisfies IDLE scopes."""
         if self.acsmode != ACSMode.IDLE:
             return
         if self.current_pass is not None or self.in_safe_mode:
             return
 
-        policy = self._idle_attitude_policy()
-        if policy == AttitudeConstraintPolicy.NONE:
+        scopes = self._idle_attitude_scopes()
+        if not scopes:
             return
 
-        if not self._idle_attitude_unsafe(self.ra, self.dec, self.roll, utime, policy):
+        if not self._idle_attitude_unsafe(self.ra, self.dec, self.roll, utime, scopes):
             return
 
-        safe_attitude = self._find_constraint_safe_idle_attitude(utime, policy)
+        safe_attitude = self._find_constraint_safe_idle_attitude(utime, scopes)
         if safe_attitude is None:
+            scope_label = attitude_constraint_scope_label(scopes)
             cause = (
                 "No constraint-safe IDLE attitude found "
-                f"(RA={self.ra:.2f} Dec={self.dec:.2f} policy={policy.value}); "
+                f"(RA={self.ra:.2f} Dec={self.dec:.2f} scopes={scope_label}); "
                 "requesting safe mode"
             )
             self._log_or_print(utime, "ERROR", f"{unixtime2date(utime)}: {cause}")
@@ -711,7 +715,7 @@ class ACS:
                         metadata={
                             "ra": self.ra,
                             "dec": self.dec,
-                            "policy": policy.value,
+                            "scopes": scope_label,
                         },
                     )
                 )
@@ -728,9 +732,9 @@ class ACS:
         )
 
     def _find_constraint_safe_idle_attitude(
-        self, utime: float, policy: AttitudeConstraintPolicy
+        self, utime: float, scopes: list[AttitudeConstraintScope]
     ) -> tuple[float, float, float] | None:
-        """Find a deterministic nearby attitude that satisfies IDLE policy."""
+        """Find a deterministic nearby attitude that satisfies IDLE scopes."""
         candidates = self._idle_safe_attitude_candidates(utime)
         for candidate_ra, candidate_dec in candidates:
             optimal_roll = optimum_roll(
@@ -747,15 +751,13 @@ class ACS:
                     candidate_dec,
                     candidate_roll,
                     utime,
-                    policy,
+                    scopes,
                 ):
                     return candidate_ra, candidate_dec, candidate_roll
         return None
 
-    def _idle_attitude_policy(self) -> AttitudeConstraintPolicy:
-        return AttitudeConstraintPolicy(
-            self.config.attitude_constraint_policy_for_mode(ACSMode.IDLE)
-        )
+    def _idle_attitude_scopes(self) -> list[AttitudeConstraintScope]:
+        return self.config.attitude_constraint_scopes_for_mode(ACSMode.IDLE)
 
     def _idle_attitude_unsafe(
         self,
@@ -763,7 +765,7 @@ class ACS:
         dec: float,
         roll: float,
         utime: float,
-        policy: AttitudeConstraintPolicy,
+        scopes: list[AttitudeConstraintScope],
     ) -> bool:
         """Runtime instrument-safety check for idle holds.
 
@@ -771,15 +773,12 @@ class ACS:
         "should the ACS repoint to protect hardware?" not "did the planner break a
         scheduling contract?"
 
-        FULL_MISSION preserves the legacy combined constraint check.
-        SCIENCE_PLUS_SAFETY checks both scoped constraint groups. SCIENCE checks
-        only image-quality constraints. SAFETY and HARD_KEEPOUT check only the
-        hardware-protection limits that must not be sustained regardless of
-        mission phase. NONE skips all checking.
+        The configured IDLE scopes describe the attitude constraints that must
+        not be sustained while idle. An empty list skips this check.
         """
-        return in_attitude_constraint_policy(
+        return in_attitude_constraint_scopes(
             self.constraint,
-            policy,
+            scopes,
             ra,
             dec,
             utime,

--- a/conops/simulation/emergency_charging.py
+++ b/conops/simulation/emergency_charging.py
@@ -12,10 +12,10 @@ from conops.config.battery import Battery
 from ..common import unixtime2date
 from ..common.enums import ACSMode, ObsType
 from ..common.vector import angular_separation
-from ..config import AttitudeConstraintPolicy, MissionConfig
+from ..config import AttitudeConstraintScope, MissionConfig
 from ..config.constraint import (
-    in_attitude_constraint_policy,
-    in_attitude_constraint_policy_batch,
+    in_attitude_constraint_scopes,
+    in_attitude_constraint_scopes_batch,
 )
 from .roll import optimum_roll
 
@@ -99,17 +99,15 @@ class EmergencyCharging:
         else:
             print(f"{unixtime2date(utime)} {description}")
 
-    def _charging_policy(self) -> AttitudeConstraintPolicy:
-        return AttitudeConstraintPolicy(
-            self.config.attitude_constraint_policy_for_mode(ACSMode.CHARGING)
-        )
+    def _charging_scopes(self) -> list[AttitudeConstraintScope]:
+        return self.config.attitude_constraint_scopes_for_mode(ACSMode.CHARGING)
 
-    def _charging_attitude_violates_policy(
+    def _charging_attitude_violates_scopes(
         self, ra: float, dec: float, utime: float, roll: float | None = None
     ) -> bool:
-        return in_attitude_constraint_policy(
+        return in_attitude_constraint_scopes(
             self.constraint,
-            self._charging_policy(),
+            self._charging_scopes(),
             ra,
             dec,
             utime,
@@ -120,8 +118,8 @@ class EmergencyCharging:
     def _charging_candidate_violations(
         self, ras: list[float], decs: list[float], utime: float
     ) -> np.ndarray:
-        return in_attitude_constraint_policy_batch(
-            self.constraint, self._charging_policy(), ras, decs, utime
+        return in_attitude_constraint_scopes_batch(
+            self.constraint, self._charging_scopes(), ras, decs, utime
         )
 
     def create_charging_pointing(
@@ -273,7 +271,7 @@ class EmergencyCharging:
         optimal_roll = optimum_roll(
             optimal_ra, optimal_dec, utime, ephem, self.solar_panel, self.constraint
         )
-        if not self._charging_attitude_violates_policy(
+        if not self._charging_attitude_violates_scopes(
             optimal_ra, optimal_dec, utime, roll=optimal_roll
         ):
             # Optimal pointing satisfies constraints; now check slew limits
@@ -612,7 +610,7 @@ class EmergencyCharging:
             return "battery_recharged"
 
         # Constraint violation (e.g., occultation)
-        if self._charging_attitude_violates_policy(
+        if self._charging_attitude_violates_scopes(
             self.current_charging_ppt.ra,
             self.current_charging_ppt.dec,
             utime,

--- a/conops/simulation/emergency_charging.py
+++ b/conops/simulation/emergency_charging.py
@@ -12,7 +12,11 @@ from conops.config.battery import Battery
 from ..common import unixtime2date
 from ..common.enums import ACSMode, ObsType
 from ..common.vector import angular_separation
-from ..config import MissionConfig
+from ..config import AttitudeConstraintPolicy, MissionConfig
+from ..config.constraint import (
+    in_attitude_constraint_policy,
+    in_attitude_constraint_policy_batch,
+)
 from .roll import optimum_roll
 
 if TYPE_CHECKING:
@@ -94,6 +98,31 @@ class EmergencyCharging:
             )
         else:
             print(f"{unixtime2date(utime)} {description}")
+
+    def _charging_policy(self) -> AttitudeConstraintPolicy:
+        return AttitudeConstraintPolicy(
+            self.config.attitude_constraint_policy_for_mode(ACSMode.CHARGING)
+        )
+
+    def _charging_attitude_violates_policy(
+        self, ra: float, dec: float, utime: float, roll: float | None = None
+    ) -> bool:
+        return in_attitude_constraint_policy(
+            self.constraint,
+            self._charging_policy(),
+            ra,
+            dec,
+            utime,
+            target_roll=roll,
+            acs_mode=ACSMode.CHARGING,
+        )
+
+    def _charging_candidate_violations(
+        self, ras: list[float], decs: list[float], utime: float
+    ) -> np.ndarray:
+        return in_attitude_constraint_policy_batch(
+            self.constraint, self._charging_policy(), ras, decs, utime
+        )
 
     def create_charging_pointing(
         self,
@@ -244,8 +273,8 @@ class EmergencyCharging:
         optimal_roll = optimum_roll(
             optimal_ra, optimal_dec, utime, ephem, self.solar_panel, self.constraint
         )
-        if not self.constraint.in_constraint(
-            optimal_ra, optimal_dec, utime, target_roll=optimal_roll
+        if not self._charging_attitude_violates_policy(
+            optimal_ra, optimal_dec, utime, roll=optimal_roll
         ):
             # Optimal pointing satisfies constraints; now check slew limits
             if self.max_slew_deg is not None:
@@ -319,7 +348,7 @@ class EmergencyCharging:
         # Batch-check all constraints at once
         candidate_ras = [ra for ra, dec in candidates]
         candidate_decs = [dec for ra, dec in candidates]
-        violations = self.constraint.in_constraint_batch(
+        violations = self._charging_candidate_violations(
             candidate_ras, candidate_decs, utime
         )
 
@@ -460,7 +489,7 @@ class EmergencyCharging:
         # Batch-check all constraints at once
         candidate_ras = [ra for ra, dec in candidates]
         candidate_decs = [dec for ra, dec in candidates]
-        violations = self.constraint.in_constraint_batch(
+        violations = self._charging_candidate_violations(
             candidate_ras, candidate_decs, utime
         )
 
@@ -583,12 +612,11 @@ class EmergencyCharging:
             return "battery_recharged"
 
         # Constraint violation (e.g., occultation)
-        if self.constraint.in_constraint(
+        if self._charging_attitude_violates_policy(
             self.current_charging_ppt.ra,
             self.current_charging_ppt.dec,
             utime,
-            target_roll=self.current_charging_ppt.roll,
-            acs_mode=ACSMode.CHARGING,
+            roll=self.current_charging_ppt.roll,
         ):
             return "constraint"
 

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -18,13 +18,12 @@ from ..common.vector import (
     vec2radec,
 )
 from ..config import (
-    AttitudeConstraintPolicy,
     Constraint,
     GroundStationRegistry,
     MissionConfig,
 )
 from ..config.constants import DTOR
-from ..config.constraint import in_attitude_constraint_policy
+from ..config.constraint import in_attitude_constraint_scopes
 from .slew import Slew
 
 # Legacy ground-pass roll for profiles without explicit roll samples.
@@ -544,16 +543,13 @@ class PassTimes:
         boresight = antenna.fixed_boresight_body
         return (float(boresight[0]), float(boresight[1]), float(boresight[2]))
 
-    def _pass_attitude_violates_policy(
+    def _pass_attitude_violates_scopes(
         self, ra: float, dec: float, roll: float, utime: float
     ) -> bool:
-        policy = AttitudeConstraintPolicy(
-            self.config.attitude_constraint_policy_for_mode(ACSMode.PASS)
-        )
         return bool(
-            in_attitude_constraint_policy(
+            in_attitude_constraint_scopes(
                 self.constraint,
-                policy,
+                self.config.attitude_constraint_scopes_for_mode(ACSMode.PASS),
                 ra,
                 dec,
                 utime,
@@ -562,7 +558,7 @@ class PassTimes:
             )
         )
 
-    def _pass_profile_violates_policy(
+    def _pass_profile_violates_scopes(
         self,
         utimes: list[float],
         track_ra: list[float],
@@ -570,7 +566,7 @@ class PassTimes:
         track_roll: list[float],
     ) -> bool:
         return any(
-            self._pass_attitude_violates_policy(ra, dec, roll, utime)
+            self._pass_attitude_violates_scopes(ra, dec, roll, utime)
             for utime, ra, dec, roll in zip(
                 utimes, track_ra, track_dec, track_roll, strict=True
             )
@@ -628,7 +624,7 @@ class PassTimes:
             track_ra = [attitude[0] for attitude in attitude_profile]
             track_dec = [attitude[1] for attitude in attitude_profile]
             track_roll = [attitude[2] for attitude in attitude_profile]
-            if not self._pass_profile_violates_policy(
+            if not self._pass_profile_violates_scopes(
                 track_utime, track_ra, track_dec, track_roll
             ):
                 return attitude_profile, True
@@ -653,7 +649,7 @@ class PassTimes:
                 if attitude_profile is None:
                     continue
                 attitude = attitude_profile[0]
-                if not self._pass_attitude_violates_policy(*attitude, utime):
+                if not self._pass_attitude_violates_scopes(*attitude, utime):
                     sample_attitudes[phase_deg] = attitude
             if not sample_attitudes:
                 return None

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -24,6 +24,7 @@ from ..config import (
     MissionConfig,
 )
 from ..config.constants import DTOR
+from ..config.constraint import in_attitude_constraint_policy
 from .slew import Slew
 
 # Legacy ground-pass roll for profiles without explicit roll samples.
@@ -549,23 +550,17 @@ class PassTimes:
         policy = AttitudeConstraintPolicy(
             self.config.attitude_constraint_policy_for_mode(ACSMode.PASS)
         )
-        if policy == AttitudeConstraintPolicy.NONE:
-            return False
-        if policy == AttitudeConstraintPolicy.FULL_MISSION:
-            return bool(
-                self.constraint.in_constraint(
-                    ra, dec, utime, target_roll=roll, acs_mode=ACSMode.PASS
-                )
+        return bool(
+            in_attitude_constraint_policy(
+                self.constraint,
+                policy,
+                ra,
+                dec,
+                utime,
+                target_roll=roll,
+                acs_mode=ACSMode.PASS,
             )
-        if policy == AttitudeConstraintPolicy.HARD_KEEPOUT:
-            return bool(
-                self.constraint.in_star_tracker_hard(
-                    ra, dec, utime, target_roll=roll, acs_mode=ACSMode.PASS
-                )
-                or self.constraint.in_radiator_hard(ra, dec, utime, target_roll=roll)
-                or self.constraint.in_telescope_hard(ra, dec, utime, target_roll=roll)
-            )
-        return False
+        )
 
     def _pass_profile_violates_policy(
         self,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -155,7 +155,7 @@ Example:
 
    config = MissionConfig(name="Reproducible Run", random_seed=42)
 
-attitude_constraint_policy
+attitude_constraint_scopes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Controls which constraints are checked against the executed attitude timeline during
@@ -163,7 +163,7 @@ post-run plan validation.
 
 .. code-block:: python
 
-   attitude_constraint_policy: dict[str, AttitudeConstraintPolicy] = <mode-specific defaults>
+   attitude_constraint_scopes: dict[str, list[AttitudeConstraintScope]] = <mode-specific defaults>
 
 **Background**
 
@@ -176,10 +176,10 @@ Not all modes are held to the same standard.  During ``SCIENCE`` mode a pointing
 violation is unambiguously a simulation bug.  During ``SLEWING`` the spacecraft is
 actively rotating between targets and may briefly sweep through a soft-constraint zone
 by design — flagging that as an error would produce false positives.  The
-``attitude_constraint_policy`` map lets you express, per ACS mode, exactly how strict
-you want that check to be.
+``attitude_constraint_scopes`` map lets you express, per ACS mode, which categories
+of attitude constraints the planner is expected to enforce.
 
-If any sample fails its policy check, a
+If any sample fails its configured scope check, a
 :class:`~conops.ditl.queue_ditl.PlanExecutionMismatch` is recorded and
 :meth:`~conops.ditl.queue_ditl.QueueDITL.run` raises
 :exc:`~conops.ditl.queue_ditl.PlanExecutionMismatchError` before returning.  The error
@@ -188,7 +188,7 @@ name — to aid debugging.
 
 **Planner admission guarantees vs. FM-monitored runtime conditions**
 
-Not every constraint violation is a scheduling failure. The policy per mode encodes
+Not every constraint violation is a scheduling failure. The scopes per mode encode
 which violations the planner claims to prevent, and therefore which post-simulation
 telemetry samples should be reported as planning mismatches. Fault Management still
 monitors configured telemetry thresholds at runtime.
@@ -197,22 +197,16 @@ monitors configured telemetry thresholds at runtime.
   ``in_constraint()`` before accepting an attitude into the plan.  If telemetry shows
   a violation in one of these modes, the planner broke its contract and the simulation
   records a :class:`~conops.ditl.queue_ditl.PlanExecutionMismatch`.  This covers the
-  complete mission constraint set: Sun, Moon, Earth limb, solar-panel illumination,
-  star-tracker hard and soft, radiator hard, and telescope hard.
+  configured scopes for that mode.
 
 * **FM-monitored runtime condition** — a violation outside the selected validation
-  policy (for example, a science-quality soft constraint while a mode is configured
-  with ``hard_keepout``). The simulation's Fault Management system dispatches a
+  scopes (for example, an imaging-quality constraint while a mode is configured only
+  with ``hardware_safety``). The simulation's Fault Management system dispatches a
   :class:`~conops.config.fault_management.FaultEvent` in real time when a configured
   threshold is crossed; the post-simulation validator does not raise a mismatch for
-  violations outside the mode's policy contract.
+  violations outside the mode's scoped contract.
 
-The default policy is ``full_mission`` for every ACS mode. A mission may explicitly
-configure ``hard_keepout`` for modes where only hardware keepouts are planning
-requirements; hard keepout violations are still validation mismatches in those modes,
-while broader mission constraints are left to runtime telemetry/FM monitoring.
-
-**Policy values** (:class:`~conops.config.AttitudeConstraintPolicy`):
+**Scope values** (:class:`~conops.config.AttitudeConstraintScope`):
 
 .. list-table::
    :header-rows: 1
@@ -220,51 +214,53 @@ while broader mission constraints are left to runtime telemetry/FM monitoring.
 
    * - Value
      - Behaviour
-   * - ``"full_mission"``
-     - The complete mission constraint (Sun, Moon, Earth limb, star tracker, radiator,
-       telescope) is evaluated.  Any violation is flagged.
-   * - ``"hard_keepout"``
-     - Only hardware/instrument hard keepouts are validated: star-tracker hard,
-       radiator hard, and telescope hard. Broader mission constraints and
-       science-quality soft constraints are not planning mismatches under this
-       policy, though they may still be monitored by Fault Management thresholds.
-   * - ``"none"``
-     - No constraint checking is performed for this mode.  Use this when the mode
-       genuinely has no pointing restrictions (rare) or when you need to suppress
-       false positives during development.
+   * - ``"hardware_safety"``
+     - Hardware/instrument hard keepouts: explicit safety constraints,
+       star-tracker hard, radiator hard, and telescope hard.
+   * - ``"imaging_quality"``
+     - Science/image-quality constraints: Sun, Moon, Earth limb, orbit,
+       anti-Sun, star-tracker soft, and explicit science constraints.
+   * - ``"power_generation"``
+     - Solar-panel / power-positive attitude constraints.
+   * - ``"ground_contact"``
+     - Ground-contact attitude constraints, when configured.
 
-**Default policy per ACS mode:**
+An empty list disables post-run attitude constraint validation for that ACS mode.
+
+**Default scopes per ACS mode:**
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 30 50
+   :widths: 20 45 35
 
    * - ACS Mode
-     - Default Policy
+     - Default Scopes
      - Rationale
    * - ``SCIENCE``
-     - ``full_mission``
-     - Science observations must satisfy all pointing constraints.
+     - ``hardware_safety``, ``imaging_quality``, ``power_generation``
+     - Science observations must be safe, image-valid, and power-valid.
    * - ``CHARGING``
-     - ``full_mission``
-     - Emergency charging still obeys the full mission keep-out.
+     - ``hardware_safety``, ``power_generation``
+     - Emergency charging must be safe and power-positive, but does not inherit
+       imaging-quality keepouts.
    * - ``SLEWING``
-     - ``full_mission``
-     - Slews must satisfy the configured mission constraint policy by default.
+     - ``hardware_safety``
+     - Slews must avoid hard hardware keepouts.
    * - ``PASS``
-     - ``full_mission``
-     - Ground-station tracking must satisfy configured mission constraints by default.
+     - ``hardware_safety``, ``power_generation``, ``ground_contact``
+     - Ground-station tracking must be safe, power-valid, and satisfy contact-specific
+       pointing constraints.
    * - ``SAA``
-     - ``full_mission``
-     - SAA attitude must satisfy configured mission constraints by default.
+     - ``hardware_safety``
+     - SAA attitude must avoid hard hardware keepouts.
    * - ``SAFE``
-     - ``full_mission``
-     - Safe-mode attitude must satisfy configured mission constraints by default.
+     - ``hardware_safety``, ``power_generation``
+     - Safe-mode attitude must be hardware-safe and power-valid.
    * - ``IDLE``
-     - ``full_mission``
-     - Idle hold attitude must satisfy configured mission constraints by default.
+     - ``hardware_safety``
+     - Idle hold attitude must avoid hard hardware keepouts.
 
-**Overriding the policy for individual modes:**
+**Overriding scopes for individual modes:**
 
 Pass a partial dict — only the modes you specify are overridden; all others keep their
 defaults.  Keys can be :class:`~conops.common.ACSMode` enum members, their integer
@@ -272,29 +268,37 @@ values, or their string names.
 
 .. code-block:: python
 
-   from conops.config import MissionConfig, AttitudeConstraintPolicy
+   from conops.config import AttitudeConstraintScope, MissionConfig
    from conops.common import ACSMode
 
    config = MissionConfig(
-       attitude_constraint_policy={
-           # Relax SLEWING to no check when using a separate, less restrictive
-           # slew constraint already enforced by the ACS slew algorithm.
-           ACSMode.SLEWING: AttitudeConstraintPolicy.NONE,
-           # Promote SAFE mode to full validation for a strict mission context.
-           "SAFE": AttitudeConstraintPolicy.FULL_MISSION,
+       attitude_constraint_scopes={
+           # Disable post-run attitude validation for SLEWING if a separate
+           # slew constraint is already enforced by the ACS slew algorithm.
+           ACSMode.SLEWING: [],
+           # Add imaging-quality validation to PASS for a strict mission context.
+           "PASS": [
+               AttitudeConstraintScope.HARDWARE_SAFETY,
+               AttitudeConstraintScope.IMAGING_QUALITY,
+               AttitudeConstraintScope.POWER_GENERATION,
+               AttitudeConstraintScope.GROUND_CONTACT,
+           ],
        }
    )
 
 **YAML configuration:**
 
-When loading a config from YAML, use the mode name string as the key and the policy
-string as the value.  Omitted modes retain their defaults.
+When loading a config from YAML, use the mode name string as the key and a list of
+scope strings as the value.  Omitted modes retain their defaults.
 
 .. code-block:: yaml
 
-   attitude_constraint_policy:
-     SLEWING: none
-     SAFE: full_mission
+   attitude_constraint_scopes:
+     SLEWING: []
+     PASS:
+       - hardware_safety
+       - power_generation
+       - ground_contact
 
 spacecraft_bus
 ~~~~~~~~~~~~~~
@@ -1419,7 +1423,7 @@ API Reference
 For detailed API documentation, see:
 
 * :class:`~conops.config.MissionConfig`
-* :class:`~conops.config.AttitudeConstraintPolicy`
+* :class:`~conops.config.AttitudeConstraintScope`
 * :class:`~conops.config.SpacecraftBus`
 * :class:`~conops.config.SolarPanelSet`
 * :class:`~conops.config.SolarPanel`

--- a/tests/acs/conftest.py
+++ b/tests/acs/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 from conops import (
     ACS,
-    AttitudeConstraintPolicy,
+    AttitudeConstraintScope,
     AttitudeControlSystem,
     Constraint,
     SpacecraftBus,
@@ -87,8 +87,13 @@ def mock_config(mock_ephem: DummyEphemeris, mock_constraint: Mock) -> Mock:
     config.spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
     config.spacecraft_bus.radiators = Mock()
     config.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
-    config.attitude_constraint_policy_for_mode = Mock(
-        return_value=AttitudeConstraintPolicy.FULL_MISSION
+    config.attitude_constraint_scopes_for_mode = Mock(
+        return_value=[
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.IMAGING_QUALITY,
+            AttitudeConstraintScope.POWER_GENERATION,
+            AttitudeConstraintScope.GROUND_CONTACT,
+        ]
     )
     return config
 

--- a/tests/acs/test_acs.py
+++ b/tests/acs/test_acs.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 
-from conops import ACS, ACSCommandType, ACSMode, AttitudeConstraintPolicy
+from conops import ACS, ACSCommandType, ACSMode, AttitudeConstraintScope
 from conops.common.enums import ObsType
 from conops.simulation.acs import IDLE_OBSID
 from conops.simulation.slew import Slew
@@ -183,12 +183,12 @@ class TestACSStateManagement:
         science_slew.endroll = 30.0
         acs.last_slew = science_slew
         acs.science_observation_active = False
-        acs.config.attitude_constraint_policy_for_mode = Mock(
-            return_value=AttitudeConstraintPolicy.FULL_MISSION
+        acs.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.HARDWARE_SAFETY]
         )
 
         monkeypatch.setattr("conops.simulation.acs.optimum_roll", lambda *args: 5.0)
-        acs.constraint.in_constraint = Mock(side_effect=[True, False])
+        acs.constraint.in_star_tracker_hard = Mock(side_effect=[True, False])
 
         ra, dec, roll, obsid = acs.pointing(1000.0)
 
@@ -200,7 +200,7 @@ class TestACSStateManagement:
     def test_pointing_replaces_hard_constrained_idle_hold(
         self, acs, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """IDLE enforcement should use the configured hard-keepout policy."""
+        """IDLE enforcement should use configured hardware-safety scopes."""
         science_slew = Slew(config=acs.config)
         science_slew.obstype = ObsType.PPT
         science_slew.obsid = 42
@@ -214,8 +214,8 @@ class TestACSStateManagement:
         science_slew.endroll = 30.0
         acs.last_slew = science_slew
         acs.science_observation_active = False
-        acs.config.attitude_constraint_policy_for_mode = Mock(
-            return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+        acs.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.HARDWARE_SAFETY]
         )
 
         monkeypatch.setattr("conops.simulation.acs.optimum_roll", lambda *args: 5.0)
@@ -231,12 +231,12 @@ class TestACSStateManagement:
         self, acs, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """IDLE enforcement should safe-mode instead of crashing on no safe hold."""
-        acs.config.attitude_constraint_policy_for_mode = Mock(
-            return_value=AttitudeConstraintPolicy.FULL_MISSION
+        acs.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.HARDWARE_SAFETY]
         )
         acs.config.fault_management.events = []
         monkeypatch.setattr("conops.simulation.acs.optimum_roll", lambda *args: 5.0)
-        acs.constraint.in_constraint = Mock(return_value=True)
+        acs.constraint.in_star_tracker_hard = Mock(return_value=True)
 
         ra, dec, roll, obsid = acs.pointing(1000.0)
 

--- a/tests/acs/test_acs_roll.py
+++ b/tests/acs/test_acs_roll.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pytest
 
-from conops import ACS, ACSMode, AttitudeConstraintPolicy
+from conops import ACS, ACSMode, AttitudeConstraintScope
 from conops.config.solar_panel import SolarPanel, SolarPanelSet
 
 
@@ -72,8 +72,8 @@ def mock_config_roll(mock_ephem_roll, mock_constraint_roll):
     config.spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
     config.spacecraft_bus.radiators = Mock()
     config.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
-    config.attitude_constraint_policy_for_mode = Mock(
-        return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+    config.attitude_constraint_scopes_for_mode = Mock(
+        return_value=[AttitudeConstraintScope.HARDWARE_SAFETY]
     )
     return config
 
@@ -166,8 +166,8 @@ class TestACSRollCalculation:
         config1.spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
         config1.spacecraft_bus.radiators = Mock()
         config1.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
-        config1.attitude_constraint_policy_for_mode = Mock(
-            return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+        config1.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.HARDWARE_SAFETY]
         )
 
         with patch("conops.simulation.passes.PassTimes"):
@@ -203,8 +203,8 @@ class TestACSRollCalculation:
         config2.spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
         config2.spacecraft_bus.radiators = Mock()
         config2.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
-        config2.attitude_constraint_policy_for_mode = Mock(
-            return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+        config2.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.HARDWARE_SAFETY]
         )
 
         with patch("conops.simulation.passes.PassTimes"):
@@ -365,8 +365,8 @@ class TestACSRollEdgeCases:
         config.spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
         config.spacecraft_bus.radiators = Mock()
         config.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
-        config.attitude_constraint_policy_for_mode = Mock(
-            return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+        config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.HARDWARE_SAFETY]
         )
 
         with patch("conops.simulation.passes.PassTimes"):

--- a/tests/battery/conftest.py
+++ b/tests/battery/conftest.py
@@ -110,6 +110,55 @@ def mock_config(mock_ephem):
     )
     constraint.in_eclipse = Mock(return_value=False)
 
+    def scoped_scalar(ra, dec, utime, target_roll=None, acs_mode=None):
+        return bool(
+            constraint.in_constraint(
+                ra,
+                dec,
+                utime,
+                target_roll=target_roll,
+                acs_mode=acs_mode,
+            )
+        )
+
+    def scoped_batch(ras, decs, utime, target_rolls=None):
+        if target_rolls is None:
+            violations = constraint.in_constraint_batch(ras, decs, utime)
+        else:
+            violations = constraint.in_constraint_batch(
+                ras,
+                decs,
+                utime,
+                target_rolls=target_rolls,
+            )
+        return np.asarray(violations, dtype=bool)
+
+    constraint.in_explicit_safety = Mock(return_value=False)
+    constraint.in_star_tracker_hard = Mock(side_effect=scoped_scalar)
+    constraint.in_radiator_hard = Mock(return_value=False)
+    constraint.in_telescope_hard = Mock(return_value=False)
+    constraint.in_panel = Mock(side_effect=scoped_scalar)
+    constraint.in_sun = Mock(return_value=False)
+    constraint.in_earth = Mock(return_value=False)
+    constraint.in_moon = Mock(return_value=False)
+    constraint.in_anti_sun = Mock(return_value=False)
+    constraint.in_orbit = Mock(return_value=False)
+    constraint.in_star_tracker_soft = Mock(return_value=False)
+    constraint.in_explicit_science = Mock(return_value=False)
+    constraint.in_ground_contact = Mock(return_value=False)
+    constraint.in_hardware_safety_constraint_batch = Mock(side_effect=scoped_batch)
+    constraint.in_power_generation_constraint_batch = Mock(side_effect=scoped_batch)
+    constraint.in_imaging_quality_constraint_batch = Mock(
+        side_effect=lambda ras, decs, utime, target_rolls=None: np.zeros(
+            len(ras), dtype=bool
+        )
+    )
+    constraint.in_ground_contact_constraint_batch = Mock(
+        side_effect=lambda ras, decs, utime, target_rolls=None: np.zeros(
+            len(ras), dtype=bool
+        )
+    )
+
     config = MissionConfig(
         spacecraft_bus=spacecraft_bus,
         solar_panel=solar_panel,

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -10,7 +10,7 @@ import yaml
 
 from conops import (
     ACSMode,
-    AttitudeConstraintPolicy,
+    AttitudeConstraintScope,
     Battery,
     Constraint,
     FaultManagement,
@@ -69,69 +69,81 @@ class TestConfig:
             == minimal_config["ground_stations"]
         )
 
-    def test_attitude_constraint_policy_defaults_by_mode(self) -> None:
-        """Test executed attitude validation policy defaults."""
+    def test_attitude_constraint_scopes_defaults_by_mode(self) -> None:
+        """Test executed attitude validation scope defaults."""
         config = MissionConfig()
-        for mode in ACSMode:
-            assert (
-                config.attitude_constraint_policy_for_mode(mode)
-                == AttitudeConstraintPolicy.FULL_MISSION
-            )
 
-    def test_attitude_constraint_policy_accepts_mode_name_overrides(self) -> None:
+        assert config.attitude_constraint_scopes_for_mode(ACSMode.SCIENCE) == [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.IMAGING_QUALITY,
+            AttitudeConstraintScope.POWER_GENERATION,
+        ]
+        assert config.attitude_constraint_scopes_for_mode(ACSMode.CHARGING) == [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.POWER_GENERATION,
+        ]
+        assert config.attitude_constraint_scopes_for_mode(ACSMode.PASS) == [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.POWER_GENERATION,
+            AttitudeConstraintScope.GROUND_CONTACT,
+        ]
+        assert config.attitude_constraint_scopes_for_mode(ACSMode.SLEWING) == [
+            AttitudeConstraintScope.HARDWARE_SAFETY
+        ]
+        assert config.attitude_constraint_scopes_for_mode(ACSMode.SAA) == [
+            AttitudeConstraintScope.HARDWARE_SAFETY
+        ]
+        assert config.attitude_constraint_scopes_for_mode(ACSMode.SAFE) == [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.POWER_GENERATION,
+        ]
+        assert config.attitude_constraint_scopes_for_mode(ACSMode.IDLE) == [
+            AttitudeConstraintScope.HARDWARE_SAFETY
+        ]
+
+    def test_attitude_constraint_scopes_accepts_mode_name_overrides(self) -> None:
         """Test mission config can override one ACS mode by name."""
         config = MissionConfig(
-            attitude_constraint_policy={"PASS": "full_mission", "CHARGING": "none"}
-        )
-
-        assert (
-            config.attitude_constraint_policy_for_mode(ACSMode.PASS)
-            == AttitudeConstraintPolicy.FULL_MISSION
-        )
-        assert (
-            config.attitude_constraint_policy_for_mode(ACSMode.CHARGING)
-            == AttitudeConstraintPolicy.NONE
-        )
-        assert (
-            config.attitude_constraint_policy_for_mode(ACSMode.SCIENCE)
-            == AttitudeConstraintPolicy.FULL_MISSION
-        )
-
-    def test_attitude_constraint_policy_accepts_scoped_overrides(self) -> None:
-        """Test mission config accepts science/safety scoped policies."""
-        config = MissionConfig(
-            attitude_constraint_policy={
-                "SCIENCE": "science_plus_safety",
-                "CHARGING": "safety",
-                "PASS": "science",
+            attitude_constraint_scopes={
+                "PASS": ["hardware_safety", "ground_contact"],
+                "CHARGING": [],
             }
         )
 
-        assert (
-            config.attitude_constraint_policy_for_mode(ACSMode.SCIENCE)
-            == AttitudeConstraintPolicy.SCIENCE_PLUS_SAFETY
-        )
-        assert (
-            config.attitude_constraint_policy_for_mode(ACSMode.CHARGING)
-            == AttitudeConstraintPolicy.SAFETY
-        )
-        assert (
-            config.attitude_constraint_policy_for_mode(ACSMode.PASS)
-            == AttitudeConstraintPolicy.SCIENCE
+        assert config.attitude_constraint_scopes_for_mode(ACSMode.PASS) == [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.GROUND_CONTACT,
+        ]
+        assert config.attitude_constraint_scopes_for_mode(ACSMode.CHARGING) == []
+        assert config.attitude_constraint_scopes_for_mode(ACSMode.SCIENCE) == [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.IMAGING_QUALITY,
+            AttitudeConstraintScope.POWER_GENERATION,
+        ]
+
+    def test_attitude_constraint_scopes_accepts_enum_overrides(self) -> None:
+        """Test mission config accepts enum scope overrides."""
+        config = MissionConfig(
+            attitude_constraint_scopes={
+                "SCIENCE": [
+                    AttitudeConstraintScope.HARDWARE_SAFETY,
+                    AttitudeConstraintScope.IMAGING_QUALITY,
+                ],
+                "CHARGING": [AttitudeConstraintScope.POWER_GENERATION],
+                "PASS": [AttitudeConstraintScope.GROUND_CONTACT],
+            }
         )
 
-    def test_attitude_constraint_policy_scope_flags(self) -> None:
-        """Test policy scope helpers document compatibility alias behavior."""
-        assert AttitudeConstraintPolicy.SCIENCE_PLUS_SAFETY.enforces_science
-        assert AttitudeConstraintPolicy.SCIENCE_PLUS_SAFETY.enforces_safety
-        assert AttitudeConstraintPolicy.FULL_MISSION.enforces_science
-        assert AttitudeConstraintPolicy.FULL_MISSION.enforces_safety
-        assert AttitudeConstraintPolicy.SCIENCE.enforces_science
-        assert not AttitudeConstraintPolicy.SCIENCE.enforces_safety
-        assert not AttitudeConstraintPolicy.SAFETY.enforces_science
-        assert AttitudeConstraintPolicy.SAFETY.enforces_safety
-        assert not AttitudeConstraintPolicy.NONE.enforces_science
-        assert not AttitudeConstraintPolicy.NONE.enforces_safety
+        assert config.attitude_constraint_scopes_for_mode(ACSMode.SCIENCE) == [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.IMAGING_QUALITY,
+        ]
+        assert config.attitude_constraint_scopes_for_mode(ACSMode.CHARGING) == [
+            AttitudeConstraintScope.POWER_GENERATION
+        ]
+        assert config.attitude_constraint_scopes_for_mode(ACSMode.PASS) == [
+            AttitudeConstraintScope.GROUND_CONTACT
+        ]
 
     def test_acs_gsp_tracking_phase_step_is_configurable(self) -> None:
         """Test ground-station roll search granularity is an ACS config setting."""

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -97,6 +97,42 @@ class TestConfig:
             == AttitudeConstraintPolicy.FULL_MISSION
         )
 
+    def test_attitude_constraint_policy_accepts_scoped_overrides(self) -> None:
+        """Test mission config accepts science/safety scoped policies."""
+        config = MissionConfig(
+            attitude_constraint_policy={
+                "SCIENCE": "science_plus_safety",
+                "CHARGING": "safety",
+                "PASS": "science",
+            }
+        )
+
+        assert (
+            config.attitude_constraint_policy_for_mode(ACSMode.SCIENCE)
+            == AttitudeConstraintPolicy.SCIENCE_PLUS_SAFETY
+        )
+        assert (
+            config.attitude_constraint_policy_for_mode(ACSMode.CHARGING)
+            == AttitudeConstraintPolicy.SAFETY
+        )
+        assert (
+            config.attitude_constraint_policy_for_mode(ACSMode.PASS)
+            == AttitudeConstraintPolicy.SCIENCE
+        )
+
+    def test_attitude_constraint_policy_scope_flags(self) -> None:
+        """Test policy scope helpers document compatibility alias behavior."""
+        assert AttitudeConstraintPolicy.SCIENCE_PLUS_SAFETY.enforces_science
+        assert AttitudeConstraintPolicy.SCIENCE_PLUS_SAFETY.enforces_safety
+        assert AttitudeConstraintPolicy.FULL_MISSION.enforces_science
+        assert AttitudeConstraintPolicy.FULL_MISSION.enforces_safety
+        assert AttitudeConstraintPolicy.SCIENCE.enforces_science
+        assert not AttitudeConstraintPolicy.SCIENCE.enforces_safety
+        assert not AttitudeConstraintPolicy.SAFETY.enforces_science
+        assert AttitudeConstraintPolicy.SAFETY.enforces_safety
+        assert not AttitudeConstraintPolicy.NONE.enforces_science
+        assert not AttitudeConstraintPolicy.NONE.enforces_safety
+
     def test_acs_gsp_tracking_phase_step_is_configurable(self) -> None:
         """Test ground-station roll search granularity is an ACS config setting."""
         acs = AttitudeControlSystem(gsp_tracking_phase_step_deg=10.0)

--- a/tests/constraint/test_constraint.py
+++ b/tests/constraint/test_constraint.py
@@ -5,7 +5,11 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from conops import Constraint, DefaultConstraint
+from conops import AttitudeConstraintPolicy, Constraint, DefaultConstraint
+from conops.config.constraint import (
+    attitude_constraint_name_for_policy,
+    in_attitude_constraint_policy,
+)
 
 
 class TestConstraintInit:
@@ -258,6 +262,92 @@ class TestInOccultMethod:
         result = constraint.in_constraint(45.0, 30.0, 1700000000.0, 2)
 
         assert result is True
+
+
+class TestConstraintScopes:
+    """Test science/scheduling and safety constraint scopes."""
+
+    @patch("conops.Constraint.in_earth")
+    def test_legacy_earth_constraint_is_science_not_safety(self, mock_earth) -> None:
+        """Top-level Earth constraints remain image-quality constraints."""
+        constraint = Constraint()
+        mock_earth.return_value = True
+
+        assert constraint.in_science_constraint(45.0, 30.0, 1700000000.0)
+        assert not constraint.in_safety_constraint(45.0, 30.0, 1700000000.0)
+
+    @patch("conops.Constraint.in_telescope_hard")
+    def test_telescope_hard_constraint_is_safety_not_science(
+        self, mock_telescope_hard
+    ) -> None:
+        """Telescope hard constraints are hardware-safety constraints."""
+        constraint = Constraint()
+        mock_telescope_hard.return_value = True
+
+        assert constraint.in_safety_constraint(45.0, 30.0, 1700000000.0)
+        assert not constraint.in_science_constraint(45.0, 30.0, 1700000000.0)
+
+    @patch("conops.Constraint.in_radiator_hard")
+    @patch("conops.Constraint.in_earth")
+    def test_science_plus_safety_constraint_accepts_either_scope(
+        self, mock_earth, mock_radiator_hard
+    ) -> None:
+        """Combined policy remains true for either scoped violation."""
+        constraint = Constraint()
+        mock_earth.return_value = False
+        mock_radiator_hard.return_value = True
+
+        assert constraint.in_science_plus_safety_constraint(45.0, 30.0, 1700000000.0)
+
+    @patch("conops.Constraint.in_earth")
+    def test_policy_helper_routes_to_configured_scope(self, mock_earth) -> None:
+        """Central policy helper applies science and safety scopes consistently."""
+        constraint = Constraint()
+        mock_earth.return_value = True
+
+        assert in_attitude_constraint_policy(
+            constraint,
+            AttitudeConstraintPolicy.SCIENCE,
+            45.0,
+            30.0,
+            1700000000.0,
+        )
+        assert not in_attitude_constraint_policy(
+            constraint,
+            AttitudeConstraintPolicy.SAFETY,
+            45.0,
+            30.0,
+            1700000000.0,
+        )
+
+    @patch("conops.Constraint.in_radiator_hard")
+    def test_policy_name_helper_routes_to_configured_scope(
+        self, mock_radiator_hard
+    ) -> None:
+        """Central policy name helper reports the active scoped constraint."""
+        constraint = Constraint()
+        mock_radiator_hard.return_value = True
+
+        assert (
+            attitude_constraint_name_for_policy(
+                constraint,
+                AttitudeConstraintPolicy.SAFETY,
+                45.0,
+                30.0,
+                1700000000.0,
+            )
+            == "Radiator Hard"
+        )
+        assert (
+            attitude_constraint_name_for_policy(
+                constraint,
+                AttitudeConstraintPolicy.SCIENCE,
+                45.0,
+                30.0,
+                1700000000.0,
+            )
+            is None
+        )
 
 
 class TestInOccultCountMethod:

--- a/tests/constraint/test_constraint.py
+++ b/tests/constraint/test_constraint.py
@@ -350,6 +350,19 @@ class TestConstraintScopes:
         )
 
 
+class TestRollIndependentConstraint:
+    """Test roll-independent constraint aggregation."""
+
+    def test_includes_ground_contact_constraint(self) -> None:
+        """Roll-independent ground-contact constraints are included."""
+        import rust_ephem
+
+        ground_contact = rust_ephem.SunConstraint(min_angle=45.0)
+        constraint = Constraint(ground_contact_constraint=ground_contact)
+
+        assert constraint.roll_independent_constraint is ground_contact
+
+
 class TestInOccultCountMethod:
     """Test in_constraint_count method logic."""
 
@@ -386,6 +399,34 @@ class TestInOccultCountMethod:
         mock_antisun.return_value = False
         mock_earth.return_value = False
         mock_panel.return_value = False
+
+        count = constraint.in_constraint_count(45.0, 30.0, 1700000000.0, 21)
+
+        assert count == 2
+
+    @patch("conops.Constraint.in_ground_contact")
+    @patch("conops.Constraint.in_panel")
+    @patch("conops.Constraint.in_earth")
+    @patch("conops.Constraint.in_anti_sun")
+    @patch("conops.Constraint.in_moon")
+    @patch("conops.Constraint.in_sun")
+    def test_in_constraint_count_ground_contact_only(
+        self,
+        mock_sun,
+        mock_moon,
+        mock_antisun,
+        mock_earth,
+        mock_panel,
+        mock_ground_contact,
+        constraint,
+    ) -> None:
+        """Test in_constraint_count includes ground-contact violations."""
+        mock_sun.return_value = False
+        mock_moon.return_value = False
+        mock_antisun.return_value = False
+        mock_earth.return_value = False
+        mock_panel.return_value = False
+        mock_ground_contact.return_value = True
 
         count = constraint.in_constraint_count(45.0, 30.0, 1700000000.0, 21)
 

--- a/tests/constraint/test_constraint.py
+++ b/tests/constraint/test_constraint.py
@@ -5,10 +5,10 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from conops import AttitudeConstraintPolicy, Constraint, DefaultConstraint
+from conops import AttitudeConstraintScope, Constraint, DefaultConstraint
 from conops.config.constraint import (
-    attitude_constraint_name_for_policy,
-    in_attitude_constraint_policy,
+    attitude_constraint_name_for_scopes,
+    in_attitude_constraint_scopes,
 )
 
 
@@ -57,8 +57,8 @@ class TestConstraintInit:
         """Test bare Constraint defaults to no star-tracker soft constraint."""
         assert Constraint().star_tracker_soft_constraint is None
 
-    def test_default_constraint_has_legacy_constraints(self) -> None:
-        """Test DefaultConstraint preserves legacy non-None defaults."""
+    def test_default_constraint_has_standard_constraints(self) -> None:
+        """Test DefaultConstraint provides the standard default components."""
         default_constraint = DefaultConstraint()
         assert default_constraint.sun_constraint is not None
         assert default_constraint.anti_sun_constraint is not None
@@ -265,15 +265,15 @@ class TestInOccultMethod:
 
 
 class TestConstraintScopes:
-    """Test science/scheduling and safety constraint scopes."""
+    """Test imaging-quality, power-generation, and safety constraint scopes."""
 
     @patch("conops.Constraint.in_earth")
-    def test_legacy_earth_constraint_is_science_not_safety(self, mock_earth) -> None:
-        """Top-level Earth constraints remain image-quality constraints."""
+    def test_earth_constraint_is_imaging_quality_not_safety(self, mock_earth) -> None:
+        """Top-level Earth constraints are imaging-quality constraints."""
         constraint = Constraint()
         mock_earth.return_value = True
 
-        assert constraint.in_science_constraint(45.0, 30.0, 1700000000.0)
+        assert constraint.in_imaging_quality_constraint(45.0, 30.0, 1700000000.0)
         assert not constraint.in_safety_constraint(45.0, 30.0, 1700000000.0)
 
     @patch("conops.Constraint.in_telescope_hard")
@@ -285,53 +285,53 @@ class TestConstraintScopes:
         mock_telescope_hard.return_value = True
 
         assert constraint.in_safety_constraint(45.0, 30.0, 1700000000.0)
-        assert not constraint.in_science_constraint(45.0, 30.0, 1700000000.0)
+        assert not constraint.in_imaging_quality_constraint(45.0, 30.0, 1700000000.0)
 
     @patch("conops.Constraint.in_radiator_hard")
     @patch("conops.Constraint.in_earth")
-    def test_science_plus_safety_constraint_accepts_either_scope(
+    def test_all_scope_constraint_accepts_either_scope(
         self, mock_earth, mock_radiator_hard
     ) -> None:
-        """Combined policy remains true for either scoped violation."""
+        """All-scope helper remains true for either scoped violation."""
         constraint = Constraint()
         mock_earth.return_value = False
         mock_radiator_hard.return_value = True
 
-        assert constraint.in_science_plus_safety_constraint(45.0, 30.0, 1700000000.0)
+        assert constraint.in_constraint(45.0, 30.0, 1700000000.0)
 
     @patch("conops.Constraint.in_earth")
-    def test_policy_helper_routes_to_configured_scope(self, mock_earth) -> None:
-        """Central policy helper applies science and safety scopes consistently."""
+    def test_scope_helper_routes_to_configured_scopes(self, mock_earth) -> None:
+        """Central scope helper applies configured scopes consistently."""
         constraint = Constraint()
         mock_earth.return_value = True
 
-        assert in_attitude_constraint_policy(
+        assert in_attitude_constraint_scopes(
             constraint,
-            AttitudeConstraintPolicy.SCIENCE,
+            [AttitudeConstraintScope.IMAGING_QUALITY],
             45.0,
             30.0,
             1700000000.0,
         )
-        assert not in_attitude_constraint_policy(
+        assert not in_attitude_constraint_scopes(
             constraint,
-            AttitudeConstraintPolicy.SAFETY,
+            [AttitudeConstraintScope.HARDWARE_SAFETY],
             45.0,
             30.0,
             1700000000.0,
         )
 
     @patch("conops.Constraint.in_radiator_hard")
-    def test_policy_name_helper_routes_to_configured_scope(
+    def test_scope_name_helper_routes_to_configured_scope(
         self, mock_radiator_hard
     ) -> None:
-        """Central policy name helper reports the active scoped constraint."""
+        """Central scope name helper reports the active scoped constraint."""
         constraint = Constraint()
         mock_radiator_hard.return_value = True
 
         assert (
-            attitude_constraint_name_for_policy(
+            attitude_constraint_name_for_scopes(
                 constraint,
-                AttitudeConstraintPolicy.SAFETY,
+                [AttitudeConstraintScope.HARDWARE_SAFETY],
                 45.0,
                 30.0,
                 1700000000.0,
@@ -339,9 +339,9 @@ class TestConstraintScopes:
             == "Radiator Hard"
         )
         assert (
-            attitude_constraint_name_for_policy(
+            attitude_constraint_name_for_scopes(
                 constraint,
-                AttitudeConstraintPolicy.SCIENCE,
+                [AttitudeConstraintScope.IMAGING_QUALITY],
                 45.0,
                 30.0,
                 1700000000.0,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from astropy.time import Time  # type: ignore[import-untyped]
 
-from conops import AttitudeConstraintPolicy, SolarPanel, SolarPanelSet
+from conops import AttitudeConstraintScope, SolarPanel, SolarPanelSet
 
 
 @pytest.fixture(autouse=True)
@@ -107,8 +107,13 @@ def test_config_with_panels(mock_ephem_with_pv: Mock) -> tuple[Mock, SolarPanelS
     config.spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
     config.spacecraft_bus.radiators = Mock()
     config.spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
-    config.attitude_constraint_policy_for_mode = Mock(
-        return_value=AttitudeConstraintPolicy.FULL_MISSION
+    config.attitude_constraint_scopes_for_mode = Mock(
+        return_value=[
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.IMAGING_QUALITY,
+            AttitudeConstraintScope.POWER_GENERATION,
+            AttitudeConstraintScope.GROUND_CONTACT,
+        ]
     )
 
     return config, panel_set

--- a/tests/passes/conftest.py
+++ b/tests/passes/conftest.py
@@ -73,9 +73,17 @@ def mock_constraint(mock_ephem):
     constraint = Mock(spec=Constraint)
     constraint.ephem = mock_ephem
     constraint.in_constraint = Mock(return_value=False)
+    constraint.in_sun = Mock(return_value=False)
+    constraint.in_earth = Mock(return_value=False)
+    constraint.in_panel = Mock(return_value=False)
+    constraint.in_moon = Mock(return_value=False)
+    constraint.in_anti_sun = Mock(return_value=False)
+    constraint.in_orbit = Mock(return_value=False)
     constraint.in_star_tracker_hard = Mock(return_value=False)
+    constraint.in_star_tracker_soft = Mock(return_value=False)
     constraint.in_radiator_hard = Mock(return_value=False)
     constraint.in_telescope_hard = Mock(return_value=False)
+    constraint.in_ground_contact = Mock(return_value=False)
     return constraint
 
 

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -643,6 +643,27 @@ class TestPassTimes:
             10.0, 20.0, 1000.0, target_roll=30.0, acs_mode=ACSMode.PASS
         )
 
+    def test_pass_profile_safety_policy_ignores_science_constraint(
+        self, mock_constraint, mock_config
+    ):
+        """PASS safety policy ignores image-quality constraints like Earth limb."""
+        mock_config.attitude_constraint_policy = {
+            ACSMode.PASS.name: AttitudeConstraintPolicy.SAFETY
+        }
+        pt = PassTimes(config=mock_config)
+        mock_constraint.in_constraint = Mock(return_value=True)
+        mock_constraint.in_earth = Mock(return_value=True)
+        mock_constraint.in_star_tracker_hard = Mock(return_value=False)
+        mock_constraint.in_radiator_hard = Mock(return_value=False)
+        mock_constraint.in_telescope_hard = Mock(return_value=False)
+
+        assert not pt._pass_profile_violates_policy([1000.0], [10.0], [20.0], [30.0])
+        mock_constraint.in_constraint.assert_not_called()
+        mock_constraint.in_earth.assert_not_called()
+        mock_constraint.in_star_tracker_hard.assert_called_once_with(
+            10.0, 20.0, 1000.0, target_roll=30.0, acs_mode=ACSMode.PASS
+        )
+
     def test_tracking_phase_profile_preserves_antenna_pointing(
         self, mock_constraint, mock_config
     ):

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -20,7 +20,7 @@ from conops.common import (
 from conops.common.enums import ACSMode, AntennaType, ObsType, SlewAlgorithm
 from conops.config import (
     AntennaPointing,
-    AttitudeConstraintPolicy,
+    AttitudeConstraintScope,
     AttitudeControlSystem,
     BandCapability,
     CommunicationsSystem,
@@ -616,40 +616,44 @@ class TestPassTimes:
         gs_ephem.assert_not_called()
         assert pt.passes == []
 
-    def test_pass_profile_uses_full_mission_policy(self, mock_constraint, mock_config):
-        """PASS profiles should be filtered by the configured full mission policy."""
+    def test_pass_profile_uses_configured_scopes(self, mock_constraint, mock_config):
+        """PASS profiles should be filtered by configured attitude scopes."""
+        mock_config.attitude_constraint_scopes[ACSMode.PASS.name] = [
+            AttitudeConstraintScope.HARDWARE_SAFETY,
+            AttitudeConstraintScope.IMAGING_QUALITY,
+        ]
         pt = PassTimes(config=mock_config)
-        mock_constraint.in_constraint = Mock(return_value=True)
+        mock_constraint.in_earth = Mock(return_value=True)
 
-        assert pt._pass_profile_violates_policy([1000.0], [10.0], [20.0], [30.0])
-        mock_constraint.in_constraint.assert_called_once_with(
-            10.0, 20.0, 1000.0, target_roll=30.0, acs_mode=ACSMode.PASS
+        assert pt._pass_profile_violates_scopes([1000.0], [10.0], [20.0], [30.0])
+        mock_constraint.in_earth.assert_called_once_with(
+            10.0, 20.0, 1000.0, target_roll=30.0
         )
 
-    def test_pass_profile_respects_hard_keepout_override(
+    def test_pass_profile_respects_hardware_safety_scope(
         self, mock_constraint, mock_config
     ):
-        """PASS profiles still honor explicit hard-keepout policy overrides."""
-        mock_config.attitude_constraint_policy = {
-            ACSMode.PASS.name: AttitudeConstraintPolicy.HARD_KEEPOUT
-        }
+        """PASS profiles still honor explicit hardware-safety scope overrides."""
+        mock_config.attitude_constraint_scopes[ACSMode.PASS.name] = [
+            AttitudeConstraintScope.HARDWARE_SAFETY
+        ]
         pt = PassTimes(config=mock_config)
         mock_constraint.in_constraint = Mock(return_value=True)
         mock_constraint.in_star_tracker_hard = Mock(return_value=True)
 
-        assert pt._pass_profile_violates_policy([1000.0], [10.0], [20.0], [30.0])
+        assert pt._pass_profile_violates_scopes([1000.0], [10.0], [20.0], [30.0])
         mock_constraint.in_constraint.assert_not_called()
         mock_constraint.in_star_tracker_hard.assert_called_once_with(
             10.0, 20.0, 1000.0, target_roll=30.0, acs_mode=ACSMode.PASS
         )
 
-    def test_pass_profile_safety_policy_ignores_science_constraint(
+    def test_pass_profile_hardware_safety_scope_ignores_imaging_constraint(
         self, mock_constraint, mock_config
     ):
-        """PASS safety policy ignores image-quality constraints like Earth limb."""
-        mock_config.attitude_constraint_policy = {
-            ACSMode.PASS.name: AttitudeConstraintPolicy.SAFETY
-        }
+        """PASS hardware-safety scope ignores image-quality constraints like Earth."""
+        mock_config.attitude_constraint_scopes[ACSMode.PASS.name] = [
+            AttitudeConstraintScope.HARDWARE_SAFETY
+        ]
         pt = PassTimes(config=mock_config)
         mock_constraint.in_constraint = Mock(return_value=True)
         mock_constraint.in_earth = Mock(return_value=True)
@@ -657,7 +661,7 @@ class TestPassTimes:
         mock_constraint.in_radiator_hard = Mock(return_value=False)
         mock_constraint.in_telescope_hard = Mock(return_value=False)
 
-        assert not pt._pass_profile_violates_policy([1000.0], [10.0], [20.0], [30.0])
+        assert not pt._pass_profile_violates_scopes([1000.0], [10.0], [20.0], [30.0])
         mock_constraint.in_constraint.assert_not_called()
         mock_constraint.in_earth.assert_not_called()
         mock_constraint.in_star_tracker_hard.assert_called_once_with(
@@ -694,8 +698,11 @@ class TestPassTimes:
         self, mock_constraint, mock_config
     ):
         """Unsafe default GSP phase should be replaced by a safe tracking phase."""
+        mock_config.attitude_constraint_scopes[ACSMode.PASS.name] = [
+            AttitudeConstraintScope.GROUND_CONTACT
+        ]
         pt = PassTimes(config=mock_config)
-        mock_constraint.in_constraint = Mock(
+        mock_constraint.in_ground_contact = Mock(
             side_effect=lambda ra, dec, utime, **kwargs: dec > -1.0
         )
 
@@ -719,6 +726,9 @@ class TestPassTimes:
             slew_acceleration=5.0,
             settle_time=0.0,
         )
+        mock_config.attitude_constraint_scopes[ACSMode.PASS.name] = [
+            AttitudeConstraintScope.GROUND_CONTACT
+        ]
         pt = PassTimes(config=mock_config)
         pt._gsp_tracking_phase_candidates = Mock(return_value=[0.0, 90.0])
         pt._tracking_attitude_profile_for_phase = Mock(
@@ -726,7 +736,7 @@ class TestPassTimes:
                 (phase_deg, 0.0, phase_deg) for _target in targets
             ]
         )
-        mock_constraint.in_constraint = Mock(
+        mock_constraint.in_ground_contact = Mock(
             side_effect=lambda ra, dec, utime, **kwargs: (
                 not (
                     (utime == 1000.0 and kwargs["target_roll"] == 0.0)
@@ -755,6 +765,9 @@ class TestPassTimes:
             slew_acceleration=0.1,
             settle_time=0.0,
         )
+        mock_config.attitude_constraint_scopes[ACSMode.PASS.name] = [
+            AttitudeConstraintScope.GROUND_CONTACT
+        ]
         pt = PassTimes(config=mock_config)
         pt._gsp_tracking_phase_candidates = Mock(return_value=[0.0, 180.0])
         pt._tracking_attitude_profile_for_phase = Mock(
@@ -762,7 +775,7 @@ class TestPassTimes:
                 (phase_deg, 0.0, phase_deg) for _target in targets
             ]
         )
-        mock_constraint.in_constraint = Mock(
+        mock_constraint.in_ground_contact = Mock(
             side_effect=lambda ra, dec, utime, **kwargs: (
                 not (
                     (utime == 1000.0 and kwargs["target_roll"] == 0.0)

--- a/tests/scheduler_queue/conftest.py
+++ b/tests/scheduler_queue/conftest.py
@@ -11,8 +11,8 @@ from astropy.time import Time  # type: ignore[import-untyped]
 
 from conops import (
     DAY_SECONDS,
-    AttitudeConstraintPolicy,
     DumbQueueScheduler,
+    MissionConfig,
     QueueDITL,
 )
 from conops.targets.plan import Plan
@@ -82,9 +82,11 @@ def mock_config() -> Mock:
     config.constraint.in_star_tracker_soft = Mock(return_value=False)
     config.constraint.in_radiator_hard = Mock(return_value=False)
     config.constraint.in_telescope_hard = Mock(return_value=False)
+    config.constraint.in_ground_contact = Mock(return_value=False)
     config.constraint.in_eclipse = Mock(return_value=False)
-    config.attitude_constraint_policy_for_mode = Mock(
-        return_value=AttitudeConstraintPolicy.FULL_MISSION
+    default_scope_config = MissionConfig()
+    config.attitude_constraint_scopes_for_mode = Mock(
+        side_effect=default_scope_config.attitude_constraint_scopes_for_mode
     )
     config.constraint.instantaneous_field_of_regard = Mock(return_value=1.234)
 

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -12,7 +12,7 @@ from conops import (
     ACSCommand,
     ACSCommandType,
     ACSMode,
-    AttitudeConstraintPolicy,
+    AttitudeConstraintScope,
     Pass,
     PlanExecutionMismatchError,
     QueueDITL,
@@ -476,7 +476,7 @@ class TestHandleChargingMode:
         mock_charging.done = False
         mock_charging.obsid = 999001  # Add obsid attribute
         queue_ditl.charging_ppt = mock_charging
-        cast(Mock, queue_ditl.constraint).in_constraint = Mock(return_value=True)
+        cast(Mock, queue_ditl.constraint).in_panel = Mock(return_value=True)
         queue_ditl._handle_charging_mode(1000.0)
         assert mock_charging.end == 1000.0
         assert mock_charging.done is True
@@ -562,7 +562,7 @@ class TestManagePPTLifecycle:
         mock_ppt.obsid = 1001  # Add obsid attribute
         queue_ditl.ppt = mock_ppt
         queue_ditl.charging_ppt = None
-        cast(Mock, queue_ditl.constraint).in_constraint = Mock(return_value=True)
+        cast(Mock, queue_ditl.constraint).in_earth = Mock(return_value=True)
         queue_ditl._manage_ppt_lifecycle(1000.0, ACSMode.SCIENCE)
         assert queue_ditl.ppt is None
 
@@ -1040,7 +1040,7 @@ class TestFetchNewPPT:
         queue_ditl.queue.targets = [mock_ppt]
         cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
         cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(return_value=None)
-        queue_ditl.constraint.in_constraint = Mock(return_value=True)
+        queue_ditl.constraint.in_earth = Mock(return_value=True)
 
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
 
@@ -1655,8 +1655,9 @@ class TestFetchNewPPT:
         cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
         cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(return_value=None)
 
-        # Constraint reports a violation for every timestamp in the window
-        queue_ditl.constraint.in_constraint = Mock(return_value=True)
+        # Science-scope constraint reports a violation for every timestamp
+        # in the locked-roll window.
+        queue_ditl.constraint.in_earth = Mock(return_value=True)
 
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
 
@@ -1706,7 +1707,7 @@ class TestFetchNewPPT:
         cast(Mock, queue_ditl.queue).get = Mock(side_effect=get_next_not_done)
         cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
         cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(return_value=None)
-        queue_ditl.constraint.in_constraint = Mock(
+        queue_ditl.constraint.in_earth = Mock(
             side_effect=lambda ra, *args, **kwargs: ra == bad_ppt.ra
         )
 
@@ -1740,8 +1741,9 @@ class TestFetchNewPPT:
         cast(Mock, queue_ditl.acs.passrequests).current_pass = Mock(return_value=None)
         cast(Mock, queue_ditl.acs.passrequests).next_pass = Mock(return_value=None)
 
-        # Constraint reports no violation (default for the fixture, but explicit here)
-        queue_ditl.constraint.in_constraint = Mock(return_value=False)
+        # Science-scope constraints report no violation (default for the fixture,
+        # but explicit here).
+        queue_ditl.constraint.in_earth = Mock(return_value=False)
 
         queue_ditl._fetch_new_ppt(1000.0, 10.0, 20.0)
 
@@ -1773,10 +1775,7 @@ class TestFetchNewPPT:
         queue_ditl.config.spacecraft_bus.attitude_control.slew_time = Mock(
             return_value=120.0
         )
-        queue_ditl.constraint.in_constraint = Mock(
-            side_effect=lambda ra, dec, utime, **kwargs: utime == 1060.0
-        )
-        queue_ditl.constraint.in_earth = Mock(
+        queue_ditl.constraint.in_star_tracker_hard = Mock(
             side_effect=lambda ra, dec, utime, **kwargs: utime == 1060.0
         )
 
@@ -1785,7 +1784,7 @@ class TestFetchNewPPT:
         cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
         assert queue_ditl.ppt is None
         log_text = "\n".join(event.description for event in queue_ditl.log.events)
-        assert "slew path violates Earth Limb" in log_text
+        assert "slew path violates ST Hard" in log_text
 
 
 class TestRecordSpacecraftState:
@@ -2189,8 +2188,7 @@ class TestPlanExecutionValidation:
         queue_ditl.obsid = [42, 42]
         queue_ditl.ra = [10.0, 10.0]
         queue_ditl.dec = [20.0, 20.0]
-        queue_ditl.constraint.in_constraint = Mock(side_effect=[False, True])
-        queue_ditl._get_constraint_name = Mock(return_value="Earth Limb")  # type: ignore[method-assign]
+        queue_ditl.constraint.in_earth = Mock(side_effect=[False, True])
         self._index_telemetry_by_time(queue_ditl)
 
         mismatches = queue_ditl.validate_attitude_constraints()
@@ -2207,18 +2205,20 @@ class TestPlanExecutionValidation:
         queue_ditl.dec = [10.0]
         queue_ditl.roll = [5.0]
         queue_ditl.constraint.in_constraint = Mock(return_value=True)
-        queue_ditl.constraint.in_sun = Mock(return_value=True)
+        queue_ditl.constraint.in_panel = Mock(return_value=True)
         self._index_telemetry_by_time(queue_ditl)
 
         mismatches = queue_ditl.validate_attitude_constraints()
 
         assert any("mode CHARGING" in str(m) for m in mismatches)
-        assert any("Sun" in str(m) for m in mismatches)
-        queue_ditl.constraint.in_constraint.assert_called_once_with(
-            40.0, 10.0, 1060.0, target_roll=5.0, acs_mode=ACSMode.CHARGING
+        assert any("Panel" in str(m) for m in mismatches)
+        assert any("power_generation" in str(m) for m in mismatches)
+        queue_ditl.constraint.in_constraint.assert_not_called()
+        queue_ditl.constraint.in_panel.assert_called_once_with(
+            40.0, 10.0, 1060.0, target_roll=5.0
         )
 
-    def test_validation_fails_for_default_full_constraint_policy_for_pass(
+    def test_validation_fails_for_default_pass_constraint_scopes(
         self, queue_ditl: QueueDITL
     ) -> None:
         entry = PlanEntry(config=queue_ditl.config)
@@ -2249,17 +2249,17 @@ class TestPlanExecutionValidation:
         queue_ditl.dec = [20.0, 21.0]
         queue_ditl.roll = [0.0, 10.0]
         queue_ditl.constraint.in_constraint = Mock(return_value=True)
-        queue_ditl.constraint.in_sun = Mock(return_value=True)
+        queue_ditl.constraint.in_ground_contact = Mock(return_value=True)
         self._index_telemetry_by_time(queue_ditl)
 
         mismatches = queue_ditl.validate_plan_matches_execution()
 
         assert any("mode PASS" in str(m) for m in mismatches)
-        assert any("Sun" in str(m) for m in mismatches)
-        assert any("full_mission" in str(m) for m in mismatches)
-        assert queue_ditl.constraint.in_constraint.call_count == 2
+        assert any("Ground Contact" in str(m) for m in mismatches)
+        assert any("ground_contact" in str(m) for m in mismatches)
+        queue_ditl.constraint.in_constraint.assert_not_called()
 
-    def test_validation_uses_configured_full_constraint_policy_for_pass(
+    def test_validation_uses_configured_constraint_scopes_for_pass(
         self, queue_ditl: QueueDITL
     ) -> None:
         entry = PlanEntry(config=queue_ditl.config)
@@ -2288,8 +2288,11 @@ class TestPlanExecutionValidation:
         queue_ditl.ra = [10.0]
         queue_ditl.dec = [20.0]
         queue_ditl.roll = [15.0]
-        queue_ditl.config.attitude_constraint_policy_for_mode = Mock(
-            return_value=AttitudeConstraintPolicy.FULL_MISSION
+        queue_ditl.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[
+                AttitudeConstraintScope.HARDWARE_SAFETY,
+                AttitudeConstraintScope.IMAGING_QUALITY,
+            ]
         )
         queue_ditl.constraint.in_constraint = Mock(return_value=True)
         queue_ditl.constraint.in_sun = Mock(return_value=True)
@@ -2299,24 +2302,22 @@ class TestPlanExecutionValidation:
 
         assert any("mode PASS" in str(m) for m in mismatches)
         assert any("Sun" in str(m) for m in mismatches)
-        assert any("full_mission" in str(m) for m in mismatches)
-        queue_ditl.constraint.in_constraint.assert_called_once_with(
-            10.0, 20.0, 1000.0, target_roll=15.0, acs_mode=ACSMode.PASS
-        )
+        assert any("imaging_quality" in str(m) for m in mismatches)
+        queue_ditl.constraint.in_constraint.assert_not_called()
 
-    def test_hard_keepout_policy_generates_validation_mismatches_for_hard_violations(
+    def test_hardware_safety_scope_generates_mismatches_for_hard_violations(
         self, queue_ditl: QueueDITL
     ) -> None:
-        # HARD_KEEPOUT policy checks only hard keepout zones; violations ARE planning
-        # mismatches. Full mission constraints are not checked (in_constraint unused).
+        # Hardware-safety scope checks only hard keepout zones; violations ARE
+        # planning mismatches. Combined constraints are not checked.
         queue_ditl.utime = [1060.0]
         queue_ditl.mode = [ACSMode.CHARGING]
         queue_ditl.obsid = [999001]
         queue_ditl.ra = [40.0]
         queue_ditl.dec = [10.0]
         queue_ditl.roll = [5.0]
-        queue_ditl.config.attitude_constraint_policy_for_mode = Mock(
-            return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+        queue_ditl.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.HARDWARE_SAFETY]
         )
         queue_ditl.constraint.in_constraint = Mock(return_value=False)
         queue_ditl.constraint.in_star_tracker_hard = Mock(return_value=False)
@@ -2329,7 +2330,7 @@ class TestPlanExecutionValidation:
         assert any("Radiator Hard" in str(m) for m in mismatches)
         queue_ditl.constraint.in_constraint.assert_not_called()
 
-    def test_safety_policy_ignores_science_constraint_violations(
+    def test_hardware_safety_scope_ignores_imaging_constraint_violations(
         self, queue_ditl: QueueDITL
     ) -> None:
         queue_ditl.utime = [1000.0]
@@ -2338,8 +2339,8 @@ class TestPlanExecutionValidation:
         queue_ditl.ra = [10.0]
         queue_ditl.dec = [20.0]
         queue_ditl.roll = [30.0]
-        queue_ditl.config.attitude_constraint_policy_for_mode = Mock(
-            return_value=AttitudeConstraintPolicy.SAFETY
+        queue_ditl.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.HARDWARE_SAFETY]
         )
         queue_ditl.constraint.in_constraint = Mock(return_value=True)
         queue_ditl.constraint.in_earth = Mock(return_value=True)
@@ -2353,7 +2354,7 @@ class TestPlanExecutionValidation:
         assert mismatches == []
         queue_ditl.constraint.in_constraint.assert_not_called()
 
-    def test_science_plus_safety_policy_flags_science_constraint_violations(
+    def test_imaging_quality_scope_flags_imaging_constraint_violations(
         self, queue_ditl: QueueDITL
     ) -> None:
         queue_ditl.utime = [1000.0]
@@ -2362,8 +2363,11 @@ class TestPlanExecutionValidation:
         queue_ditl.ra = [10.0]
         queue_ditl.dec = [20.0]
         queue_ditl.roll = [30.0]
-        queue_ditl.config.attitude_constraint_policy_for_mode = Mock(
-            return_value=AttitudeConstraintPolicy.SCIENCE_PLUS_SAFETY
+        queue_ditl.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[
+                AttitudeConstraintScope.HARDWARE_SAFETY,
+                AttitudeConstraintScope.IMAGING_QUALITY,
+            ]
         )
         queue_ditl.constraint.in_constraint = Mock(return_value=False)
         queue_ditl.constraint.in_earth = Mock(return_value=True)
@@ -2372,7 +2376,7 @@ class TestPlanExecutionValidation:
         mismatches = queue_ditl.validate_attitude_constraints()
 
         assert any("Earth Limb" in str(m) for m in mismatches)
-        assert any("science_plus_safety" in str(m) for m in mismatches)
+        assert any("imaging_quality" in str(m) for m in mismatches)
         queue_ditl.constraint.in_constraint.assert_not_called()
 
     def test_validation_fails_for_unknown_attitude_mode(
@@ -2394,19 +2398,19 @@ class TestPlanExecutionValidation:
     @pytest.mark.parametrize(
         "mode", [ACSMode.SLEWING, ACSMode.SAA, ACSMode.SAFE, ACSMode.IDLE]
     )
-    def test_hard_keepout_policy_flags_hard_violations_as_mismatches(
+    def test_hardware_safety_scope_flags_hard_violations_as_mismatches(
         self, queue_ditl: QueueDITL, mode: ACSMode
     ) -> None:
-        # HARD_KEEPOUT policy checks hard keepout zones; violations ARE planning
-        # mismatches. Full mission constraints are not checked (in_constraint unused).
+        # Hardware-safety scope checks hard keepout zones; violations ARE planning
+        # mismatches. Combined constraints are not checked.
         queue_ditl.utime = [1000.0]
         queue_ditl.mode = [mode]
         queue_ditl.obsid = [IDLE_OBSID]
         queue_ditl.ra = [10.0]
         queue_ditl.dec = [20.0]
         queue_ditl.roll = [30.0]
-        queue_ditl.config.attitude_constraint_policy_for_mode = Mock(
-            return_value=AttitudeConstraintPolicy.HARD_KEEPOUT
+        queue_ditl.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.HARDWARE_SAFETY]
         )
         queue_ditl.constraint.in_constraint = Mock(return_value=False)
         queue_ditl.constraint.in_star_tracker_hard = Mock(return_value=False)
@@ -2419,7 +2423,7 @@ class TestPlanExecutionValidation:
         assert any("Radiator Hard" in str(m) for m in mismatches)
         queue_ditl.constraint.in_constraint.assert_not_called()
 
-    def test_validation_fails_for_idle_full_constraint_violation(
+    def test_validation_fails_for_idle_imaging_constraint_violation(
         self, queue_ditl: QueueDITL
     ) -> None:
         queue_ditl.utime = [1000.0]
@@ -2428,8 +2432,11 @@ class TestPlanExecutionValidation:
         queue_ditl.ra = [10.0]
         queue_ditl.dec = [20.0]
         queue_ditl.roll = [30.0]
-        queue_ditl.config.attitude_constraint_policy_for_mode = Mock(
-            return_value=AttitudeConstraintPolicy.FULL_MISSION
+        queue_ditl.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[
+                AttitudeConstraintScope.HARDWARE_SAFETY,
+                AttitudeConstraintScope.IMAGING_QUALITY,
+            ]
         )
         queue_ditl.constraint.in_constraint = Mock(return_value=True)
         queue_ditl.constraint.in_earth = Mock(return_value=True)
@@ -2439,10 +2446,8 @@ class TestPlanExecutionValidation:
 
         assert any("mode IDLE" in str(m) for m in mismatches)
         assert any("Earth" in str(m) for m in mismatches)
-        assert any("full_mission" in str(m) for m in mismatches)
-        queue_ditl.constraint.in_constraint.assert_called_once_with(
-            10.0, 20.0, 1000.0, target_roll=30.0, acs_mode=ACSMode.IDLE
-        )
+        assert any("imaging_quality" in str(m) for m in mismatches)
+        queue_ditl.constraint.in_constraint.assert_not_called()
 
     def test_execution_coverage_uses_full_gsp_entry_window(
         self, queue_ditl: QueueDITL
@@ -3004,10 +3009,7 @@ class TestCalcMethod:
         queue_ditl.emergency_charging.create_charging_pointing = Mock(
             return_value=charging_ppt
         )
-        queue_ditl.constraint.in_constraint = Mock(
-            side_effect=lambda ra, dec, utime, **kwargs: utime == 1060.0
-        )
-        queue_ditl.constraint.in_earth = Mock(
+        queue_ditl.constraint.in_star_tracker_hard = Mock(
             side_effect=lambda ra, dec, utime, **kwargs: utime == 1060.0
         )
 
@@ -3020,7 +3022,7 @@ class TestCalcMethod:
         assert science_ppt.done is False
         log_text = "\n".join(event.description for event in queue_ditl.log.events)
         assert "Skipping emergency charge slew" in log_text
-        assert "Earth Limb" in log_text
+        assert "ST Hard" in log_text
 
     def test_calc_drops_short_science_entry_when_charging_interrupts(
         self, queue_ditl
@@ -3666,17 +3668,20 @@ class TestGetConstraintName:
         queue_ditl.constraint.in_star_tracker_hard = Mock(return_value=False)
         queue_ditl.constraint.in_star_tracker_soft = Mock(return_value=False)
         _ = queue_ditl._get_constraint_name(ra, dec, utime)
-        # Order: Sun, Earth, Panel — Moon is never reached
+        # Order checks hardware safety first, then imaging-quality, then
+        # power-generation, so Moon is checked before Panel.
         queue_ditl.constraint.in_sun.assert_called_once_with(
             ra, dec, utime, target_roll=None
         )
         queue_ditl.constraint.in_earth.assert_called_once_with(
             ra, dec, utime, target_roll=None
         )
+        queue_ditl.constraint.in_moon.assert_called_once_with(
+            ra, dec, utime, target_roll=None
+        )
         queue_ditl.constraint.in_panel.assert_called_once_with(
             ra, dec, utime, target_roll=None
         )
-        queue_ditl.constraint.in_moon.assert_not_called()
 
     def test_get_constraint_name_unknown_name(self, queue_ditl) -> None:
         ra, dec, utime = 14.0, 24.0, 5000.0
@@ -4025,10 +4030,7 @@ class TestCheckAndManagePasses:
         queue_ditl.acs.passrequests.current_pass = Mock(return_value=None)
         queue_ditl.acs.passrequests.next_pass = Mock(return_value=pass_obj)
         queue_ditl.acs.acsmode = ACSMode.SCIENCE
-        queue_ditl.constraint.in_constraint = Mock(
-            side_effect=lambda ra, dec, utime, **kwargs: utime == 1060.0
-        )
-        queue_ditl.constraint.in_earth = Mock(
+        queue_ditl.constraint.in_ground_contact = Mock(
             side_effect=lambda ra, dec, utime, **kwargs: utime == 1060.0
         )
 
@@ -4039,7 +4041,7 @@ class TestCheckAndManagePasses:
         assert len(queue_ditl.plan) == 0
         log_text = "\n".join(event.description for event in queue_ditl.log.events)
         assert "Skipping pass slew to GS_TEST" in log_text
-        assert "Earth Limb" in log_text
+        assert "Ground Contact" in log_text
 
     def test_check_and_manage_passes_exports_gsp_plan_entry_for_pass_slew(
         self, queue_ditl, tmp_path
@@ -5567,8 +5569,9 @@ class TestQueueDITLCoverage:
             mock_queue.get = Mock(return_value=None)
             mock_queue_class.return_value = mock_queue
 
-            # Mock constraint
+            # Mock a charging-scope power-generation violation.
             mock_config.constraint.in_constraint = Mock(return_value=True)
+            mock_config.constraint.in_panel = Mock(return_value=True)
 
             ditl = QueueDITL(config=mock_config, ephem=mock_ephem, queue=mock_queue)
             ditl.acs = mock_acs
@@ -5584,9 +5587,10 @@ class TestQueueDITLCoverage:
             # Call _manage_ppt_lifecycle
             ditl._manage_ppt_lifecycle(1000.0, ACSMode.SCIENCE)
 
-            # Verify constraint check and termination
-            mock_config.constraint.in_constraint.assert_called_once_with(
-                10.0, 20.0, 1000.0, target_roll=mock_acs.roll, acs_mode=ACSMode.CHARGING
+            # Verify scoped constraint check and termination.
+            mock_config.constraint.in_constraint.assert_not_called()
+            mock_config.constraint.in_panel.assert_called_once_with(
+                10.0, 20.0, 1000.0, target_roll=mock_acs.roll
             )
             mock_terminate.assert_called_once_with("constraint", 1000.0)
 

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -2329,6 +2329,52 @@ class TestPlanExecutionValidation:
         assert any("Radiator Hard" in str(m) for m in mismatches)
         queue_ditl.constraint.in_constraint.assert_not_called()
 
+    def test_safety_policy_ignores_science_constraint_violations(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.utime = [1000.0]
+        queue_ditl.mode = [ACSMode.IDLE]
+        queue_ditl.obsid = [IDLE_OBSID]
+        queue_ditl.ra = [10.0]
+        queue_ditl.dec = [20.0]
+        queue_ditl.roll = [30.0]
+        queue_ditl.config.attitude_constraint_policy_for_mode = Mock(
+            return_value=AttitudeConstraintPolicy.SAFETY
+        )
+        queue_ditl.constraint.in_constraint = Mock(return_value=True)
+        queue_ditl.constraint.in_earth = Mock(return_value=True)
+        queue_ditl.constraint.in_star_tracker_hard = Mock(return_value=False)
+        queue_ditl.constraint.in_radiator_hard = Mock(return_value=False)
+        queue_ditl.constraint.in_telescope_hard = Mock(return_value=False)
+        self._index_telemetry_by_time(queue_ditl)
+
+        mismatches = queue_ditl.validate_attitude_constraints()
+
+        assert mismatches == []
+        queue_ditl.constraint.in_constraint.assert_not_called()
+
+    def test_science_plus_safety_policy_flags_science_constraint_violations(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.utime = [1000.0]
+        queue_ditl.mode = [ACSMode.IDLE]
+        queue_ditl.obsid = [IDLE_OBSID]
+        queue_ditl.ra = [10.0]
+        queue_ditl.dec = [20.0]
+        queue_ditl.roll = [30.0]
+        queue_ditl.config.attitude_constraint_policy_for_mode = Mock(
+            return_value=AttitudeConstraintPolicy.SCIENCE_PLUS_SAFETY
+        )
+        queue_ditl.constraint.in_constraint = Mock(return_value=False)
+        queue_ditl.constraint.in_earth = Mock(return_value=True)
+        self._index_telemetry_by_time(queue_ditl)
+
+        mismatches = queue_ditl.validate_attitude_constraints()
+
+        assert any("Earth Limb" in str(m) for m in mismatches)
+        assert any("science_plus_safety" in str(m) for m in mismatches)
+        queue_ditl.constraint.in_constraint.assert_not_called()
+
     def test_validation_fails_for_unknown_attitude_mode(
         self, queue_ditl: QueueDITL
     ) -> None:
@@ -5480,7 +5526,6 @@ class TestQueueDITLCoverage:
             patch("conops.Queue") as mock_queue_class,
             patch("conops.PassTimes") as mock_passtimes,
             patch("conops.ACS") as mock_acs_class,
-            patch.object(QueueDITL, "_get_constraint_name") as mock_get_constraint,
             patch.object(QueueDITL, "_terminate_emergency_charging") as mock_terminate,
         ):
             # Mock PassTimes
@@ -5524,7 +5569,6 @@ class TestQueueDITLCoverage:
 
             # Mock constraint
             mock_config.constraint.in_constraint = Mock(return_value=True)
-            mock_get_constraint.return_value = "SAA"
 
             ditl = QueueDITL(config=mock_config, ephem=mock_ephem, queue=mock_queue)
             ditl.acs = mock_acs
@@ -5543,9 +5587,6 @@ class TestQueueDITLCoverage:
             # Verify constraint check and termination
             mock_config.constraint.in_constraint.assert_called_once_with(
                 10.0, 20.0, 1000.0, target_roll=mock_acs.roll, acs_mode=ACSMode.CHARGING
-            )
-            mock_get_constraint.assert_called_once_with(
-                10.0, 20.0, 1000.0, roll=mock_acs.roll, mode=ACSMode.CHARGING
             )
             mock_terminate.assert_called_once_with("constraint", 1000.0)
 


### PR DESCRIPTION
## Problem
The previous policy model was too coarse. It could distinguish science from safety, but it could not express the actual operational categories independently:

- hardware safety keepouts that apply to all executed attitudes
- imaging-quality constraints used for science collection and target selection
- power-generation constraints used for charge and power-positive attitudes
- ground-contact constraints used for GSP tracking attitudes

That made charge and pass modes either inherit imaging-quality rules they should not enforce, or skip non-imaging constraints they still need.

## Solution
- Replace `AttitudeConstraintPolicy` / `attitude_constraint_policy` with explicit `AttitudeConstraintScope` / `attitude_constraint_scopes`.
- Add scopes: `hardware_safety`, `imaging_quality`, `power_generation`, and `ground_contact`.
- Default mode scopes:
  - `SCIENCE`: hardware safety + imaging quality + power generation
  - `CHARGING`: hardware safety + power generation
  - `SLEWING`: hardware safety
  - `PASS`: hardware safety + power generation + ground contact
  - `SAA`: hardware safety
  - `SAFE`: hardware safety + power generation
  - `IDLE`: hardware safety
- Classify top-level Sun/Earth/Moon/orbit/anti-sun/STR-soft/science constraints as imaging quality.
- Classify panel constraints as power generation.
- Classify explicit safety, STR-hard, radiator-hard, and telescope-hard constraints as hardware safety.
- Add a separate `ground_contact_constraint` hook for contact tracking constraints.
- Route ACS idle holds, emergency charging, GSP pass filtering, housekeeping telemetry, locked-roll science checks, and post-run validation through configured scopes.
- Remove the old policy compatibility aliases and old `science_plus_safety` naming from the touched API surface.

## Compatibility
This is intentionally a breaking config API change. Mission configs should use `attitude_constraint_scopes` with lists of scope strings. Old `attitude_constraint_policy` values are not preserved.

## Validation
- `PYTHONPATH=. coastvenv/bin/python -m pytest tests/config/test_config.py tests/constraint/test_constraint.py tests/acs/test_acs.py tests/acs/test_acs_roll.py tests/passes/test_passes.py tests/scheduler_queue/test_queue_ditl.py -q`
  - `496 passed`
- `git diff --check`
  - clean
- Verified with the matching Tamalpais config update in CosmicFrontierLabs/tamalpais-configuration#23.