### PR TITLE
fix: scope ACS constraint logging

### DIFF
--- a/conops/config/constraint.py
+++ b/conops/config/constraint.py
@@ -1264,6 +1264,36 @@ def imaging_quality_attitude_constraint_name(
     return None
 
 
+def imaging_quality_attitude_constraint_names(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> list[str]:
+    """Return all violated imaging-quality constraint names."""
+    names = []
+    if constraint.in_sun(ra, dec, utime, target_roll=target_roll):
+        names.append("Sun")
+    if constraint.in_earth(ra, dec, utime, target_roll=target_roll):
+        names.append("Earth Limb")
+    if constraint.in_moon(ra, dec, utime, target_roll=target_roll):
+        names.append("Moon")
+    if constraint.in_anti_sun(ra, dec, utime, target_roll=target_roll):
+        names.append("Anti-Sun")
+    if constraint.in_orbit(ra, dec, utime, target_roll=target_roll):
+        names.append("Orbit")
+    if constraint.in_star_tracker_soft(
+        ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+    ):
+        names.append("ST Soft")
+    if _has_real_constraint_method(constraint, "in_explicit_science"):
+        if constraint.in_explicit_science(ra, dec, utime, target_roll=target_roll):
+            names.append("Science")
+    return names
+
+
 def power_generation_attitude_constraint_name(
     constraint: Constraint,
     ra: float,
@@ -1278,6 +1308,20 @@ def power_generation_attitude_constraint_name(
     return None
 
 
+def power_generation_attitude_constraint_names(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> list[str]:
+    """Return all violated power-generation constraint names."""
+    if constraint.in_panel(ra, dec, utime, target_roll=target_roll):
+        return ["Panel"]
+    return []
+
+
 def ground_contact_attitude_constraint_name(
     constraint: Constraint,
     ra: float,
@@ -1290,6 +1334,20 @@ def ground_contact_attitude_constraint_name(
     if constraint.in_ground_contact(ra, dec, utime, target_roll=target_roll):
         return "Ground Contact"
     return None
+
+
+def ground_contact_attitude_constraint_names(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> list[str]:
+    """Return all violated ground-contact constraint names."""
+    if constraint.in_ground_contact(ra, dec, utime, target_roll=target_roll):
+        return ["Ground Contact"]
+    return []
 
 
 def hardware_safety_attitude_constraint_name(
@@ -1313,6 +1371,30 @@ def hardware_safety_attitude_constraint_name(
     if constraint.in_telescope_hard(ra, dec, utime, target_roll=target_roll):
         return "Telescope Hard"
     return None
+
+
+def hardware_safety_attitude_constraint_names(
+    constraint: Constraint,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> list[str]:
+    """Return all violated hardware-safety constraint names."""
+    names = []
+    if _has_real_constraint_method(constraint, "in_explicit_safety"):
+        if constraint.in_explicit_safety(ra, dec, utime, target_roll=target_roll):
+            names.append("Safety")
+    if constraint.in_star_tracker_hard(
+        ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+    ):
+        names.append("ST Hard")
+    if constraint.in_radiator_hard(ra, dec, utime, target_roll=target_roll):
+        names.append("Radiator Hard")
+    if constraint.in_telescope_hard(ra, dec, utime, target_roll=target_roll):
+        names.append("Telescope Hard")
+    return names
 
 
 def attitude_constraint_name_for_scope(
@@ -1345,6 +1427,36 @@ def attitude_constraint_name_for_scope(
     raise ValueError(f"Unknown attitude constraint scope: {scope_value!r}")
 
 
+def attitude_constraint_names_for_scope(
+    constraint: Constraint,
+    scope: str | Enum,
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> list[str]:
+    """Return all violated constraint names for one configured scope."""
+    scope_value = _attitude_scope_value(scope)
+    if scope_value == AttitudeConstraintScope.HARDWARE_SAFETY.value:
+        return hardware_safety_attitude_constraint_names(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if scope_value == AttitudeConstraintScope.IMAGING_QUALITY.value:
+        return imaging_quality_attitude_constraint_names(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if scope_value == AttitudeConstraintScope.POWER_GENERATION.value:
+        return power_generation_attitude_constraint_names(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    if scope_value == AttitudeConstraintScope.GROUND_CONTACT.value:
+        return ground_contact_attitude_constraint_names(
+            constraint, ra, dec, utime, target_roll=target_roll, acs_mode=acs_mode
+        )
+    raise ValueError(f"Unknown attitude constraint scope: {scope_value!r}")
+
+
 def attitude_constraint_name_for_scopes(
     constraint: Constraint,
     scopes: list[str | Enum],
@@ -1368,6 +1480,32 @@ def attitude_constraint_name_for_scopes(
         if name is not None:
             return name
     return None
+
+
+def attitude_constraint_names_for_scopes(
+    constraint: Constraint,
+    scopes: list[str | Enum],
+    ra: float,
+    dec: float,
+    utime: float,
+    target_roll: float | None = None,
+    acs_mode: ACSMode | int | None = None,
+) -> list[str]:
+    """Return all violated constraint names for configured scopes."""
+    names = []
+    for scope in _attitude_scope_values(scopes):
+        names.extend(
+            attitude_constraint_names_for_scope(
+                constraint,
+                scope,
+                ra,
+                dec,
+                utime,
+                target_roll=target_roll,
+                acs_mode=acs_mode,
+            )
+        )
+    return names
 
 
 def science_attitude_constraint_name(

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -13,6 +13,7 @@ from ..common import (
 from ..common.vector import angular_separation
 from ..config import AttitudeConstraintScope, FaultEvent, MissionConfig
 from ..config.constraint import (
+    attitude_constraint_name_for_scopes,
     attitude_constraint_scope_label,
     in_attitude_constraint_scopes,
 )
@@ -911,45 +912,32 @@ class ACS:
             and self.last_slew.at is not None
             and not isinstance(self.last_slew.at, bool)
             and self.last_slew.obstype == ObsType.PPT
-            and self.constraint.in_constraint(
+        ):
+            assert self.last_slew.at is not None
+
+            scopes = self.config.attitude_constraint_scopes_for_mode(self.acsmode)
+            constraint_name = attitude_constraint_name_for_scopes(
+                self.constraint,
+                scopes,
                 self.last_slew.at.ra,
                 self.last_slew.at.dec,
                 utime,
                 target_roll=self.roll,
+                acs_mode=self.acsmode,
             )
-        ):
-            assert self.last_slew.at is not None
 
-            # Keep the target's stored roll in sync with the ACS locked roll.
-            self.last_slew.at.roll = self.roll
-
-            # Collect only the true constraints
-            true_constraints = []
-            if self.last_slew.at.in_moon(utime):
-                true_constraints.append("Moon")
-            if self.last_slew.at.in_sun(utime):
-                true_constraints.append("Sun")
-            if self.last_slew.at.in_earth(utime):
-                true_constraints.append("Earth")
-            if self.last_slew.at.in_panel(utime):
-                true_constraints.append("Panel")
-            if self.last_slew.at.in_star_tracker_hard(utime, acs_mode=self.acsmode):
-                true_constraints.append("ST Hard")
-            if self.last_slew.at.in_star_tracker_soft(utime, acs_mode=self.acsmode):
-                true_constraints.append("ST Soft")
-
-            # Print only if there are true constraints
-            if true_constraints:
+            if constraint_name is not None:
                 self._log_or_print(
                     utime,
                     "CONSTRAINT",
-                    "%s: CONSTRAINT: RA=%s Dec=%s obsid=%s %s"
+                    "%s: CONSTRAINT: RA=%s Dec=%s obsid=%s %s (%s)"
                     % (
                         unixtime2date(utime),
                         self.last_slew.at.ra,
                         self.last_slew.at.dec,
                         self.last_slew.obsid,
-                        " ".join(true_constraints),
+                        constraint_name,
+                        attitude_constraint_scope_label(scopes),
                     ),
                 )
         # Check star tracker constraints

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -13,7 +13,7 @@ from ..common import (
 from ..common.vector import angular_separation
 from ..config import AttitudeConstraintScope, FaultEvent, MissionConfig
 from ..config.constraint import (
-    attitude_constraint_name_for_scopes,
+    attitude_constraint_names_for_scopes,
     attitude_constraint_scope_label,
     in_attitude_constraint_scopes,
 )
@@ -916,7 +916,7 @@ class ACS:
             assert self.last_slew.at is not None
 
             scopes = self.config.attitude_constraint_scopes_for_mode(self.acsmode)
-            constraint_name = attitude_constraint_name_for_scopes(
+            constraint_names = attitude_constraint_names_for_scopes(
                 self.constraint,
                 scopes,
                 self.last_slew.at.ra,
@@ -926,7 +926,7 @@ class ACS:
                 acs_mode=self.acsmode,
             )
 
-            if constraint_name is not None:
+            if constraint_names:
                 self._log_or_print(
                     utime,
                     "CONSTRAINT",
@@ -936,7 +936,7 @@ class ACS:
                         self.last_slew.at.ra,
                         self.last_slew.at.dec,
                         self.last_slew.obsid,
-                        constraint_name,
+                        " ".join(constraint_names),
                         attitude_constraint_scope_label(scopes),
                     ),
                 )

--- a/tests/acs/test_acs.py
+++ b/tests/acs/test_acs.py
@@ -309,6 +309,49 @@ class TestACSStateManagement:
         assert "Panel" in constraint_calls[0].args[2]
         assert "power_generation" in constraint_calls[0].args[2]
 
+    def test_constraint_logging_reports_all_scoped_violations(self, acs) -> None:
+        """Telemetry should report every violation within the active scopes."""
+        science_slew = Slew(config=acs.config)
+        science_slew.obstype = ObsType.PPT
+        science_slew.obsid = 42
+        science_slew.at = Mock(ra=10.0, dec=20.0, roll=0.0)
+        acs.last_slew = science_slew
+        acs.acsmode = ACSMode.SCIENCE
+        acs.roll = 30.0
+        acs.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[
+                AttitudeConstraintScope.IMAGING_QUALITY,
+                AttitudeConstraintScope.POWER_GENERATION,
+            ]
+        )
+        acs.config.spacecraft_bus.star_trackers = Mock()
+        acs.config.spacecraft_bus.star_trackers.num_trackers = Mock(return_value=0)
+        acs.constraint.in_constraint = Mock(return_value=False)
+        acs.constraint.in_sun = Mock(return_value=True)
+        acs.constraint.in_earth = Mock(return_value=True)
+        acs.constraint.in_moon = Mock(return_value=False)
+        acs.constraint.in_anti_sun = Mock(return_value=False)
+        acs.constraint.in_orbit = Mock(return_value=False)
+        acs.constraint.in_star_tracker_soft = Mock(return_value=False)
+        acs.constraint.in_panel = Mock(return_value=True)
+        acs.constraint.in_star_tracker_hard = Mock(return_value=False)
+        acs.constraint.in_radiator_hard = Mock(return_value=False)
+        acs.constraint.in_telescope_hard = Mock(return_value=False)
+        acs._log_or_print = Mock()
+
+        acs._check_constraints(1000.0)
+
+        acs.constraint.in_constraint.assert_not_called()
+        constraint_calls = [
+            call
+            for call in acs._log_or_print.call_args_list
+            if call.args[1] == "CONSTRAINT"
+        ]
+        assert len(constraint_calls) == 1
+        description = constraint_calls[0].args[2]
+        assert "Sun Earth Limb Panel" in description
+        assert "imaging_quality+power_generation" in description
+
 
 class TestACSPassRequestManagement:
     """Test pass request management."""

--- a/tests/acs/test_acs.py
+++ b/tests/acs/test_acs.py
@@ -246,6 +246,69 @@ class TestACSStateManagement:
         assert acs.config.fault_management.events[-1].event_type == "safe_mode_trigger"
         assert acs.config.fault_management.events[-1].name == "idle_attitude_constraint"
 
+    def test_constraint_logging_uses_idle_scopes(self, acs) -> None:
+        """Legacy CONSTRAINT telemetry should respect the current ACS mode scopes."""
+        science_slew = Slew(config=acs.config)
+        science_slew.obstype = ObsType.PPT
+        science_slew.obsid = 42
+        science_slew.at = Mock(ra=10.0, dec=20.0, roll=0.0)
+        acs.last_slew = science_slew
+        acs.acsmode = ACSMode.IDLE
+        acs.roll = 30.0
+        acs.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.HARDWARE_SAFETY]
+        )
+        acs.config.spacecraft_bus.star_trackers = Mock()
+        acs.config.spacecraft_bus.star_trackers.num_trackers = Mock(return_value=0)
+        acs.constraint.in_constraint = Mock(return_value=True)
+        acs.constraint.in_panel = Mock(return_value=True)
+        acs.constraint.in_star_tracker_hard = Mock(return_value=False)
+        acs.constraint.in_radiator_hard = Mock(return_value=False)
+        acs.constraint.in_telescope_hard = Mock(return_value=False)
+        acs._log_or_print = Mock()
+
+        acs._check_constraints(1000.0)
+
+        acs.constraint.in_constraint.assert_not_called()
+        assert science_slew.at.roll == 0.0
+        assert not any(
+            call.args[1] == "CONSTRAINT" for call in acs._log_or_print.call_args_list
+        )
+
+    def test_constraint_logging_reports_power_generation_scope(self, acs) -> None:
+        """Telemetry should still report power-generation scoped violations."""
+        science_slew = Slew(config=acs.config)
+        science_slew.obstype = ObsType.PPT
+        science_slew.obsid = 42
+        science_slew.at = Mock(ra=10.0, dec=20.0, roll=0.0)
+        acs.last_slew = science_slew
+        acs.acsmode = ACSMode.SCIENCE
+        acs.roll = 30.0
+        acs.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.POWER_GENERATION]
+        )
+        acs.config.spacecraft_bus.star_trackers = Mock()
+        acs.config.spacecraft_bus.star_trackers.num_trackers = Mock(return_value=0)
+        acs.constraint.in_constraint = Mock(return_value=False)
+        acs.constraint.in_panel = Mock(return_value=True)
+        acs.constraint.in_star_tracker_hard = Mock(return_value=False)
+        acs.constraint.in_radiator_hard = Mock(return_value=False)
+        acs.constraint.in_telescope_hard = Mock(return_value=False)
+        acs._log_or_print = Mock()
+
+        acs._check_constraints(1000.0)
+
+        acs.constraint.in_constraint.assert_not_called()
+        assert science_slew.at.roll == 0.0
+        constraint_calls = [
+            call
+            for call in acs._log_or_print.call_args_list
+            if call.args[1] == "CONSTRAINT"
+        ]
+        assert len(constraint_calls) == 1
+        assert "Panel" in constraint_calls[0].args[2]
+        assert "power_generation" in constraint_calls[0].args[2]
+
 
 class TestACSPassRequestManagement:
     """Test pass request management."""

--- a/tests/constraint/test_constraint.py
+++ b/tests/constraint/test_constraint.py
@@ -8,6 +8,7 @@ import pytest
 from conops import AttitudeConstraintScope, Constraint, DefaultConstraint
 from conops.config.constraint import (
     attitude_constraint_name_for_scopes,
+    attitude_constraint_names_for_scopes,
     in_attitude_constraint_scopes,
 )
 
@@ -348,6 +349,29 @@ class TestConstraintScopes:
             )
             is None
         )
+
+    @patch("conops.Constraint.in_panel")
+    @patch("conops.Constraint.in_earth")
+    @patch("conops.Constraint.in_sun")
+    def test_scope_names_helper_reports_all_configured_violations(
+        self, mock_sun, mock_earth, mock_panel
+    ) -> None:
+        """Central scope names helper reports every active scoped constraint."""
+        constraint = Constraint()
+        mock_sun.return_value = True
+        mock_earth.return_value = True
+        mock_panel.return_value = True
+
+        assert attitude_constraint_names_for_scopes(
+            constraint,
+            [
+                AttitudeConstraintScope.IMAGING_QUALITY,
+                AttitudeConstraintScope.POWER_GENERATION,
+            ],
+            45.0,
+            30.0,
+            1700000000.0,
+        ) == ["Sun", "Earth Limb", "Panel"]
 
 
 class TestRollIndependentConstraint:


### PR DESCRIPTION
## Summary
- Make ACS legacy `CONSTRAINT` telemetry use `attitude_constraint_name_for_scopes()` with the current ACS mode scopes.
- Preserve the `CONSTRAINT` event type for compatibility, but include the active scope label in the message.
- Add regressions for `IDLE`/`hardware_safety` ignoring panel violations and `CHARGING`/`power_generation` reporting them.

## Problem
After explicit attitude constraint scopes were added, planning and validation used scoped attitude constraints, but `ACS._check_constraints()` still sampled the global `in_constraint()` helper. That made `IDLE` attitudes log `Panel` violations even when `IDLE` only enforced `hardware_safety`, which confused downstream mission seed gates.

## Validation
- `PYTHONPATH=. coastvenv/bin/python -m pytest tests/acs/test_acs.py tests/constraint/test_constraint.py -q`
- `coastvenv/bin/python -m ruff check conops/simulation/acs.py tests/acs/test_acs.py`
- `git diff --check`

Note: local pre-commit stopped only because the `mypy` executable is unavailable in this checkout; ruff and tests passed.