### PR TITLE
fix: export scoped attitude constraint telemetry

### DIFF
--- a/conops/ditl/ditl.py
+++ b/conops/ditl/ditl.py
@@ -8,6 +8,11 @@ from conops.targets.plan import Plan
 from ..common import angular_separation, dtutcfromtimestamp, radec2vec, scbodyvector
 from ..common.vector import attitude_to_quat
 from ..config import MissionConfig
+from ..config.constraint import (
+    all_attitude_constraint_name,
+    attitude_constraint_name_for_scopes,
+    attitude_constraint_scope_label,
+)
 from ..simulation.roll import optimum_roll
 from .ditl_log import DITLLog
 from .ditl_mixin import DITLMixin
@@ -259,6 +264,33 @@ class DITL(DITLMixin, DITLStats):
                 if self.calculate_field_of_regard
                 else None
             )
+            violated = self.constraint.in_constraint(
+                ra, dec, self.utime[i], target_roll=roll, acs_mode=mode
+            )
+            in_constraint_name = None
+            if violated:
+                in_constraint_name = (
+                    all_attitude_constraint_name(
+                        self.constraint,
+                        ra,
+                        dec,
+                        self.utime[i],
+                        target_roll=roll,
+                        acs_mode=mode,
+                    )
+                    or "Unknown"
+                )
+            scopes = self.config.attitude_constraint_scopes_for_mode(mode)
+            scope_constraint_name = attitude_constraint_name_for_scopes(
+                self.constraint,
+                scopes,
+                ra,
+                dec,
+                self.utime[i],
+                target_roll=roll,
+                acs_mode=mode,
+            )
+            scope_label = attitude_constraint_scope_label(scopes)
             _q = attitude_to_quat(ra, dec, roll)
             hk = Housekeeping(
                 timestamp=datetime.fromtimestamp(self.utime[i], tz=timezone.utc),
@@ -291,6 +323,11 @@ class DITL(DITLMixin, DITLStats):
                 ),
                 radiator_hard_violations=self.acs.radiator_hard_violations,
                 telescope_hard_violations=self.acs.telescope_hard_violations,
+                in_constraint=in_constraint_name,
+                attitude_constraint=scope_constraint_name,
+                attitude_constraint_scope=scope_label
+                if scope_constraint_name is not None
+                else None,
                 radiator_sun_exposure=self.acs.radiator_sun_exposure,
                 radiator_earth_exposure=self.acs.radiator_earth_exposure,
                 radiator_heat_dissipation_w=self.acs.radiator_heat_dissipation_w,

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1177,8 +1177,9 @@ class QueueDITL(DITLMixin, DITLStats):
             target_roll=roll,
             acs_mode=mode,
         )
+        scope_label = attitude_constraint_scope_label(scopes)
         _constraint_violation = (
-            (scope_constraint_name, attitude_constraint_scope_label(scopes))
+            (scope_constraint_name, scope_label)
             if scope_constraint_name is not None
             else None
         )
@@ -1242,6 +1243,10 @@ class QueueDITL(DITLMixin, DITLStats):
                 else None
             ),
             in_constraint=in_constraint_name,
+            attitude_constraint=scope_constraint_name,
+            attitude_constraint_scope=scope_label
+            if scope_constraint_name is not None
+            else None,
             ppt_unavailable=self._ppt_unavailable,
             radiator_hard_violations=self.acs.radiator_hard_violations,
             telescope_hard_violations=self.acs.telescope_hard_violations,

--- a/conops/ditl/telemetry.py
+++ b/conops/ditl/telemetry.py
@@ -118,7 +118,19 @@ class Housekeeping(BaseModel):
         ),
     )
     in_constraint: str | None = Field(
-        default=None, description="Name of currently violated constraint (if any)"
+        default=None,
+        description=(
+            "Name of any globally configured constraint violated by the attitude "
+            "(legacy diagnostic; not scoped by ACS mode)"
+        ),
+    )
+    attitude_constraint: str | None = Field(
+        default=None,
+        description="Name of active scoped attitude constraint violation (if any)",
+    )
+    attitude_constraint_scope: str | None = Field(
+        default=None,
+        description="Configured attitude constraint scope label for active violation",
     )
     ppt_unavailable: bool | None = Field(
         default=None,
@@ -372,6 +384,16 @@ class HousekeepingList(list[Housekeeping]):
     def in_constraint(self) -> list[str | None]:
         """Get violated constraint names from all housekeeping records."""
         return [hk.in_constraint for hk in self]
+
+    @property
+    def attitude_constraint(self) -> list[str | None]:
+        """Get active scoped attitude constraint violations from all records."""
+        return [hk.attitude_constraint for hk in self]
+
+    @property
+    def attitude_constraint_scope(self) -> list[str | None]:
+        """Get active scoped attitude constraint labels from all records."""
+        return [hk.attitude_constraint_scope for hk in self]
 
     @property
     def radiator_hard_violations(self) -> list[int | None]:

--- a/tests/ditl/conftest.py
+++ b/tests/ditl/conftest.py
@@ -214,6 +214,7 @@ def mock_config_detailed():
     config.constraint.panel_constraint.solar_panel = Mock()
     config.constraint.in_constraint = Mock(return_value=False)
     config.constraint.instantaneous_field_of_regard = Mock(return_value=1.234)
+    config.attitude_constraint_scopes_for_mode = Mock(return_value=[])
 
     # Mock battery
     config.battery = Mock()

--- a/tests/ditl/test_ditl.py
+++ b/tests/ditl/test_ditl.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pytest
 
-from conops import DITL, ACSMode, DITLs
+from conops import DITL, ACSMode, AttitudeConstraintScope, DITLs
 
 
 class TestDITLInit:
@@ -90,6 +90,50 @@ class TestDITLCalc:
         assert len(ditl.batterylevel) == simlen
         assert len(ditl.batteryalert) == simlen
         assert len(ditl.power) == simlen
+
+    def test_calc_housekeeping_separates_global_from_scoped_constraints(
+        self, ditl: DITL
+    ) -> None:
+        """DITL housekeeping should keep legacy and scoped violations distinct."""
+        ditl.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.HARDWARE_SAFETY]
+        )
+        ditl.constraint.in_constraint = Mock(return_value=True)
+        ditl.constraint.in_star_tracker_hard = Mock(return_value=False)
+        ditl.constraint.in_radiator_hard = Mock(return_value=False)
+        ditl.constraint.in_telescope_hard = Mock(return_value=False)
+        ditl.constraint.in_sun = Mock(return_value=False)
+        ditl.constraint.in_earth = Mock(return_value=True)
+        ditl.constraint.in_moon = Mock(return_value=False)
+        ditl.constraint.in_anti_sun = Mock(return_value=False)
+        ditl.constraint.in_orbit = Mock(return_value=False)
+        ditl.constraint.in_star_tracker_soft = Mock(return_value=False)
+        ditl.constraint.in_panel = Mock(return_value=False)
+        ditl.constraint.in_ground_contact = Mock(return_value=False)
+
+        ditl.calc()
+
+        hk = ditl.telemetry.housekeeping[0]
+        assert hk.in_constraint == "Earth Limb"
+        assert hk.attitude_constraint is None
+        assert hk.attitude_constraint_scope is None
+
+    def test_calc_housekeeping_exports_scoped_constraint_violation(
+        self, ditl: DITL
+    ) -> None:
+        """DITL housekeeping should export active scoped attitude violations."""
+        ditl.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.POWER_GENERATION]
+        )
+        ditl.constraint.in_constraint = Mock(return_value=False)
+        ditl.constraint.in_panel = Mock(return_value=True)
+
+        ditl.calc()
+
+        hk = ditl.telemetry.housekeeping[0]
+        assert hk.in_constraint is None
+        assert hk.attitude_constraint == "Panel"
+        assert hk.attitude_constraint_scope == "power_generation"
 
 
 class TestDITLSimulationLoop:

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -2354,6 +2354,47 @@ class TestPlanExecutionValidation:
         assert mismatches == []
         queue_ditl.constraint.in_constraint.assert_not_called()
 
+    def test_housekeeping_separates_global_from_scoped_constraint_violations(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.HARDWARE_SAFETY]
+        )
+        queue_ditl.constraint.in_constraint = Mock(return_value=True)
+        queue_ditl.constraint.in_earth = Mock(return_value=True)
+        queue_ditl.constraint.in_star_tracker_hard = Mock(return_value=False)
+        queue_ditl.constraint.in_radiator_hard = Mock(return_value=False)
+        queue_ditl.constraint.in_telescope_hard = Mock(return_value=False)
+
+        hk = queue_ditl._create_housekeeping_record(
+            1000.0, 10.0, 20.0, 30.0, ACSMode.IDLE
+        )
+
+        assert hk.in_constraint == "Earth Limb"
+        assert hk.attitude_constraint is None
+        assert hk.attitude_constraint_scope is None
+        assert queue_ditl._attitude_constraint_violations == [None]
+
+    def test_housekeeping_exports_scoped_constraint_violation(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.config.attitude_constraint_scopes_for_mode = Mock(
+            return_value=[AttitudeConstraintScope.POWER_GENERATION]
+        )
+        queue_ditl.constraint.in_constraint = Mock(return_value=False)
+        queue_ditl.constraint.in_panel = Mock(return_value=True)
+
+        hk = queue_ditl._create_housekeeping_record(
+            1000.0, 10.0, 20.0, 30.0, ACSMode.CHARGING
+        )
+
+        assert hk.in_constraint is None
+        assert hk.attitude_constraint == "Panel"
+        assert hk.attitude_constraint_scope == "power_generation"
+        assert queue_ditl._attitude_constraint_violations == [
+            ("Panel", "power_generation")
+        ]
+
     def test_imaging_quality_scope_flags_imaging_constraint_violations(
         self, queue_ditl: QueueDITL
     ) -> None:


### PR DESCRIPTION
## Problem
The DITL housekeeping `in_constraint` field reports any globally configured constraint hit. That is useful diagnostic data, but it is not scoped by the ACS mode's active attitude constraint scopes. Downstream consumers can therefore interpret a non-active science/performance keepout as an executed hard violation.

## Solution
- Add `Housekeeping.attitude_constraint` for the active scoped attitude constraint violation, if any.
- Add `Housekeeping.attitude_constraint_scope` with the configured scope label for that active violation.
- Keep legacy `in_constraint` unchanged for compatibility and diagnostics.
- Populate the new fields from the same scoped result used by post-simulation validation.

