### PR TITLE
Add battery recharge hysteresis

### DIFF
--- a/conops/config/battery.py
+++ b/conops/config/battery.py
@@ -28,7 +28,15 @@ class Battery(ConfigModel):
         default=0.3, description="Maximum allowed depth of discharge (0.0-1.0)"
     )
     recharge_threshold: float = Field(
-        default=0.95, description="Battery level fraction to stop charging (0.0-1.0)"
+        default=0.95,
+        description="Battery level fraction that starts emergency recharge (0.0-1.0)",
+    )
+    recharge_clear_threshold: float | None = Field(
+        default=None,
+        description=(
+            "Battery level fraction that clears emergency recharge. Defaults to "
+            "recharge_threshold + 0.005, capped at 1.0."
+        ),
     )
     charge_level: float = Field(
         default=0, description="Current battery charge level (Wh)"
@@ -47,7 +55,23 @@ class Battery(ConfigModel):
         if "watthour" not in values:
             values["watthour"] = values.get("amphour", 20) * values.get("voltage", 28)
 
+        if values.get("recharge_clear_threshold") is None:
+            recharge_threshold = float(values.get("recharge_threshold", 0.95))
+            values["recharge_clear_threshold"] = min(1.0, recharge_threshold + 0.005)
+
         return values
+
+    @model_validator(mode="after")
+    def validate_recharge_thresholds(self) -> "Battery":
+        """Validate recharge hysteresis thresholds."""
+        if self.recharge_clear_threshold is None:
+            raise ValueError("recharge_clear_threshold must be set")
+        if self.recharge_clear_threshold < self.recharge_threshold:
+            raise ValueError(
+                "recharge_clear_threshold must be greater than or equal to "
+                "recharge_threshold"
+            )
+        return self
 
     def model_post_init(self, __context: object) -> None:
         self.charge_level = self.watthour
@@ -71,18 +95,27 @@ class Battery(ConfigModel):
     @property
     def battery_alert(self) -> bool:
         """Is the battery in an alert status caused by discharge"""
+        threshold_tolerance = 1e-12
+        battery_level = self.battery_level
+
         # Depth of discharge > max_depth_of_discharge, start an emergency recharge state
         if self.below_minimum_charge_level:
             self.emergency_recharge = True
             return True
 
-        # Alert is True when battery level is below recharge threshold
-        if self.battery_level < self.recharge_threshold:
+        # Start recharge at the lower threshold, then keep it latched until the
+        # higher clear threshold is reached. This avoids charge/resume chatter.
+        if battery_level < self.recharge_threshold - threshold_tolerance:
             self.emergency_recharge = True
             return True
-        else:
-            self.emergency_recharge = False
-            return False
+        if (
+            self.emergency_recharge
+            and battery_level < self.recharge_clear_threshold - threshold_tolerance
+        ):
+            return True
+
+        self.emergency_recharge = False
+        return False
 
     @property
     def minimum_charge_level(self) -> float:

--- a/conops/config/battery.py
+++ b/conops/config/battery.py
@@ -6,6 +6,11 @@ from ..common import ChargeState
 from ._base import ConfigModel
 
 
+DEFAULT_RECHARGE_THRESHOLD = 0.95
+DEFAULT_RECHARGE_CLEAR_HYSTERESIS = 0.005
+BATTERY_ALERT_THRESHOLD_TOLERANCE = 1e-12
+
+
 class Battery(ConfigModel):
     """It's a fake battery"""
 
@@ -28,14 +33,15 @@ class Battery(ConfigModel):
         default=0.3, description="Maximum allowed depth of discharge (0.0-1.0)"
     )
     recharge_threshold: float = Field(
-        default=0.95,
+        default=DEFAULT_RECHARGE_THRESHOLD,
         description="Battery level fraction that starts emergency recharge (0.0-1.0)",
     )
     recharge_clear_threshold: float | None = Field(
         default=None,
         description=(
             "Battery level fraction that clears emergency recharge. Defaults to "
-            "recharge_threshold + 0.005, capped at 1.0."
+            "recharge_threshold + "
+            f"{DEFAULT_RECHARGE_CLEAR_HYSTERESIS:g}, capped at 1.0."
         ),
     )
     charge_level: float = Field(
@@ -56,8 +62,12 @@ class Battery(ConfigModel):
             values["watthour"] = values.get("amphour", 20) * values.get("voltage", 28)
 
         if values.get("recharge_clear_threshold") is None:
-            recharge_threshold = float(values.get("recharge_threshold", 0.95))
-            values["recharge_clear_threshold"] = min(1.0, recharge_threshold + 0.005)
+            recharge_threshold = float(
+                values.get("recharge_threshold", DEFAULT_RECHARGE_THRESHOLD)
+            )
+            values["recharge_clear_threshold"] = min(
+                1.0, recharge_threshold + DEFAULT_RECHARGE_CLEAR_HYSTERESIS
+            )
 
         return values
 
@@ -95,7 +105,7 @@ class Battery(ConfigModel):
     @property
     def battery_alert(self) -> bool:
         """Is the battery in an alert status caused by discharge"""
-        threshold_tolerance = 1e-12
+        threshold_tolerance = BATTERY_ALERT_THRESHOLD_TOLERANCE
         battery_level = self.battery_level
 
         # Depth of discharge > max_depth_of_discharge, start an emergency recharge state

--- a/conops/config/battery.py
+++ b/conops/config/battery.py
@@ -5,7 +5,6 @@ from pydantic import Field, PrivateAttr, model_validator
 from ..common import ChargeState
 from ._base import ConfigModel
 
-
 DEFAULT_RECHARGE_THRESHOLD = 0.95
 DEFAULT_RECHARGE_CLEAR_HYSTERESIS = 0.005
 BATTERY_ALERT_THRESHOLD_TOLERANCE = 1e-12
@@ -118,9 +117,11 @@ class Battery(ConfigModel):
         if battery_level < self.recharge_threshold - threshold_tolerance:
             self.emergency_recharge = True
             return True
+        recharge_clear_threshold = self.recharge_clear_threshold
+        assert recharge_clear_threshold is not None
         if (
             self.emergency_recharge
-            and battery_level < self.recharge_clear_threshold - threshold_tolerance
+            and battery_level < recharge_clear_threshold - threshold_tolerance
         ):
             return True
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -975,7 +975,9 @@ The :class:`~conops.config.Battery` models the spacecraft battery system.
 * ``voltage`` (float): Battery voltage (Volts)
 * ``watthour`` (float): Total energy capacity (Watt-hours, auto-calculated)
 * ``max_depth_of_discharge`` (float): Maximum allowed DoD (0-1)
-* ``recharge_threshold`` (float): SOC level to end emergency recharge (0-1)
+* ``recharge_threshold`` (float): SOC level that starts emergency recharge (0-1)
+* ``recharge_clear_threshold`` (float): SOC level that clears emergency recharge
+  (0-1, defaults to ``recharge_threshold + 0.005`` capped at 1.0)
 * ``charge_level`` (float): Current charge in Watt-hours
 
 .. code-block:: python
@@ -988,7 +990,8 @@ The :class:`~conops.config.Battery` models the spacecraft battery system.
        voltage=28.0,
        watthour=560.0,  # Optional, calculated from amphour * voltage
        max_depth_of_discharge=0.4,  # Allow 40% discharge
-       recharge_threshold=0.95,     # Recharge until 95% SOC
+       recharge_threshold=0.95,     # Start emergency recharge below 95% SOC
+       recharge_clear_threshold=0.955,  # Continue charging until 95.5% SOC
    )
 
 constraint
@@ -1313,7 +1316,8 @@ Here is a complete example of creating a ``MissionConfig`` programmatically:
            amphour=20.0,
            voltage=28.0,
            max_depth_of_discharge=0.4,
-           recharge_threshold=0.95
+           recharge_threshold=0.95,
+           recharge_clear_threshold=0.955,
        ),
        constraint=Constraint(
            sun_constraint=rust_ephem.SunConstraint(min_angle=45.0),

--- a/tests/battery/test_battery.py
+++ b/tests/battery/test_battery.py
@@ -135,6 +135,17 @@ class TestBatteryAlerts:
         b.charge_level = b.watthour * 0.96
         assert b.battery_alert is False
 
+    def test_battery_alert_stays_latched_until_clear_threshold(self, default_battery):
+        b = default_battery
+        b.charge_level = b.watthour * 0.60
+        assert b.battery_alert is True
+
+        b.charge_level = b.watthour * 0.952
+        assert b.battery_alert is True
+
+        b.charge_level = b.watthour * b.recharge_clear_threshold
+        assert b.battery_alert is False
+
     def test_emergency_recharge_cleared_above_recharge_threshold(self, default_battery):
         b = default_battery
         b.charge_level = b.watthour * 0.96

--- a/tests/battery/test_battery_recharge.py
+++ b/tests/battery/test_battery_recharge.py
@@ -46,9 +46,14 @@ class TestBattery:
         """Test that recharge_threshold defaults to 0.95 (95%)."""
         assert default_battery.recharge_threshold == 0.95
 
+    def test_default_recharge_clear_threshold(self, default_battery) -> None:
+        """Default recharge clear threshold adds hysteresis above the start threshold."""
+        assert default_battery.recharge_clear_threshold == 0.955
+
     def test_custom_recharge_threshold(self, battery_with_custom_threshold) -> None:
         """Test that custom recharge_threshold can be set."""
         assert battery_with_custom_threshold.recharge_threshold == 0.90
+        assert battery_with_custom_threshold.recharge_clear_threshold == 0.905
 
     def test_battery_alert_true_when_below_max_depth_of_discharge(
         self, battery_with_dod
@@ -105,23 +110,46 @@ class TestBattery:
         )
         assert battery_with_dod_and_threshold.emergency_recharge is True
 
-    def test_battery_alert_clears_at_ninetyfive_percent(
+    def test_battery_alert_persists_at_ninetyfive_percent(
         self, battery_with_dod_and_threshold
     ):
-        """Battery alert should clear at recharge threshold (95%)."""
+        """Battery alert should not clear until the clear threshold is reached."""
+        battery_with_dod_and_threshold.charge_level = (
+            battery_with_dod_and_threshold.watthour * 0.60
+        )
+        _ = battery_with_dod_and_threshold.battery_alert
         battery_with_dod_and_threshold.charge_level = (
             battery_with_dod_and_threshold.watthour * 0.95
+        )
+        assert battery_with_dod_and_threshold.battery_alert is True
+
+    def test_emergency_recharge_persists_at_ninetyfive_percent(
+        self, battery_with_dod_and_threshold
+    ):
+        """Emergency recharge should remain latched at the start threshold."""
+        battery_with_dod_and_threshold.charge_level = (
+            battery_with_dod_and_threshold.watthour * 0.60
+        )
+        _ = battery_with_dod_and_threshold.battery_alert
+        battery_with_dod_and_threshold.charge_level = (
+            battery_with_dod_and_threshold.watthour * 0.95
+        )
+        _ = battery_with_dod_and_threshold.battery_alert
+        assert battery_with_dod_and_threshold.emergency_recharge is True
+
+    def test_battery_alert_clears_at_recharge_clear_threshold(
+        self, battery_with_dod_and_threshold
+    ):
+        """Battery alert should clear at the recharge clear threshold."""
+        battery_with_dod_and_threshold.charge_level = (
+            battery_with_dod_and_threshold.watthour * 0.60
+        )
+        _ = battery_with_dod_and_threshold.battery_alert
+        battery_with_dod_and_threshold.charge_level = (
+            battery_with_dod_and_threshold.watthour
+            * battery_with_dod_and_threshold.recharge_clear_threshold
         )
         assert battery_with_dod_and_threshold.battery_alert is False
-
-    def test_emergency_recharge_clears_at_ninetyfive_percent(
-        self, battery_with_dod_and_threshold
-    ):
-        """Emergency recharge should clear at recharge threshold (95%)."""
-        battery_with_dod_and_threshold.charge_level = (
-            battery_with_dod_and_threshold.watthour * 0.95
-        )
-        assert battery_with_dod_and_threshold.emergency_recharge is False
 
     def test_battery_alert_false_when_above_threshold(self, battery_with_dod) -> None:
         """Test battery_alert False when battery level is sufficient."""
@@ -1298,21 +1326,37 @@ class TestBatteryRechargeScenarios:
         battery.charge_level = battery.watthour * 0.94
         assert battery.battery_alert is True
 
-    def test_full_discharge_recharge_cycle_alert_clears_at_95percent(self) -> None:
+    def test_full_discharge_recharge_cycle_alert_persists_at_95percent(self) -> None:
         battery = Battery(
             max_depth_of_discharge=0.35, recharge_threshold=0.95, watthour=560.0
         )
+        battery.charge_level = battery.watthour * 0.60
+        _ = battery.battery_alert
         battery.charge_level = battery.watthour * 0.95
-        assert battery.battery_alert is False
+        assert battery.battery_alert is True
 
-    def test_full_discharge_recharge_cycle_emergency_recharge_clears_at_95percent(
+    def test_full_discharge_recharge_cycle_emergency_recharge_persists_at_95percent(
         self,
     ) -> None:
         battery = Battery(
             max_depth_of_discharge=0.35, recharge_threshold=0.95, watthour=560.0
         )
+        battery.charge_level = battery.watthour * 0.60
+        _ = battery.battery_alert
         battery.charge_level = battery.watthour * 0.95
-        assert battery.emergency_recharge is False
+        _ = battery.battery_alert
+        assert battery.emergency_recharge is True
+
+    def test_full_discharge_recharge_cycle_alert_clears_at_clear_threshold(
+        self,
+    ) -> None:
+        battery = Battery(
+            max_depth_of_discharge=0.35, recharge_threshold=0.95, watthour=560.0
+        )
+        battery.charge_level = battery.watthour * 0.60
+        _ = battery.battery_alert
+        battery.charge_level = battery.watthour * battery.recharge_clear_threshold
+        assert battery.battery_alert is False
 
     def test_full_discharge_recharge_cycle_alert_remains_cleared_at_100percent(
         self,
@@ -1330,8 +1374,19 @@ class TestBatteryRechargeScenarios:
 
     def test_multiple_charge_discharge_cycles_first_cycle_clear(self) -> None:
         battery = Battery(max_depth_of_discharge=0.35, recharge_threshold=0.95)
-        battery.charge_level = battery.watthour * 0.95
+        battery.charge_level = battery.watthour * 0.60
+        _ = battery.battery_alert
+        battery.charge_level = battery.watthour * battery.recharge_clear_threshold
         assert battery.battery_alert is False
+
+    def test_multiple_charge_discharge_cycles_first_cycle_persists_at_start_threshold(
+        self,
+    ) -> None:
+        battery = Battery(max_depth_of_discharge=0.35, recharge_threshold=0.95)
+        battery.charge_level = battery.watthour * 0.60
+        _ = battery.battery_alert
+        battery.charge_level = battery.watthour * 0.95
+        assert battery.battery_alert is True
 
     def test_multiple_charge_discharge_cycles_second_cycle_alert(self) -> None:
         battery = Battery(max_depth_of_discharge=0.35, recharge_threshold=0.95)
@@ -1340,8 +1395,19 @@ class TestBatteryRechargeScenarios:
 
     def test_multiple_charge_discharge_cycles_second_cycle_clear(self) -> None:
         battery = Battery(max_depth_of_discharge=0.35, recharge_threshold=0.95)
-        battery.charge_level = battery.watthour * 0.95
+        battery.charge_level = battery.watthour * 0.55
+        _ = battery.battery_alert
+        battery.charge_level = battery.watthour * battery.recharge_clear_threshold
         assert battery.battery_alert is False
+
+    def test_multiple_charge_discharge_cycles_second_cycle_persists_at_start_threshold(
+        self,
+    ) -> None:
+        battery = Battery(max_depth_of_discharge=0.35, recharge_threshold=0.95)
+        battery.charge_level = battery.watthour * 0.55
+        _ = battery.battery_alert
+        battery.charge_level = battery.watthour * 0.95
+        assert battery.battery_alert is True
 
 
 if __name__ == "__main__":

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -33,6 +33,22 @@ from conops.config import (
 )
 
 
+def _mock_battery(
+    *,
+    max_depth_of_discharge: float = 0.3,
+    recharge_threshold: float = 0.95,
+    recharge_clear_threshold: float = 0.955,
+    capacity: float | None = None,
+) -> Mock:
+    battery = Mock(spec=Battery)
+    battery.max_depth_of_discharge = max_depth_of_discharge
+    battery.recharge_threshold = recharge_threshold
+    battery.recharge_clear_threshold = recharge_clear_threshold
+    if capacity is not None:
+        battery.capacity = capacity
+    return battery
+
+
 class TestConfig:
     """Test Config class initialization."""
 
@@ -163,8 +179,7 @@ class TestConfig:
         spacecraft_bus = Mock(spec=SpacecraftBus)
         solar_panel = Mock(spec=SolarPanelSet)
         payload = Mock(spec=Payload)
-        battery = Mock(spec=Battery)
-        battery.max_depth_of_discharge = 0.3  # Configure mock battery
+        battery = _mock_battery()
         constraint = Mock(spec=Constraint)
         panel_constraint_mock = Mock()
         panel_constraint_mock.solar_panel = None
@@ -192,8 +207,7 @@ class TestConfig:
         import pytest
         from pydantic import ValidationError
 
-        battery = Mock(spec=Battery)
-        battery.max_depth_of_discharge = 0.3  # Configure mock battery
+        battery = _mock_battery()
         config = MissionConfig(
             spacecraft_bus=Mock(spec=SpacecraftBus),
             solar_panel=Mock(spec=SolarPanelSet),
@@ -209,8 +223,7 @@ class TestConfig:
     def test_init_fault_management_defaults_adds_threshold(self) -> None:
         """Test init_fault_management_defaults adds battery_level threshold if not present."""
         fault_management = FaultManagement()
-        battery = Mock(spec=Battery)
-        battery.max_depth_of_discharge = 0.2
+        battery = _mock_battery(max_depth_of_discharge=0.2)
         config = MissionConfig(
             spacecraft_bus=Mock(spec=SpacecraftBus),
             solar_panel=Mock(spec=SolarPanelSet),
@@ -236,8 +249,7 @@ class TestConfig:
         fault_management.add_threshold(
             "battery_level", yellow=0.5, red=0.4, direction="below"
         )
-        battery = Mock(spec=Battery)
-        battery.max_depth_of_discharge = 0.2
+        battery = _mock_battery(max_depth_of_discharge=0.2)
         config = MissionConfig(
             spacecraft_bus=Mock(spec=SpacecraftBus),
             solar_panel=Mock(spec=SolarPanelSet),
@@ -314,7 +326,7 @@ class TestConfig:
             spacecraft_bus=Mock(spec=SpacecraftBus, mass=100.0),
             solar_panel=Mock(spec=SolarPanelSet, area=10.0),
             payload=Mock(spec=Payload, mass=50.0),
-            battery=Mock(spec=Battery, capacity=200.0, max_depth_of_discharge=0.8),
+            battery=_mock_battery(max_depth_of_discharge=0.8, capacity=200.0),
             constraint=Mock(spec=Constraint),
             ground_stations=Mock(spec=GroundStationRegistry),
         )

--- a/tests/ditl/conftest.py
+++ b/tests/ditl/conftest.py
@@ -102,6 +102,8 @@ def create_statistics_test_config(ephem: DummyEphemeris | None = None) -> Missio
     battery = Mock(spec=Battery)
     battery.capacity = 100.0
     battery.max_depth_of_discharge = 0.3
+    battery.recharge_threshold = 0.95
+    battery.recharge_clear_threshold = 0.955
     constraint = Mock(spec=Constraint)
     constraint.ephem = ephem
     constraint.constraint = None  # no combined rust-ephem constraint in tests

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -13,6 +13,7 @@ from conops import (
     ACSCommandType,
     ACSMode,
     AttitudeConstraintScope,
+    Battery,
     Pass,
     PlanExecutionMismatchError,
     QueueDITL,
@@ -464,6 +465,31 @@ class TestHandleChargingMode:
         # Check the log instead of print output
         log_text = "\n".join(event.description for event in queue_ditl.log.events)
         assert "Battery recharged" in log_text
+
+    def test_charging_stays_active_until_recharge_clear_threshold(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        battery = Battery(recharge_threshold=0.95, watthour=560.0)
+        battery.charge_level = battery.watthour * 0.60
+        assert battery.battery_alert is True
+        battery.charge_level = battery.watthour * 0.952
+        queue_ditl.battery = battery
+
+        mock_charging = Mock()
+        mock_charging.ra = 10.0
+        mock_charging.dec = 20.0
+        mock_charging.roll = 30.0
+        mock_charging.end = 0
+        mock_charging.done = False
+        mock_charging.obsid = 999001
+        queue_ditl.charging_ppt = mock_charging
+
+        queue_ditl._handle_charging_mode(1000.0)
+
+        assert queue_ditl.charging_ppt is mock_charging
+        assert mock_charging.done is False
+        cast(Mock, queue_ditl.acs.enqueue_command).assert_not_called()
+        cast(Mock, queue_ditl.queue.get).assert_not_called()
 
     def test_charging_ends_when_constrained_end_and_done_set(
         self, queue_ditl: QueueDITL, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## Problem

Emergency charging used a single `recharge_threshold` both to start and clear the alert. In the TAM schedule this lets COAST stop charging as soon as state of charge reaches 95%, schedule one short payload interval, then immediately fall below 95% again and re-enter charging. In the visualizer this shows up as gaps/slew churn in the middle of what should be a continuous Sun-charge recovery.

## Solution

Add a latched recharge clear threshold:

- `recharge_threshold` starts emergency recharge.
- `recharge_clear_threshold` clears emergency recharge.
- If unspecified, `recharge_clear_threshold` defaults to `recharge_threshold + 0.005`, capped at 1.0.

While `emergency_recharge` is active, `battery_alert` now stays true until the higher clear threshold is reached. This keeps the scheduler in charging mode through the small SOC buffer instead of bouncing around the lower threshold.

## Why 0.5%

I tested a larger 2% default first. It removed the chatter, but it was too conservative for the current TAM plan: charge time increased to 184 minutes and science fell to 1210 minutes. A 0.5% default still removes the immediate restart pattern while keeping the cost smaller:

- 92 entries total
- 75 AT entries, 15 CHARGE entries, 2 GSP entries
- 1262 minutes AT
- 137 minutes CHARGE
- 24 minutes GSP
- 0 CHARGE-to-CHARGE gaps
- 0 charge restarts within 3 minutes
