### PR TITLE
Export GSP station coordinates

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1733,6 +1733,11 @@ class QueueDITL(DITLMixin, DITLStats):
         entry.ss_max = contact_duration
         entry.exptime = contact_duration
         entry.station = station
+        station_location = self._gsp_station_location(station)
+        if station_location is not None:
+            entry.station_lat_deg, entry.station_lon_deg, entry.station_alt_m = (
+                station_location
+            )
         entry.contact_begin = pass_begin
         entry.contact_end = pass_end
         entry.track_start_ra = gspass.gsstartra
@@ -1758,6 +1763,21 @@ class QueueDITL(DITLMixin, DITLStats):
             acs_mode=self.acs.acsmode,
         )
         return True
+
+    def _gsp_station_location(self, station: str) -> tuple[float, float, float] | None:
+        try:
+            ground_station = self.config.ground_stations.get(station)
+        except (AttributeError, KeyError):
+            return None
+
+        try:
+            return (
+                float(ground_station.latitude_deg),
+                float(ground_station.longitude_deg),
+                float(getattr(ground_station, "elevation_m", 0.0)),
+            )
+        except (AttributeError, TypeError, ValueError):
+            return None
 
     def _planned_gsp_entry(self, gspass: Pass) -> PlanEntry | None:
         station, pass_begin, pass_end = self._ground_pass_key(gspass)

--- a/conops/targets/plan_entry.py
+++ b/conops/targets/plan_entry.py
@@ -26,6 +26,9 @@ class PlanEntry:
     saa: SAA | None
     slewpath: tuple[list[float], list[float]]
     station: str | None
+    station_lat_deg: float | None
+    station_lon_deg: float | None
+    station_alt_m: float | None
     contact_begin: float | None
     contact_end: float | None
     track_start_ra: float | None
@@ -61,6 +64,9 @@ class PlanEntry:
         self.end = 0
         self.obsid = 0
         self.station = None
+        self.station_lat_deg = None
+        self.station_lon_deg = None
+        self.station_alt_m = None
         self.contact_begin = None
         self.contact_end = None
         self.track_start_ra = None

--- a/conops/targets/plan_schema.py
+++ b/conops/targets/plan_schema.py
@@ -109,6 +109,9 @@ class PlanEntrySchema(BaseModel):
     done: bool = False
     exposure: int = 0
     station: str | None = None
+    station_lat_deg: float | None = None
+    station_lon_deg: float | None = None
+    station_alt_m: float | None = None
     contact_begin: float | None = None
     contact_end: float | None = None
     track_start_ra: float | None = None
@@ -203,6 +206,9 @@ class PlanEntrySchema(BaseModel):
                 "done": getattr(data, "done", False),
                 "exposure": cls._computed_exposure(data),
                 "station": getattr(data, "station", None),
+                "station_lat_deg": getattr(data, "station_lat_deg", None),
+                "station_lon_deg": getattr(data, "station_lon_deg", None),
+                "station_alt_m": getattr(data, "station_alt_m", None),
                 "contact_begin": getattr(data, "contact_begin", None),
                 "contact_end": getattr(data, "contact_end", None),
                 "track_start_ra": getattr(data, "track_start_ra", None),

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -206,6 +206,9 @@ class TestPlanEntrySchema:
                 _ENTRY_DICT,
                 obstype="GSP",
                 station="TRO",
+                station_lat_deg=12.34,
+                station_lon_deg=-56.78,
+                station_alt_m=910.0,
                 contact_begin=1_000_120.0,
                 contact_end=1_000_720.0,
                 track_start_ra=12.5,
@@ -219,6 +222,9 @@ class TestPlanEntrySchema:
 
         dumped = entry.model_dump(mode="json")
         assert dumped["station"] == "TRO"
+        assert dumped["station_lat_deg"] == pytest.approx(12.34)
+        assert dumped["station_lon_deg"] == pytest.approx(-56.78)
+        assert dumped["station_alt_m"] == pytest.approx(910.0)
         assert dumped["contact_begin"] == "1970-01-12T13:48:40+00:00"
         assert dumped["contact_end"] == "1970-01-12T13:58:40+00:00"
         assert dumped["track_start_ra"] == pytest.approx(12.5)
@@ -230,6 +236,9 @@ class TestPlanEntrySchema:
 
         reloaded = PlanEntrySchema(**dumped)
         assert reloaded.station == "TRO"
+        assert reloaded.station_lat_deg == pytest.approx(12.34)
+        assert reloaded.station_lon_deg == pytest.approx(-56.78)
+        assert reloaded.station_alt_m == pytest.approx(910.0)
         assert reloaded.contact_begin == pytest.approx(1_000_120.0)
         assert reloaded.contact_end == pytest.approx(1_000_720.0)
         assert reloaded.track_start_ra == pytest.approx(12.5)
@@ -433,6 +442,9 @@ class TestPlanSchema:
         assert isinstance(entry["end"], str), "end should be an ISO-8601 string"
         assert "T" in entry["begin"]
         assert "station" not in entry
+        assert "station_lat_deg" not in entry
+        assert "station_lon_deg" not in entry
+        assert "station_alt_m" not in entry
         assert "contact_begin" not in entry
         assert "contact_end" not in entry
         assert "track_start_ra" not in entry

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -14,6 +14,8 @@ from conops import (
     ACSMode,
     AttitudeConstraintScope,
     Battery,
+    GroundStation,
+    GroundStationRegistry,
     Pass,
     PlanExecutionMismatchError,
     QueueDITL,
@@ -4137,6 +4139,17 @@ class TestCheckAndManagePasses:
         queue_ditl.acs.passrequests.current_pass = Mock(return_value=None)
         queue_ditl.acs.passrequests.next_pass = Mock(return_value=pass_obj)
         queue_ditl.acs.acsmode = ACSMode.SCIENCE
+        queue_ditl.config.ground_stations = GroundStationRegistry(
+            stations=[
+                GroundStation(
+                    code="GS_TEST",
+                    name="Test Station",
+                    latitude_deg=12.34,
+                    longitude_deg=-56.78,
+                    elevation_m=910.0,
+                )
+            ]
+        )
 
         with patch.object(Pass, "time_to_slew", return_value=True):
             queue_ditl._check_and_manage_passes(utime, ra, dec)
@@ -4159,6 +4172,9 @@ class TestCheckAndManagePasses:
         assert entry.exposure == 600
         assert entry.exptime == 600
         assert entry.station == "GS_TEST"
+        assert entry.station_lat_deg == pytest.approx(12.34)
+        assert entry.station_lon_deg == pytest.approx(-56.78)
+        assert entry.station_alt_m == pytest.approx(910.0)
         assert entry.contact_begin == pass_obj.begin
         assert entry.contact_end == pass_obj.end
         assert entry.ra == pytest.approx(pass_obj.gsstartra)
@@ -4178,6 +4194,9 @@ class TestCheckAndManagePasses:
         assert schema.entries[0].slewdist == pytest.approx(entry.slewdist)
         assert schema.entries[0].exposure == 600
         assert schema.entries[0].station == "GS_TEST"
+        assert schema.entries[0].station_lat_deg == pytest.approx(12.34)
+        assert schema.entries[0].station_lon_deg == pytest.approx(-56.78)
+        assert schema.entries[0].station_alt_m == pytest.approx(910.0)
         assert schema.entries[0].contact_begin == pass_obj.begin
         assert schema.entries[0].track_start_ra == pytest.approx(pass_obj.gsstartra)
         assert schema.entries[0].track_start_dec == pytest.approx(pass_obj.gsstartdec)
@@ -4189,6 +4208,9 @@ class TestCheckAndManagePasses:
         saved_json = saved_path.read_text()
         assert '"obstype": "GSP"' in saved_json
         assert '"station": "GS_TEST"' in saved_json
+        assert '"station_lat_deg": 12.34' in saved_json
+        assert '"station_lon_deg": -56.78' in saved_json
+        assert '"station_alt_m": 910.0' in saved_json
         assert '"track_start_ra": 100.0' in saved_json
         assert '"track_start_roll": 37.0' in saved_json
         assert '"track_end_ra": 115.0' in saved_json


### PR DESCRIPTION
## Summary
- add station_lat_deg, station_lon_deg, and station_alt_m to exported GSP plan entries
- populate the fields from the configured ground-station registry when a GSP plan entry is recorded
- cover PlanSchema round-trip and QueueDITL GSP export behavior
