### PR TITLE
fix(type): fix various mypy errors

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -30,3 +30,21 @@ jobs:
         uses: astral-sh/ruff-action@v3
         with:
           args: format --check
+
+  mypy:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          activate-environment: true
+          python-version: "3.12"
+
+      - name: Install package with dev dependencies
+        run: uv pip install .[dev]
+
+      - name: Run mypy
+        run: mypy conops/

--- a/conops/config/battery.py
+++ b/conops/config/battery.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import Field, model_validator
+from pydantic import Field, PrivateAttr, model_validator
 
 from ..common import ChargeState
 from ._base import ConfigModel
@@ -38,6 +38,8 @@ class Battery(ConfigModel):
         description="Illumination threshold for emergency charging (0.0-1.0)",
     )
 
+    _last_charge_power: float = PrivateAttr(default=0.0)
+
     @model_validator(mode="before")
     @classmethod
     def set_defaults(cls, values: dict[str, Any]) -> dict[str, Any]:
@@ -47,11 +49,8 @@ class Battery(ConfigModel):
 
         return values
 
-    def __init__(self, **data: dict[str, Any]) -> None:
-        super().__init__(**data)
-
-        self.charge_level = self.watthour  # Start fully charged
-        self._last_charge_power = 0.0  # Track last charge power for state determination
+    def model_post_init(self, __context: object) -> None:
+        self.charge_level = self.watthour
 
     @property
     def charge_state(self) -> ChargeState:

--- a/conops/config/constraint.py
+++ b/conops/config/constraint.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from enum import Enum
 from functools import cached_property, lru_cache
 from typing import cast
@@ -1022,7 +1023,7 @@ def _attitude_scope_value(scope: str | Enum) -> str:
     return scope
 
 
-def _attitude_scope_values(scopes: list[str | Enum]) -> list[str]:
+def _attitude_scope_values(scopes: Sequence[str | Enum]) -> list[str]:
     values: list[str] = []
     for scope in scopes:
         value = _attitude_scope_value(scope)
@@ -1031,7 +1032,7 @@ def _attitude_scope_values(scopes: list[str | Enum]) -> list[str]:
     return values
 
 
-def attitude_constraint_scope_label(scopes: list[str | Enum]) -> str:
+def attitude_constraint_scope_label(scopes: Sequence[str | Enum]) -> str:
     """Return a stable label for a mode's configured constraint scopes."""
     values = _attitude_scope_values(scopes)
     return "+".join(values) if values else "none"
@@ -1151,7 +1152,7 @@ def in_attitude_constraint_scope(
 
 def in_attitude_constraint_scopes(
     constraint: Constraint,
-    scopes: list[str | Enum],
+    scopes: Sequence[str | Enum],
     ra: float,
     dec: float,
     utime: float,
@@ -1459,7 +1460,7 @@ def attitude_constraint_names_for_scope(
 
 def attitude_constraint_name_for_scopes(
     constraint: Constraint,
-    scopes: list[str | Enum],
+    scopes: Sequence[str | Enum],
     ra: float,
     dec: float,
     utime: float,
@@ -1484,7 +1485,7 @@ def attitude_constraint_name_for_scopes(
 
 def attitude_constraint_names_for_scopes(
     constraint: Constraint,
-    scopes: list[str | Enum],
+    scopes: Sequence[str | Enum],
     ra: float,
     dec: float,
     utime: float,
@@ -1572,7 +1573,7 @@ def all_attitude_constraint_name(
 
 def in_attitude_constraint_scopes_batch(
     constraint: Constraint,
-    scopes: list[str | Enum],
+    scopes: Sequence[str | Enum],
     ras: list[float],
     decs: list[float],
     utime: float,

--- a/conops/visualization/mpl/sky_pointing.py
+++ b/conops/visualization/mpl/sky_pointing.py
@@ -1342,7 +1342,7 @@ class SkyPointingController:
                 return None
             stacked = cast(npt.NDArray[np.bool_], np.vstack(masks))
             if kind == "hard":
-                return cast(npt.NDArray[np.bool_], np.any(stacked, axis=0))
+                return np.any(stacked, axis=0)
             # Soft: AtLeast violation semantics
             min_func = int(getattr(star_trackers, "min_functional_trackers", 1))
             required = max(0, len(trackers) - min_func + 1)

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,9 @@ exclude = (?x)(
     # Exclude files in tests/ directory
     tests/.*
     |
+    # Exclude scripts/ (duck-typed utilities, not checked by pre-commit)
+    scripts/.*
+    |
     # Exclude docs directory
     docs/.*
     |


### PR DESCRIPTION
# Description

This PR fixes various `mypy` errors that have crept into the codebase with recent PRs.

In order to enforce `mypy` correctness, I have also added it to GitHub actions.

Co-pilot description:

This pull request introduces several improvements and refactorings across the configuration and visualization modules, focusing on type safety, initialization logic, and code maintainability. The most significant changes include replacing usages of `list` with the more general `Sequence` type for function arguments, refactoring attribute initialization in the `Battery` configuration, and updating the mypy configuration to exclude additional directories from type checking.

**Type annotation improvements:**

* Changed function arguments from `list[str | Enum]` to `Sequence[str | Enum]` in multiple functions within `conops/config/constraint.py` to allow for greater flexibility in accepted argument types and improve type safety. [[1]](diffhunk://#diff-eeb99acd4d46efb45375e29e7733780eaf82e0c8967d45e0d9dd45312b019ca7R1) [[2]](diffhunk://#diff-eeb99acd4d46efb45375e29e7733780eaf82e0c8967d45e0d9dd45312b019ca7L1025-R1026) [[3]](diffhunk://#diff-eeb99acd4d46efb45375e29e7733780eaf82e0c8967d45e0d9dd45312b019ca7L1034-R1035) [[4]](diffhunk://#diff-eeb99acd4d46efb45375e29e7733780eaf82e0c8967d45e0d9dd45312b019ca7L1154-R1155) [[5]](diffhunk://#diff-eeb99acd4d46efb45375e29e7733780eaf82e0c8967d45e0d9dd45312b019ca7L1462-R1463) [[6]](diffhunk://#diff-eeb99acd4d46efb45375e29e7733780eaf82e0c8967d45e0d9dd45312b019ca7L1487-R1488) [[7]](diffhunk://#diff-eeb99acd4d46efb45375e29e7733780eaf82e0c8967d45e0d9dd45312b019ca7L1575-R1576)

**Battery configuration refactor:**

* Refactored `Battery` class in `conops/config/battery.py` to use `PrivateAttr` for `_last_charge_power`, moved initialization logic to `model_post_init`, and removed the custom `__init__` method for better compatibility with Pydantic's model lifecycle. [[1]](diffhunk://#diff-a7df974839235a06f7e32e05e6dfb0a7f94624708a58dbfa2b852e7abd083c20L3-R3) [[2]](diffhunk://#diff-a7df974839235a06f7e32e05e6dfb0a7f94624708a58dbfa2b852e7abd083c20R41-R42) [[3]](diffhunk://#diff-a7df974839235a06f7e32e05e6dfb0a7f94624708a58dbfa2b852e7abd083c20L50-R53)

**Visualization code cleanup:**

* Simplified the return value of the "hard" case in `_eval_trackers` in `conops/visualization/mpl/sky_pointing.py` by removing an unnecessary type cast.

**Type checker configuration:**

* Updated `mypy.ini` to exclude the `scripts/` directory from type checking, in addition to existing exclusions, to prevent issues with duck-typed utilities.