### PR TITLE
fix: Clarify TLE mean elements in plan metadata

### DIFF
--- a/conops/targets/__init__.py
+++ b/conops/targets/__init__.py
@@ -15,6 +15,7 @@ from .plan_entry import (
 from .plan_metadata import (
     EphemerisMetadata,
     PlanMetadata,
+    TLEMeanElementsMetadata,
     attach_tle_plan_metadata,
 )
 from .plan_schema import PlanEntrySchema, PlanSchema
@@ -39,6 +40,7 @@ __all__ = [
     "TargetQueue",
     "TargetSlewEstimate",
     "EphemerisMetadata",
+    "TLEMeanElementsMetadata",
     "PlanMetadata",
     "attach_tle_plan_metadata",
 ]

--- a/conops/targets/plan_metadata.py
+++ b/conops/targets/plan_metadata.py
@@ -15,6 +15,19 @@ def _format_utc_datetime(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+TLE_MEAN_ELEMENTS_NOTE = (
+    "TLE mean elements for SGP4, not propagated osculating elements. "
+    "RightAscension_deg is RAAN. SemimajorAxis_m is derived from TLE mean "
+    "motion, and TrueAnomaly_deg is derived from TLE mean anomaly."
+)
+
+
+class TLEMeanElementsMetadata(BaseModel):
+    epoch_utc: str
+    elements: dict[str, float]
+    note: str
+
+
 class EphemerisMetadata(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -25,15 +38,7 @@ class EphemerisMetadata(BaseModel):
     norad_id: int | None = None
     line1: str | None = None
     line2: str | None = None
-    classical_elements: dict[str, float] | None = None
-    classical_elements_note: str | None = None
-
-
-TLE_CLASSICAL_ELEMENTS_NOTE = (
-    "TLE mean elements at the TLE epoch; RightAscension_deg is RAAN. "
-    "SemimajorAxis_m is derived from TLE mean motion, and "
-    "TrueAnomaly_deg is derived from TLE mean anomaly."
-)
+    tle_mean_elements: TLEMeanElementsMetadata | None = None
 
 
 class PlanMetadata(BaseModel):
@@ -61,17 +66,21 @@ class PlanMetadata(BaseModel):
                 "tle_record must provide classical_elements(); install rust-ephem >= 0.11"
             )
 
+        tle_epoch_utc = _format_utc_datetime(tle_record.epoch)
         return cls(
             ephemeris=EphemerisMetadata(
                 source=source,
                 tle_file=str(tle_file) if tle_file is not None else None,
                 tle_name=tle_record.name,
-                tle_epoch_utc=_format_utc_datetime(tle_record.epoch),
+                tle_epoch_utc=tle_epoch_utc,
                 norad_id=tle_record.norad_id,
                 line1=tle_record.line1,
                 line2=tle_record.line2,
-                classical_elements=classical_elements(),
-                classical_elements_note=TLE_CLASSICAL_ELEMENTS_NOTE,
+                tle_mean_elements=TLEMeanElementsMetadata(
+                    epoch_utc=tle_epoch_utc,
+                    elements=classical_elements(),
+                    note=TLE_MEAN_ELEMENTS_NOTE,
+                ),
             )
         )
 

--- a/tests/plan/test_plan.py
+++ b/tests/plan/test_plan.py
@@ -238,7 +238,11 @@ class TestPlanSaveLoad:
                 "norad_id": 12345,
                 "line1": "1 43613U 18070A   26060.00000000  .00000000  00000-0  00000-0 0  9991",
                 "line2": "2 43613  97.7898  39.6457 0016466  83.3495 116.0254 15.13083683    09",
-                "classical_elements": {"SemimajorAxis_m": 6_900_000.0},
+                "tle_mean_elements": {
+                    "epoch_utc": "2026-03-01T00:00:00Z",
+                    "elements": {"SemimajorAxis_m": 6_900_000.0},
+                    "note": "TLE mean elements for SGP4.",
+                },
             }
         }
         dest = tmp_path / "plan.json"

--- a/tests/plan/test_plan_metadata.py
+++ b/tests/plan/test_plan_metadata.py
@@ -38,11 +38,16 @@ def test_plan_metadata_from_tle_record_uses_rust_ephem_elements(
     assert ephemeris["line1"] == _TLE1
     assert ephemeris["line2"] == _TLE2
 
-    elements = ephemeris["classical_elements"]
+    tle_mean_elements = ephemeris["tle_mean_elements"]
+    assert tle_mean_elements["epoch_utc"] == ephemeris["tle_epoch_utc"]
+    assert "not propagated osculating elements" in tle_mean_elements["note"]
+
+    elements = tle_mean_elements["elements"]
     assert elements == tle_record.classical_elements()
     assert elements["SemimajorAxis_m"] == pytest.approx(6904941.542146514)
     assert elements["Inclination_deg"] == pytest.approx(97.7898)
     assert elements["RightAscension_deg"] == pytest.approx(39.6457)
+    assert "classical_elements" not in ephemeris
 
 
 def test_attach_tle_plan_metadata_preserves_existing_metadata(
@@ -54,7 +59,7 @@ def test_attach_tle_plan_metadata_preserves_existing_metadata(
     attach_tle_plan_metadata(plan, tle_record=tle_record)
 
     assert plan.metadata["producer"] == {"name": "mission-generator"}
-    assert plan.metadata["ephemeris"]["classical_elements"] == (
+    assert plan.metadata["ephemeris"]["tle_mean_elements"]["elements"] == (
         tle_record.classical_elements()
     )
 
@@ -78,7 +83,7 @@ def test_plan_metadata_preserves_non_tle_ephemeris_payload() -> None:
 
     assert metadata["ephemeris"]["source"] == "SPICE"
     assert metadata["ephemeris"]["kernel"] == "example.bsp"
-    assert "classical_elements_note" not in metadata["ephemeris"]
+    assert "tle_mean_elements" not in metadata["ephemeris"]
 
 
 def test_plan_metadata_preserves_missing_source_ephemeris_payload() -> None:
@@ -88,7 +93,7 @@ def test_plan_metadata_preserves_missing_source_ephemeris_payload() -> None:
 
     assert metadata["ephemeris"]["kernel"] == "example.bsp"
     assert "source" not in metadata["ephemeris"]
-    assert "classical_elements_note" not in metadata["ephemeris"]
+    assert "tle_mean_elements" not in metadata["ephemeris"]
 
 
 def test_plan_metadata_preserves_empty_ephemeris_payload() -> None:


### PR DESCRIPTION
## Problem

Plan metadata exports values under `classical_elements`, which implies propagated osculating COEs and does not explicitly associate an epoch with the values. The implementation actually exports TLE mean elements at the TLE epoch, with semimajor axis and true anomaly derived from TLE mean motion and mean anomaly.

## Changes

- Replace the ambiguous `classical_elements` and note fields with a typed `tle_mean_elements` object.
- Group `epoch_utc`, `elements`, and `note` in that object so the epoch cannot be inferred incorrectly from plan start.
- State explicitly that the values are TLE mean elements for SGP4, not propagated osculating elements.
- Export `TLEMeanElementsMetadata` and update plan serialization coverage.

This intentionally does not retain a `classical_elements` alias, because that would preserve the ambiguity for consumers.

## Output shape

```json
"tle_mean_elements": {
  "epoch_utc": "2026-03-01T00:26:20.000256Z",
  "elements": { "TrueAnomaly_deg": 116.19480034509827 },
  "note": "TLE mean elements for SGP4, not propagated osculating elements. ..."
}
```

## Validation

- Focused plan/schema suite: 68 passed, 1 skipped
- Full suite: 2217 passed, 1 skipped
- Formatting, lint, pyupgrade, and mypy passed
- Full Tamalpais plan generation completed and produced the expected nested metadata