### PR TITLE
feat: export plan-start osculating elements

### DIFF
--- a/conops/ditl/ditl_mixin.py
+++ b/conops/ditl/ditl_mixin.py
@@ -198,7 +198,11 @@ class DITLMixin:
 
     def _attach_orbit_state_timeseries_to_plan(self) -> None:
         """Attach GCRS spacecraft position/velocity samples to the current plan."""
-        from ..targets import OrbitStateSampleSchema, OrbitStateTimeseriesSchema
+        from ..targets import (
+            OrbitStateSampleSchema,
+            OrbitStateTimeseriesSchema,
+            attach_osculating_elements_metadata,
+        )
 
         pv = getattr(self.ephem, "gcrs_pv", None)
         positions = getattr(pv, "position", None)
@@ -243,6 +247,11 @@ class DITLMixin:
             )
 
         self.plan.orbit_state_timeseries = OrbitStateTimeseriesSchema(samples=samples)
+        attach_osculating_elements_metadata(
+            self.plan,
+            self.ephem,
+            self.begin,
+        )
 
     def plot(self) -> None:
         """Plot DITL timeline.

--- a/conops/targets/__init__.py
+++ b/conops/targets/__init__.py
@@ -14,8 +14,10 @@ from .plan_entry import (
 )
 from .plan_metadata import (
     EphemerisMetadata,
+    OsculatingElementsMetadata,
     PlanMetadata,
     TLEMeanElementsMetadata,
+    attach_osculating_elements_metadata,
     attach_tle_plan_metadata,
 )
 from .plan_schema import PlanEntrySchema, PlanSchema
@@ -41,6 +43,8 @@ __all__ = [
     "TargetSlewEstimate",
     "EphemerisMetadata",
     "TLEMeanElementsMetadata",
+    "OsculatingElementsMetadata",
     "PlanMetadata",
+    "attach_osculating_elements_metadata",
     "attach_tle_plan_metadata",
 ]

--- a/conops/targets/plan_metadata.py
+++ b/conops/targets/plan_metadata.py
@@ -149,15 +149,12 @@ def attach_osculating_elements_metadata(
     plan: Plan,
     ephemeris: rust_ephem.Ephemeris,
     epoch: datetime,
-    *,
-    mu_km3_s2: float = rust_ephem.WGS72_EARTH_MU_KM3_S2,
 ) -> None:
     """Attach GCRS osculating elements at an exact ephemeris timestamp.
 
-    ``mu_km3_s2`` defaults to the WGS-72 Earth value used by SGP4. Automatic
-    DITL plan export uses that default. Callers converting states generated
-    with another gravity model must pass its matching gravitational parameter;
-    the exact value used is included in the serialized elements.
+    rust-ephem owns the Cartesian-state conversion, including selection of its
+    central-body gravitational parameter. The exact value returned by
+    rust-ephem is included in the serialized elements.
     """
     timestamps = ephemeris.timestamp
     positions = ephemeris.gcrs_pv.position
@@ -185,7 +182,6 @@ def attach_osculating_elements_metadata(
     elements = rust_ephem.osculating_elements_from_state(
         position_km=positions[index],
         velocity_km_s=velocities[index],
-        mu_km3_s2=mu_km3_s2,
     )
     serialized_elements = {
         "SemimajorAxis_m": elements["semimajor_axis_km"] * 1_000.0,

--- a/conops/targets/plan_metadata.py
+++ b/conops/targets/plan_metadata.py
@@ -152,7 +152,13 @@ def attach_osculating_elements_metadata(
     *,
     mu_km3_s2: float = rust_ephem.WGS72_EARTH_MU_KM3_S2,
 ) -> None:
-    """Attach GCRS osculating elements at an exact ephemeris timestamp."""
+    """Attach GCRS osculating elements at an exact ephemeris timestamp.
+
+    ``mu_km3_s2`` defaults to the WGS-72 Earth value used by SGP4. Automatic
+    DITL plan export uses that default. Callers converting states generated
+    with another gravity model must pass its matching gravitational parameter;
+    the exact value used is included in the serialized elements.
+    """
     timestamps = ephemeris.timestamp
     positions = ephemeris.gcrs_pv.position
     velocities = ephemeris.gcrs_pv.velocity

--- a/conops/targets/plan_metadata.py
+++ b/conops/targets/plan_metadata.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 
 import rust_ephem
 from pydantic import BaseModel, ConfigDict
@@ -9,10 +10,14 @@ from pydantic import BaseModel, ConfigDict
 from .plan import Plan
 
 
-def _format_utc_datetime(value: datetime) -> str:
+def _as_utc_datetime(value: datetime) -> datetime:
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return value.astimezone(timezone.utc)
+
+
+def _format_utc_datetime(value: datetime) -> str:
+    return _as_utc_datetime(value).isoformat().replace("+00:00", "Z")
 
 
 TLE_MEAN_ELEMENTS_NOTE = (
@@ -21,11 +26,25 @@ TLE_MEAN_ELEMENTS_NOTE = (
     "motion, and TrueAnomaly_deg is derived from TLE mean anomaly."
 )
 
+OSCULATING_ELEMENTS_NOTE = (
+    "Instantaneous two-body osculating elements derived from the GCRS "
+    "position and velocity at epoch_utc. RightAscension_deg is RAAN. "
+    "Angles are normalized to [0, 360) degrees."
+)
+
 
 class TLEMeanElementsMetadata(BaseModel):
     epoch_utc: str
     elements: dict[str, float]
     note: str
+
+
+class OsculatingElementsMetadata(BaseModel):
+    epoch_utc: str
+    frame: Literal["GCRS"] = "GCRS"
+    origin: Literal["Earth center"] = "Earth center"
+    elements: dict[str, float]
+    note: str = OSCULATING_ELEMENTS_NOTE
 
 
 class EphemerisMetadata(BaseModel):
@@ -39,6 +58,7 @@ class EphemerisMetadata(BaseModel):
     line1: str | None = None
     line2: str | None = None
     tle_mean_elements: TLEMeanElementsMetadata | None = None
+    osculating_elements: OsculatingElementsMetadata | None = None
 
 
 class PlanMetadata(BaseModel):
@@ -85,6 +105,28 @@ class PlanMetadata(BaseModel):
         )
 
 
+def _attach_ephemeris_metadata(
+    plan: Plan,
+    ephemeris_update: EphemerisMetadata,
+) -> None:
+    existing = PlanMetadata.model_validate(getattr(plan, "metadata", None) or {})
+    existing_data = existing.model_dump(mode="json", exclude_none=True)
+    existing_ephemeris = existing_data.get("ephemeris", {})
+    update_ephemeris = ephemeris_update.model_dump(
+        mode="json",
+        exclude_none=True,
+    )
+    plan.metadata = PlanMetadata.model_validate(
+        {
+            **existing_data,
+            "ephemeris": {
+                **existing_ephemeris,
+                **update_ephemeris,
+            },
+        }
+    ).model_dump(mode="json", exclude_none=True)
+
+
 def attach_tle_plan_metadata(
     plan: Plan,
     tle_record: rust_ephem.TLERecord,
@@ -93,16 +135,70 @@ def attach_tle_plan_metadata(
     source: str = "TLE",
 ) -> None:
     """Attach TLE metadata to ``plan.metadata`` while preserving existing keys."""
-    existing = PlanMetadata.model_validate(getattr(plan, "metadata", None) or {})
     ephemeris_metadata = PlanMetadata.from_tle_record(
         tle_record=tle_record,
         tle_file=tle_file,
         source=source,
-    )
+    ).ephemeris
+    if ephemeris_metadata is None:
+        raise ValueError("TLE plan metadata must include ephemeris metadata")
+    _attach_ephemeris_metadata(plan, ephemeris_metadata)
 
-    plan.metadata = PlanMetadata.model_validate(
-        {
-            **existing.model_dump(mode="json", exclude_none=True),
-            **ephemeris_metadata.model_dump(mode="json", exclude_none=True),
-        }
-    ).model_dump(mode="json", exclude_none=True)
+
+def attach_osculating_elements_metadata(
+    plan: Plan,
+    ephemeris: rust_ephem.Ephemeris,
+    epoch: datetime,
+    *,
+    mu_km3_s2: float = rust_ephem.WGS72_EARTH_MU_KM3_S2,
+) -> None:
+    """Attach GCRS osculating elements at an exact ephemeris timestamp."""
+    timestamps = ephemeris.timestamp
+    positions = ephemeris.gcrs_pv.position
+    velocities = ephemeris.gcrs_pv.velocity
+    if not (len(timestamps) == len(positions) == len(velocities)):
+        raise ValueError(
+            "Ephemeris timestamps, GCRS positions, and GCRS velocities must "
+            "have matching lengths"
+        )
+
+    epoch_utc = _as_utc_datetime(epoch)
+    matching_indices = [
+        index
+        for index, timestamp in enumerate(timestamps)
+        if _as_utc_datetime(timestamp) == epoch_utc
+    ]
+    if len(matching_indices) != 1:
+        raise ValueError(
+            "Osculating-element epoch must match exactly one ephemeris "
+            f"timestamp; found {len(matching_indices)} matches for "
+            f"{_format_utc_datetime(epoch_utc)}"
+        )
+
+    index = matching_indices[0]
+    elements = rust_ephem.osculating_elements_from_state(
+        position_km=positions[index],
+        velocity_km_s=velocities[index],
+        mu_km3_s2=mu_km3_s2,
+    )
+    serialized_elements = {
+        "SemimajorAxis_m": elements["semimajor_axis_km"] * 1_000.0,
+        "Eccentricity": elements["eccentricity"],
+        "Inclination_deg": elements["inclination_deg"],
+        "RightAscension_deg": elements["right_ascension_of_ascending_node_deg"],
+        "ArgPeriapsis_deg": elements["argument_of_periapsis_deg"],
+        "TrueAnomaly_deg": elements["true_anomaly_deg"],
+        "GravitationalParameter_m3_s2": (
+            elements["gravitational_parameter_km3_s2"] * 1.0e9
+        ),
+    }
+
+    _attach_ephemeris_metadata(
+        plan,
+        EphemerisMetadata(
+            osculating_elements=OsculatingElementsMetadata(
+                epoch_utc=_format_utc_datetime(epoch_utc),
+                elements=serialized_elements,
+            )
+        ),
+    )

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -409,12 +409,11 @@ includes the selected state epoch, ``frame: "GCRS"``, ``origin: "Earth center"``
 the gravitational parameter used for the conversion. Element angles are normalized to
 ``[0, 360)`` degrees.
 
-Automatic DITL plan export uses the WGS-72 Earth gravitational parameter, matching the
-default used by SGP4. The exact value is serialized as
-``GravitationalParameter_m3_s2`` so consumers can reproduce the conversion. Callers
-converting an ephemeris generated with another gravity model should invoke
-:func:`~conops.targets.attach_osculating_elements_metadata` with that model's matching
-``mu_km3_s2`` value.
+rust-ephem owns the Cartesian-state conversion and selection of the central-body
+gravitational parameter; its current default is the WGS-72 Earth value used by SGP4.
+Coast does not select or implement a gravity model. It serializes the exact value returned
+by rust-ephem as ``GravitationalParameter_m3_s2`` so consumers can reproduce the
+conversion.
 
 For validation and programmatic construction, use
 :class:`~conops.targets.PlanMetadata` and :class:`~conops.targets.EphemerisMetadata`.

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -409,6 +409,13 @@ includes the selected state epoch, ``frame: "GCRS"``, ``origin: "Earth center"``
 the gravitational parameter used for the conversion. Element angles are normalized to
 ``[0, 360)`` degrees.
 
+Automatic DITL plan export uses the WGS-72 Earth gravitational parameter, matching the
+default used by SGP4. The exact value is serialized as
+``GravitationalParameter_m3_s2`` so consumers can reproduce the conversion. Callers
+converting an ephemeris generated with another gravity model should invoke
+:func:`~conops.targets.attach_osculating_elements_metadata` with that model's matching
+``mu_km3_s2`` value.
+
 For validation and programmatic construction, use
 :class:`~conops.targets.PlanMetadata` and :class:`~conops.targets.EphemerisMetadata`.
 ``Plan.metadata`` itself remains a JSON-compatible dictionary so that mission tools can add

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -382,8 +382,14 @@ Plan Provenance
 
 Use :func:`~conops.targets.attach_tle_plan_metadata` to store the TLE provenance used to
 create a plan. The helper records the source, TLE filename and lines, epoch, NORAD ID, and
-derived classical elements under the plan's ``metadata.ephemeris`` object while preserving
-any metadata keys already present.
+TLE mean elements under the plan's ``metadata.ephemeris`` object.
+
+Use :func:`~conops.targets.attach_osculating_elements_metadata` separately to record
+instantaneous osculating elements derived from the propagated GCRS position and velocity.
+The requested epoch must match exactly one ephemeris timestamp. Both helpers preserve
+metadata keys already present. :class:`~conops.ditl.ditl.DITL` and
+:class:`~conops.ditl.queue_ditl.QueueDITL` call this helper automatically at the
+simulation start epoch when attaching the orbit-state timeseries.
 
 .. code-block:: python
 
@@ -396,6 +402,12 @@ any metadata keys already present.
        tle_file="examples/example.tle",
    )
    ditl.plan.save("plan_20251201.json")
+
+The resulting ``metadata.ephemeris`` object keeps the two element sets distinct:
+``tle_mean_elements`` is associated with the TLE epoch, while ``osculating_elements``
+includes the selected state epoch, ``frame: "GCRS"``, ``origin: "Earth center"``, and
+the gravitational parameter used for the conversion. Element angles are normalized to
+``[0, 360)`` degrees.
 
 For validation and programmatic construction, use
 :class:`~conops.targets.PlanMetadata` and :class:`~conops.targets.EphemerisMetadata`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "pydantic>=2.12",
     "pyproj>=3.7.0",
     "pytz>=2025.2",
-    "rust-ephem>=0.11.0",
+    "rust-ephem @ git+https://github.com/CosmicFrontierLabs/rust-ephem.git@bc05341",
     "shapely>=2",
     "tqdm>=4.67",
 ]

--- a/tests/baselines/default_plan_output.golden
+++ b/tests/baselines/default_plan_output.golden
@@ -4048,6 +4048,25 @@
         }
       }
     ],
+    "metadata": {
+      "ephemeris": {
+        "osculating_elements": {
+          "elements": {
+            "ArgPeriapsis_deg": 180.0,
+            "Eccentricity": 0.9953563216507494,
+            "GravitationalParameter_m3_s2": 398600800000000.0,
+            "Inclination_deg": 8.13010235415598,
+            "RightAscension_deg": 0.0,
+            "SemimajorAxis_m": 3508145.3493022895,
+            "TrueAnomaly_deg": 180.0
+          },
+          "epoch_utc": "2026-01-01T00:00:00Z",
+          "frame": "GCRS",
+          "note": "Instantaneous two-body osculating elements derived from the GCRS position and velocity at epoch_utc. RightAscension_deg is RAAN. Angles are normalized to [0, 360) degrees.",
+          "origin": "Earth center"
+        }
+      }
+    },
     "num_entries": 5,
     "start": "2026-01-01T00:00:00+00:00",
     "version": 0

--- a/tests/plan/test_plan_metadata.py
+++ b/tests/plan/test_plan_metadata.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
 
+import numpy as np
 import pytest
+import rust_ephem
 from rust_ephem.tle import TLERecord
 
-from conops.targets import Plan, PlanMetadata, attach_tle_plan_metadata
+from conops.targets import (
+    Plan,
+    PlanMetadata,
+    attach_osculating_elements_metadata,
+    attach_tle_plan_metadata,
+)
 
 _TLE1 = "1 43613U 18070A   26060.00000000  .00000000  00000-0  00000-0 0  9991"
 _TLE2 = "2 43613  97.7898  39.6457 0016466  83.3495 116.0254 15.13083683    09"
@@ -62,6 +70,105 @@ def test_attach_tle_plan_metadata_preserves_existing_metadata(
     assert plan.metadata["ephemeris"]["tle_mean_elements"]["elements"] == (
         tle_record.classical_elements()
     )
+
+
+def test_attach_osculating_elements_uses_exact_gcrs_state_and_preserves_tle(
+    tle_record: TLERecord,
+) -> None:
+    epoch = datetime(2026, 3, 1, 18, 0, tzinfo=timezone.utc)
+    ephemeris = Mock(spec=rust_ephem.Ephemeris)
+    ephemeris.timestamp = np.array(
+        [epoch - timedelta(minutes=1), epoch],
+        dtype=object,
+    )
+    ephemeris.gcrs_pv = Mock(
+        position=np.array(
+            [
+                [7000.0, 0.0, 0.0],
+                [-6045.0, -3490.0, 2500.0],
+            ]
+        ),
+        velocity=np.array(
+            [
+                [0.0, 7.5, 0.0],
+                [-3.457, 6.618, 2.533],
+            ]
+        ),
+    )
+    plan = Plan()
+    plan.metadata = {"producer": {"name": "mission-generator"}}
+    attach_tle_plan_metadata(plan, tle_record=tle_record)
+
+    attach_osculating_elements_metadata(plan, ephemeris, epoch)
+
+    assert plan.metadata["producer"] == {"name": "mission-generator"}
+    ephemeris_metadata = plan.metadata["ephemeris"]
+    assert "tle_mean_elements" in ephemeris_metadata
+
+    osculating = ephemeris_metadata["osculating_elements"]
+    assert osculating["epoch_utc"] == "2026-03-01T18:00:00Z"
+    assert osculating["frame"] == "GCRS"
+    assert osculating["origin"] == "Earth center"
+    assert "Instantaneous two-body osculating elements" in osculating["note"]
+
+    elements = osculating["elements"]
+    assert elements["SemimajorAxis_m"] == pytest.approx(
+        8_788_070.943,
+        abs=0.001,
+    )
+    assert elements["Eccentricity"] == pytest.approx(0.171210, abs=1.0e-6)
+    assert elements["Inclination_deg"] == pytest.approx(153.249, abs=0.001)
+    assert elements["RightAscension_deg"] == pytest.approx(255.279, abs=0.001)
+    assert elements["ArgPeriapsis_deg"] == pytest.approx(20.068, abs=0.001)
+    assert elements["TrueAnomaly_deg"] == pytest.approx(28.446, abs=0.001)
+    assert elements["GravitationalParameter_m3_s2"] == pytest.approx(
+        rust_ephem.WGS72_EARTH_MU_KM3_S2 * 1.0e9
+    )
+
+    attach_tle_plan_metadata(plan, tle_record=tle_record)
+    assert plan.metadata["ephemeris"]["osculating_elements"]["elements"] == elements
+
+
+def test_attach_osculating_elements_requires_exact_epoch() -> None:
+    epoch = datetime(2026, 3, 1, 18, 0, tzinfo=timezone.utc)
+    ephemeris = Mock(spec=rust_ephem.Ephemeris)
+    ephemeris.timestamp = np.array(
+        [epoch - timedelta(minutes=1)],
+        dtype=object,
+    )
+    ephemeris.gcrs_pv = Mock(
+        position=np.array([[7000.0, 0.0, 0.0]]),
+        velocity=np.array([[0.0, 7.5, 0.0]]),
+    )
+
+    with pytest.raises(ValueError, match="found 0 matches"):
+        attach_osculating_elements_metadata(Plan(), ephemeris, epoch)
+
+
+def test_attach_osculating_elements_rejects_duplicate_epoch() -> None:
+    epoch = datetime(2026, 3, 1, 18, 0, tzinfo=timezone.utc)
+    ephemeris = Mock(spec=rust_ephem.Ephemeris)
+    ephemeris.timestamp = np.array([epoch, epoch], dtype=object)
+    ephemeris.gcrs_pv = Mock(
+        position=np.array([[7000.0, 0.0, 0.0]] * 2),
+        velocity=np.array([[0.0, 7.5, 0.0]] * 2),
+    )
+
+    with pytest.raises(ValueError, match="found 2 matches"):
+        attach_osculating_elements_metadata(Plan(), ephemeris, epoch)
+
+
+def test_attach_osculating_elements_requires_aligned_state_arrays() -> None:
+    epoch = datetime(2026, 3, 1, 18, 0, tzinfo=timezone.utc)
+    ephemeris = Mock(spec=rust_ephem.Ephemeris)
+    ephemeris.timestamp = np.array([epoch], dtype=object)
+    ephemeris.gcrs_pv = Mock(
+        position=np.array([[7000.0, 0.0, 0.0]]),
+        velocity=np.empty((0, 3)),
+    )
+
+    with pytest.raises(ValueError, match="matching lengths"):
+        attach_osculating_elements_metadata(Plan(), ephemeris, epoch)
 
 
 def test_plan_metadata_requires_rust_ephem_element_api() -> None:

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -77,8 +77,9 @@ class TestQueueDITLInitialization:
     def test_attach_orbit_state_timeseries_to_plan(
         self, queue_ditl: QueueDITL, tmp_path
     ) -> None:
+        queue_ditl.begin = datetime(2026, 1, 1, tzinfo=timezone.utc)
         queue_ditl.ephem.timestamp = [
-            datetime(2026, 1, 1, tzinfo=timezone.utc),
+            queue_ditl.begin,
             datetime(2026, 1, 1, 0, 1, tzinfo=timezone.utc),
         ]
         queue_ditl.ephem.gcrs_pv = Mock(
@@ -101,6 +102,10 @@ class TestQueueDITLInitialization:
         assert sample.timestamp == "2026-01-01T00:00:00+00:00"
         assert sample.position_km == pytest.approx((7000.0, 0.0, 0.0))
         assert sample.velocity_km_s == pytest.approx((0.0, 7.5, 0.0))
+        osculating = queue_ditl.plan.metadata["ephemeris"]["osculating_elements"]
+        assert osculating["epoch_utc"] == "2026-01-01T00:00:00Z"
+        assert osculating["frame"] == "GCRS"
+        assert osculating["origin"] == "Earth center"
 
         plan_path = queue_ditl.plan.save(tmp_path / "plan.json")
         raw = json.loads(plan_path.read_text())


### PR DESCRIPTION
## Problem

COAST exports TLE mean elements at the TLE epoch and a GCRS position/velocity timeseries, but it does not export instantaneous osculating elements for the propagated state. External trajectory comparisons therefore require consumers to repeat the Cartesian-to-COE conversion and can accidentally mix TLE mean elements with propagated elements or associate them with the wrong epoch.

## Changes

- add a typed `metadata.ephemeris.osculating_elements` block with an explicit epoch, `GCRS` frame, Earth-center origin, conversion note, and gravitational parameter
- derive the elements automatically from the exact simulation-start GCRS position and velocity when COAST attaches the orbit-state timeseries
- use rust-ephem for the Cartesian-state conversion; Coast only maps the result into its established SI plan-output keys
- leave central-body gravitational-parameter selection in rust-ephem and serialize the exact value it returns; rust-ephem currently defaults to the WGS-72 Earth value used by SGP4
- require the requested epoch to match exactly one ephemeris sample and require timestamps, positions, and velocities to have matching lengths
- preserve TLE mean elements and other ephemeris metadata regardless of attachment order
- document the distinction between `tle_mean_elements` and `osculating_elements`
- update the default-plan golden output to cover the new metadata contract

## Dependency

This PR is stacked on CosmicFrontierLabs/rust-ephem#180. Until that PR is merged and released, `pyproject.toml` points to its immutable commit `bc05341` so CI can exercise the real conversion. Before this PR is marked ready, replace that direct reference with the released rust-ephem version constraint.

## Validation

- full suite: `2221 passed, 1 skipped`
- focused metadata/schema/QueueDITL suite: `35 passed, 1 skipped`
- all configured hooks passed, including Ruff, pyupgrade, Sphinx, pyproject validation, and strict mypy
- default deterministic plan baseline passes with only the intentional osculating metadata addition
- smoke-tested against a real rust-ephem `TLEEphemeris` GCRS state and timestamp
