### PR TITLE
fix: specify quaternion action in plan schema

### DIFF
--- a/conops/common/vector.py
+++ b/conops/common/vector.py
@@ -335,6 +335,8 @@ def attitude_for_body_vector_tracking(
 # Attitude quaternion represents the rotation from ECI to spacecraft body
 # frame, matching the direction-cosine convention used in scbodyvector():
 #   R = R_x(+roll) @ R_y(dec) @ R_z(-ra)   (all angles in radians)
+# Hamilton vector action:
+#   [0, v_body] = q ⊗ [0, v_eci] ⊗ conjugate(q)
 # Body X = boresight, Body Z = "up" (defines roll).
 
 
@@ -358,7 +360,8 @@ def attitude_to_quat(
     """Convert spacecraft attitude (RA, Dec, Roll) in degrees to quaternion [w, x, y, z].
 
     The attitude quaternion encodes the rotation R = R_x(+roll) @ R_y(dec) @ R_z(-ra)
-    that transforms ECI vectors into spacecraft body frame.
+    that transforms ECI vectors into spacecraft body frame. It uses the
+    Hamilton product and vector action ``q * v * conjugate(q)``.
     """
     ra = np.deg2rad(ra_deg)
     dec = np.deg2rad(dec_deg)

--- a/conops/targets/plan.py
+++ b/conops/targets/plan.py
@@ -17,7 +17,7 @@ from pydantic import (
 )
 
 from .._version import __version__
-from .plan_entry import PlanEntry
+from .plan_entry import AttitudeRotationConventionSchema, PlanEntry
 
 
 class TargetList(BaseModel):
@@ -54,7 +54,7 @@ class AttitudeSampleSchema(BaseModel):
     quat_z: float | None = None
 
 
-class AttitudeTimeseriesSchema(BaseModel):
+class AttitudeTimeseriesSchema(AttitudeRotationConventionSchema):
     """Continuous executed spacecraft attitude timeline tied to a plan file."""
 
     version: int = 0
@@ -66,6 +66,8 @@ class AttitudeTimeseriesSchema(BaseModel):
     plan_version: int | None = None
     plan_start: float | None = None
     plan_end: float | None = None
+    frame: Literal["GCRS"] = "GCRS"
+    body_frame: Literal["COAST_BODY"] = "COAST_BODY"
     samples: list[AttitudeSampleSchema] = Field(default_factory=list)
 
     @computed_field  # type: ignore[prop-decorator]

--- a/conops/targets/plan_entry.py
+++ b/conops/targets/plan_entry.py
@@ -26,12 +26,19 @@ BodyAxis = Literal["+X", "-X", "+Y", "-Y", "+Z", "-Z"]
 RollSource = Literal["planned", "defaulted_from_unconstrained_sentinel"]
 
 
-class AttitudeRotationSchema(BaseModel):
-    """Generic attitude rotation representation."""
+class AttitudeRotationConventionSchema(BaseModel):
+    """Machine-readable attitude rotation convention."""
 
     representation: Literal["quaternion"] = "quaternion"
     direction: Literal["inertial_to_body"] = "inertial_to_body"
     order: Literal["wxyz"] = "wxyz"
+    quaternion_product: Literal["hamilton"] = "hamilton"
+    vector_action: Literal["q_v_q_conjugate"] = "q_v_q_conjugate"
+
+
+class AttitudeRotationSchema(AttitudeRotationConventionSchema):
+    """Generic attitude rotation representation."""
+
     values: tuple[float, float, float, float]
 
 

--- a/docs/plan_serialization.rst
+++ b/docs/plan_serialization.rst
@@ -313,7 +313,11 @@ Entry Fields
      - object | null
      - Commanded fixed target attitude for ``AT``, ``PPT``, and ``TOO`` entries. It contains
        a GCRS-to-COAST-body quaternion in ``wxyz`` order and the RA/Dec/roll inputs used to
-       generate it. It is ``null`` for dynamically tracked entries such as ``GSP``.
+       generate it. The rotation records ``quaternion_product: "hamilton"`` and
+       ``vector_action: "q_v_q_conjugate"`` explicitly: an inertial vector ``v`` is
+       transformed into body coordinates as ``q * v * conjugate(q)``. Consumers using
+       ``conjugate(q) * v * q`` must conjugate the exported quaternion. It is ``null`` for
+       dynamically tracked entries such as ``GSP``.
 
 Ground Station Pass (GSP) Entries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -439,6 +443,13 @@ field so that consumers can locate it without scanning the directory.
      "plan_version": 3,
      "plan_start": "2025-12-01T00:00:00+00:00",
      "plan_end": "2025-12-01T23:59:00+00:00",
+     "frame": "GCRS",
+     "body_frame": "COAST_BODY",
+     "representation": "quaternion",
+     "direction": "inertial_to_body",
+     "order": "wxyz",
+     "quaternion_product": "hamilton",
+     "vector_action": "q_v_q_conjugate",
      "num_samples": 2,
      "samples": [
        {
@@ -500,6 +511,17 @@ field so that consumers can locate it without scanning the directory.
    * - ``plan_end``
      - string | null
      - ISO-8601 UTC timestamp matching the plan's ``end`` field.
+   * - ``frame`` / ``body_frame``
+     - string
+     - Source and destination frames for every sample quaternion: ``GCRS`` and
+       ``COAST_BODY``.
+   * - ``representation`` / ``direction`` / ``order``
+     - string
+     - Every sample uses an ``inertial_to_body`` quaternion in ``wxyz`` component order.
+   * - ``quaternion_product`` / ``vector_action``
+     - string
+     - Every sample uses the Hamilton product and transforms inertial vectors into body
+       coordinates as ``q * v * conjugate(q)``.
    * - ``num_samples``
      - int
      - Number of attitude samples in ``samples``.

--- a/tests/baselines/default_plan_output.golden
+++ b/tests/baselines/default_plan_output.golden
@@ -1,6 +1,12 @@
 {
   "attitude_timeseries": {
+    "body_frame": "COAST_BODY",
+    "direction": "inertial_to_body",
+    "frame": "GCRS",
     "num_samples": 288,
+    "order": "wxyz",
+    "quaternion_product": "hamilton",
+    "representation": "quaternion",
     "samples": [
       {
         "dec": 0.0,
@@ -3747,6 +3753,7 @@
         "utime": 1767311700.0
       }
     ],
+    "vector_action": "q_v_q_conjugate",
     "version": 0
   },
   "orbit_state_timeseries_summary": {
@@ -3844,13 +3851,15 @@
           "rotation": {
             "direction": "inertial_to_body",
             "order": "wxyz",
+            "quaternion_product": "hamilton",
             "representation": "quaternion",
             "values": [
               -0.33124285883428206,
               0.13811672678658393,
               0.26472108466300764,
               -0.8950556885400442
-            ]
+            ],
+            "vector_action": "q_v_q_conjugate"
           }
         }
       },
@@ -3888,13 +3897,15 @@
           "rotation": {
             "direction": "inertial_to_body",
             "order": "wxyz",
+            "quaternion_product": "hamilton",
             "representation": "quaternion",
             "values": [
               -0.017009829004397924,
               0.792860483291601,
               0.6053640995494111,
               0.06795017828218786
-            ]
+            ],
+            "vector_action": "q_v_q_conjugate"
           }
         }
       },
@@ -3932,13 +3943,15 @@
           "rotation": {
             "direction": "inertial_to_body",
             "order": "wxyz",
+            "quaternion_product": "hamilton",
             "representation": "quaternion",
             "values": [
               -0.40422188881944526,
               0.8940430380011926,
               0.1928557332398833,
               -0.009918515884208057
-            ]
+            ],
+            "vector_action": "q_v_q_conjugate"
           }
         }
       },
@@ -3976,13 +3989,15 @@
           "rotation": {
             "direction": "inertial_to_body",
             "order": "wxyz",
+            "quaternion_product": "hamilton",
             "representation": "quaternion",
             "values": [
               0.07608062768571641,
               0.3664540665546916,
               0.8829714475409405,
               0.2833453335135997
-            ]
+            ],
+            "vector_action": "q_v_q_conjugate"
           }
         }
       },
@@ -4020,13 +4035,15 @@
           "rotation": {
             "direction": "inertial_to_body",
             "order": "wxyz",
+            "quaternion_product": "hamilton",
             "representation": "quaternion",
             "values": [
               -0.8113660378157899,
               -0.21557635248643178,
               -0.2216618148063541,
               -0.4960625250757263
-            ]
+            ],
+            "vector_action": "q_v_q_conjugate"
           }
         }
       }

--- a/tests/plan/test_plan.py
+++ b/tests/plan/test_plan.py
@@ -280,6 +280,13 @@ class TestPlanSaveLoad:
         assert attitude_path.exists()
         attitude_raw = json.loads(attitude_path.read_text())
         assert attitude_raw["plan_file"] == "plan.json"
+        assert attitude_raw["frame"] == "GCRS"
+        assert attitude_raw["body_frame"] == "COAST_BODY"
+        assert attitude_raw["representation"] == "quaternion"
+        assert attitude_raw["direction"] == "inertial_to_body"
+        assert attitude_raw["order"] == "wxyz"
+        assert attitude_raw["quaternion_product"] == "hamilton"
+        assert attitude_raw["vector_action"] == "q_v_q_conjugate"
         assert attitude_raw["samples"][0]["obsid"] == 0
 
     def test_save_writes_orbit_state_timeseries_companion(self, tmp_path):

--- a/tests/plan/test_plan_schema.py
+++ b/tests/plan/test_plan_schema.py
@@ -155,6 +155,8 @@ class TestPlanEntryExport:
         assert attitude["rotation"]["representation"] == "quaternion"
         assert attitude["rotation"]["direction"] == "inertial_to_body"
         assert attitude["rotation"]["order"] == "wxyz"
+        assert attitude["rotation"]["quaternion_product"] == "hamilton"
+        assert attitude["rotation"]["vector_action"] == "q_v_q_conjugate"
         assert attitude["rotation"]["values"] == pytest.approx(
             attitude_to_quat(15.0, 45.0, 10.0).tolist()
         )
@@ -179,11 +181,23 @@ class TestPlanEntryExport:
         attitude = TargetAttitudeSchema(rotation=rotation, pointing=pointing)
 
         assert attitude.rotation.representation == "quaternion"
+        assert attitude.rotation.quaternion_product == "hamilton"
+        assert attitude.rotation.vector_action == "q_v_q_conjugate"
         assert attitude.pointing.boresight_axis == "+Z"
 
         with pytest.raises(ValidationError):
             AttitudeRotationSchema(
                 representation="matrix",
+                values=(1.0, 0.0, 0.0, 0.0),
+            )
+        with pytest.raises(ValidationError):
+            AttitudeRotationSchema(
+                quaternion_product="jpl",
+                values=(1.0, 0.0, 0.0, 0.0),
+            )
+        with pytest.raises(ValidationError):
+            AttitudeRotationSchema(
+                vector_action="q_conjugate_v_q",
                 values=(1.0, 0.0, 0.0, 0.0),
             )
         with pytest.raises(ValidationError):
@@ -327,6 +341,8 @@ class TestPlanIO:
         attitude = raw["entries"][0]["target_attitude"]
         assert attitude["rotation"]["direction"] == "inertial_to_body"
         assert attitude["rotation"]["order"] == "wxyz"
+        assert attitude["rotation"]["quaternion_product"] == "hamilton"
+        assert attitude["rotation"]["vector_action"] == "q_v_q_conjugate"
         assert attitude["pointing"]["boresight_axis"] == "+X"
 
     def test_load_existing_example_json(self):


### PR DESCRIPTION
## Problem

The plan schema identifies target attitude quaternions as `inertial_to_body` in `wxyz` order, but does not state the quaternion product or vector action. That is insufficient to distinguish COAST's Hamilton `q * v * conjugate(q)` action from consumers such as MAX that apply a frame quaternion as `conjugate(q) * v * q`.

This ambiguity caused MAX to apply COAST's numeric quaternion in the opposite sense. For ObsID 10483, the resulting boresight was about 7.9 degrees off and AD observed pervasive STR/imager occultations.

## Change

- Add machine-readable `quaternion_product: "hamilton"` and `vector_action: "q_v_q_conjugate"` fields to exported target attitudes.
- Document the exact vector transformation and the requirement for opposite-action consumers to conjugate the quaternion.
- Constrain the fields with literals and cover serialization/validation in tests.

This does not change any quaternion values or COAST pointing behavior. It makes the existing convention unambiguous so downstream format converters can translate it correctly.

## Validation

- `pytest`: 2217 passed, 1 skipped
- full pre-commit suite, including Sphinx and mypy
- default-plan golden regression