### PR TITLE
fix: select reachable safe ground-pass profiles

### DIFF
--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1936,6 +1936,12 @@ class QueueDITL(DITLMixin, DITLStats):
         if next_pass is None:
             return False
 
+        # An accepted reservation already owns its ingress and tracking profile.
+        # Replanning it after the ingress slew completes can select a different
+        # profile and leave the spacecraft off-attitude at contact start.
+        if self._ground_pass_key(next_pass) in self._planned_gsp_keys:
+            return False
+
         # Check if it's time to start slewing for the next pass. Tracking
         # profiles are all pass-safe, but their incoming slew paths depend on
         # the actual attitude at this step.

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1808,6 +1808,34 @@ class QueueDITL(DITLMixin, DITLStats):
                 return entry
         return None
 
+    def _gsp_slew_for_profile(
+        self,
+        gspass: Pass,
+        profile: list[tuple[float, float, float]],
+        utime: float,
+        ra: float,
+        dec: float,
+        roll: float,
+    ) -> Slew | None:
+        """Build the incoming slew for one tracking-profile candidate."""
+        if utime >= gspass.begin:
+            target = gspass.attitude_for_profile_at(profile, utime)
+        else:
+            target = profile[0] if profile else None
+        if target is None:
+            return None
+
+        slew = Slew(config=self.config)
+        slew.startra = ra
+        slew.startdec = dec
+        slew.startroll = roll
+        slew.slewstart = utime
+        slew.endra, slew.enddec, slew.endroll = target
+        slew.obstype = ObsType.GSP
+        slew.obsid = gspass.obsid
+        slew.calc_slewtime()
+        return slew
+
     def _close_gsp_plan_entry(self, gspass: Pass, executed_end: float) -> None:
         """Extend a GSP plan entry's end time to match when the pass actually ended."""
         entry = self._planned_gsp_entry(gspass)
@@ -1848,6 +1876,19 @@ class QueueDITL(DITLMixin, DITLStats):
         # Check if we're in a pass, if yes, command ACS to start the pass
         current_pass = self.acs.passrequests.current_pass(utime)
         if current_pass is not None and self.acs.acsmode != ACSMode.PASS:
+            if not current_pass.at_selected_tracking_attitude(utime, ra, dec, roll):
+                self.log.log_event(
+                    utime=utime,
+                    event_type="PASS",
+                    description=(
+                        f"Skipping pass start for {current_pass.station} - "
+                        "spacecraft did not reach the selected safe tracking "
+                        "attitude before contact"
+                    ),
+                    obsid=current_pass.obsid,
+                    acs_mode=self.acs.acsmode,
+                )
+                return False
             if not self._gsp_plan_entry_allowed(current_pass, reserved_begin=utime):
                 return False
             self.log.log_event(
@@ -1895,54 +1936,87 @@ class QueueDITL(DITLMixin, DITLStats):
         if next_pass is None:
             return False
 
-        # Check if it's time to start slewing for the next pass
+        # Check if it's time to start slewing for the next pass. Tracking
+        # profiles are all pass-safe, but their incoming slew paths depend on
+        # the actual attitude at this step.
         if next_pass.time_to_slew(utime=utime, ra=ra, dec=dec, roll=roll):
+            due_profiles = (
+                next_pass.tracking_profiles_due_for_slew(
+                    utime=utime,
+                    ra=ra,
+                    dec=dec,
+                    roll=roll,
+                )
+                if next_pass.ephem is not None
+                else []
+            )
+            if not due_profiles:
+                # Preserve support for externally constructed Pass objects that
+                # only provide the legacy start-attitude fields.
+                due_profiles = next_pass.available_tracking_profiles() or [
+                    [
+                        (
+                            next_pass.gsstartra,
+                            next_pass.gsstartdec,
+                            next_pass.gsstartroll,
+                        )
+                    ]
+                ]
             if not self._gsp_plan_entry_allowed(next_pass, reserved_begin=utime):
                 return False
-            # If it's time to slew, enqueue the slew command
-            self.log.log_event(
-                utime=utime,
-                event_type="SLEW",
-                description=f"Slewing for pass to {next_pass.station}",
-                acs_mode=self.acs.acsmode,
-            )
+            first_violation: tuple[float, str, str] | None = None
+            for profile in due_profiles:
+                slew = self._gsp_slew_for_profile(
+                    next_pass,
+                    profile,
+                    utime,
+                    ra,
+                    dec,
+                    roll,
+                )
+                if slew is None:
+                    continue
+                violation = self._slew_attitude_constraint_violation(slew, ACSMode.PASS)
+                if violation is not None:
+                    if first_violation is None:
+                        first_violation = violation
+                    continue
 
-            # Create slew object for the pass
-            slew = Slew(config=self.config)
-
-            slew.startra = ra
-            slew.startdec = dec
-            slew.startroll = roll
-            slew.slewstart = utime
-            slew.endra = next_pass.gsstartra
-            slew.enddec = next_pass.gsstartdec
-            slew.endroll = next_pass.gsstartroll
-            slew.obstype = ObsType.GSP  # Ground Station Pass slew
-            slew.obsid = next_pass.obsid
-            slew.calc_slewtime()
-            violation = self._slew_attitude_constraint_violation(slew, ACSMode.PASS)
-            if violation is not None:
-                violation_time, constraint_name, scope_label = violation
+                next_pass.select_tracking_profile(profile)
                 self.log.log_event(
                     utime=utime,
-                    event_type="PASS",
-                    description=(
-                        f"Skipping pass slew to {next_pass.station} - path violates "
-                        f"{constraint_name} ({scope_label}) at "
-                        f"{unixtime2date(violation_time)}"
-                    ),
-                    obsid=next_pass.obsid,
+                    event_type="SLEW",
+                    description=f"Slewing for pass to {next_pass.station}",
                     acs_mode=self.acs.acsmode,
                 )
-                return False
-            command = ACSCommand(
-                command_type=ACSCommandType.SLEW_TO_TARGET,
-                execution_time=utime,
-                slew=slew,
+                command = ACSCommand(
+                    command_type=ACSCommandType.SLEW_TO_TARGET,
+                    execution_time=utime,
+                    slew=slew,
+                )
+                self.acs.enqueue_command(command)
+                self._record_gsp_plan_entry(next_pass, reserved_begin=utime, slew=slew)
+                return True
+
+            if first_violation is not None:
+                violation_time, constraint_name, scope_label = first_violation
+                detail = (
+                    f"first candidate violates {constraint_name} ({scope_label}) "
+                    f"at {unixtime2date(violation_time)}"
+                )
+            else:
+                detail = "no candidate produced a valid slew"
+            self.log.log_event(
+                utime=utime,
+                event_type="PASS",
+                description=(
+                    f"Skipping pass slew to {next_pass.station} - no "
+                    f"constraint-safe tracking-profile ingress; {detail}"
+                ),
+                obsid=next_pass.obsid,
+                acs_mode=self.acs.acsmode,
             )
-            self.acs.enqueue_command(command)
-            self._record_gsp_plan_entry(next_pass, reserved_begin=utime, slew=slew)
-            return True
+            return False
 
         return False
 

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -127,6 +127,10 @@ class Pass(BaseModel):
     roll: list[float] = Field(default_factory=list)
     station_ra: list[float] = Field(default_factory=list)
     station_dec: list[float] = Field(default_factory=list)
+    tracking_attitude_profiles: list[list[tuple[float, float, float]]] = Field(
+        default_factory=list,
+        exclude=True,
+    )
 
     # Scheduling / status
     slewrequired: float = 0.0
@@ -189,6 +193,91 @@ class Pass(BaseModel):
 
         ra, dec = self.ra_dec(utime)
         return ra, dec, self.roll_at(utime)
+
+    def attitude_for_profile_at(
+        self,
+        profile: list[tuple[float, float, float]],
+        utime: float,
+    ) -> tuple[float, float, float] | None:
+        idx = self._profile_index(utime)
+        if idx is None or idx >= len(profile):
+            return None
+        return profile[idx]
+
+    def available_tracking_profiles(
+        self,
+    ) -> list[list[tuple[float, float, float]]]:
+        if self.tracking_attitude_profiles:
+            return self.tracking_attitude_profiles
+        if not self.ra or not self.dec:
+            return []
+        return [
+            list(
+                zip(
+                    self.ra,
+                    self.dec,
+                    self.roll or [self.gsstartroll] * len(self.ra),
+                    strict=True,
+                )
+            )
+        ]
+
+    def select_tracking_profile(
+        self, profile: list[tuple[float, float, float]]
+    ) -> None:
+        """Use a constraint-safe tracking profile selected for the incoming slew."""
+        self.ra = [attitude[0] for attitude in profile]
+        self.dec = [attitude[1] for attitude in profile]
+        self.roll = [attitude[2] for attitude in profile]
+        self.gsstartra, self.gsstartdec, self.gsstartroll = profile[0]
+        self.gsendra, self.gsenddec, self.gsendroll = profile[-1]
+
+    def tracking_profiles_due_for_slew(
+        self, utime: float, ra: float, dec: float, roll: float = 0.0
+    ) -> list[list[tuple[float, float, float]]]:
+        """Return tracking profiles whose incoming slew must start by this step."""
+        assert self.ephem is not None, "Ephemeris must be set for Pass class"
+
+        due_profiles: list[list[tuple[float, float, float]]] = []
+        for profile in self.available_tracking_profiles():
+            if utime >= self.begin:
+                target = self.attitude_for_profile_at(profile, utime)
+            else:
+                target = profile[0] if profile else None
+            if target is None:
+                continue
+
+            slewtime = self._slew_time_to_target(utime, ra, dec, roll, *target)
+            time_until_slew = (self.begin - slewtime) - utime
+            if time_until_slew <= pass_slew_trigger_buffer(self.ephem.step_size):
+                due_profiles.append(profile)
+        return due_profiles
+
+    def at_selected_tracking_attitude(
+        self,
+        utime: float,
+        ra: float,
+        dec: float,
+        roll: float,
+        tolerance_deg: float = 1e-3,
+    ) -> bool:
+        """Return whether ACS reached the selected profile before starting contact."""
+        if not self.utime:
+            return True
+        target_ra, target_dec, target_roll = self.attitude_at(utime)
+        if target_ra is None or target_dec is None:
+            return False
+        return bool(
+            quaternion_attitude_distance(
+                ra,
+                dec,
+                roll,
+                target_ra,
+                target_dec,
+                target_roll,
+            )
+            <= tolerance_deg
+        )
 
     def station_ra_dec(self, utime: float) -> tuple[float | None, float | None]:
         """Return the spacecraft-to-ground-station line of sight."""
@@ -376,35 +465,7 @@ class Pass(BaseModel):
         If on time, slews to pass start. If late, slews to where the pass currently is.
         Returns True when the pass time minus slew time is less than 60 seconds away.
         """
-        assert self.ephem is not None, "Ephemeris must be set for Pass class"
-        assert self.config is not None, "Config must be set for Pass class"
-
-        # Determine target pointing: if we're late, target where pass currently is
-        if utime >= self.begin:
-            # We're late - target current pass position
-            target_ra, target_dec, target_roll = self.attitude_at(utime)
-            if target_ra is None or target_dec is None:
-                return False
-        else:
-            # On time - target pass start
-            if not self.ra or not self.dec:
-                return False
-            target_ra, target_dec, target_roll = (
-                self.ra[0],
-                self.dec[0],
-                self.roll[0] if self.roll else self.gsstartroll,
-            )
-
-        slewtime = self._slew_time_to_target(
-            utime, ra, dec, roll, target_ra, target_dec, target_roll
-        )
-        # Determine if we need to start slewing now
-        time_until_slew = (self.begin - slewtime) - utime
-
-        if time_until_slew <= pass_slew_trigger_buffer(self.ephem.step_size):
-            return True
-        else:
-            return False
+        return bool(self.tracking_profiles_due_for_slew(utime, ra, dec, roll))
 
 
 class PassTimes:
@@ -567,13 +628,17 @@ class PassTimes:
             attitude_profile.append(attitude)
         return attitude_profile
 
-    def _fixed_phase_tracking_attitude_profile(
+    def _fixed_phase_tracking_attitude_profiles(
         self,
         antenna_boresight: tuple[float, float, float],
         target_vectors: np.ndarray,
         track_utime: list[float],
-    ) -> tuple[list[tuple[float, float, float]] | None, bool]:
+    ) -> tuple[
+        list[tuple[float, float, float]] | None,
+        list[list[tuple[float, float, float]]],
+    ]:
         fallback_profile: list[tuple[float, float, float]] | None = None
+        safe_profiles: list[list[tuple[float, float, float]]] = []
         for phase_deg in self._gsp_tracking_phase_candidates():
             attitude_profile = self._tracking_attitude_profile_for_phase(
                 antenna_boresight, target_vectors, phase_deg
@@ -588,9 +653,9 @@ class PassTimes:
             if not self._pass_profile_violates_scopes(
                 track_utime, track_ra, track_dec, track_roll
             ):
-                return attitude_profile, True
+                safe_profiles.append(attitude_profile)
 
-        return fallback_profile, False
+        return fallback_profile, safe_profiles
 
     def _safe_tracking_attitudes_by_sample(
         self,
@@ -691,34 +756,124 @@ class PassTimes:
             for sample_index, phase in enumerate(phase_path)
         ]
 
+    def _dynamic_phase_tracking_attitude_profiles(
+        self,
+        safe_attitudes: list[dict[float, tuple[float, float, float]]],
+        track_utime: list[float],
+    ) -> list[list[tuple[float, float, float]]]:
+        """Return the preferred dynamic profile plus reachable alternatives."""
+        preferred = self._dynamic_phase_tracking_attitude_profile(
+            safe_attitudes, track_utime
+        )
+        if preferred is None:
+            return []
+
+        phase_rank = {
+            phase: index
+            for index, phase in enumerate(self._gsp_tracking_phase_candidates())
+        }
+        suffixes: dict[float, tuple[float, float, list[float]]] = {
+            phase: (0.0, 0.0, [phase]) for phase in safe_attitudes[-1]
+        }
+        for sample_index in range(len(safe_attitudes) - 2, -1, -1):
+            dt = float(track_utime[sample_index + 1] - track_utime[sample_index])
+            next_suffixes: dict[float, tuple[float, float, list[float]]] = {}
+            for phase, attitude in safe_attitudes[sample_index].items():
+                best: tuple[float, float, list[float]] | None = None
+                for next_phase, (
+                    suffix_max_step,
+                    suffix_total_step,
+                    suffix_path,
+                ) in suffixes.items():
+                    next_attitude = safe_attitudes[sample_index + 1][next_phase]
+                    if not self._step_motion_feasible(attitude, next_attitude, dt):
+                        continue
+                    step_distance = quaternion_attitude_distance(
+                        *attitude,
+                        *next_attitude,
+                    )
+                    candidate = (
+                        max(step_distance, suffix_max_step),
+                        step_distance + suffix_total_step,
+                        [phase] + suffix_path,
+                    )
+                    candidate_key = (
+                        candidate[0],
+                        candidate[1],
+                        [phase_rank[path_phase] for path_phase in candidate[2]],
+                    )
+                    if best is None:
+                        best = candidate
+                        best_key = candidate_key
+                    elif candidate_key < best_key:
+                        best = candidate
+                        best_key = candidate_key
+                if best is not None:
+                    next_suffixes[phase] = best
+            suffixes = next_suffixes
+            if not suffixes:
+                return [preferred]
+
+        profiles = [preferred]
+        for initial_phase in self._gsp_tracking_phase_candidates():
+            suffix = suffixes.get(initial_phase)
+            if suffix is None:
+                continue
+            phase_path = suffix[2]
+            profile = [
+                safe_attitudes[sample_index][phase]
+                for sample_index, phase in enumerate(phase_path)
+            ]
+            if profile != preferred:
+                profiles.append(profile)
+        return profiles
+
+    def _constraint_safe_tracking_attitude_profiles(
+        self,
+        antenna_boresight: tuple[float, float, float],
+        target_vectors: np.ndarray,
+        track_utime: list[float],
+    ) -> tuple[list[list[tuple[float, float, float]]], bool] | None:
+        fallback_profile, fixed_phase_profiles = (
+            self._fixed_phase_tracking_attitude_profiles(
+                antenna_boresight,
+                target_vectors,
+                track_utime,
+            )
+        )
+        if fixed_phase_profiles:
+            return fixed_phase_profiles, True
+
+        safe_attitudes = self._safe_tracking_attitudes_by_sample(
+            antenna_boresight, target_vectors, track_utime
+        )
+        if safe_attitudes is not None:
+            dynamic_profiles = self._dynamic_phase_tracking_attitude_profiles(
+                safe_attitudes, track_utime
+            )
+            if dynamic_profiles:
+                return dynamic_profiles, True
+
+        if fallback_profile is None:
+            return None
+        return [fallback_profile], False
+
     def _constraint_safe_tracking_attitude_profile(
         self,
         antenna_boresight: tuple[float, float, float],
         target_vectors: np.ndarray,
         track_utime: list[float],
     ) -> tuple[list[tuple[float, float, float]], bool] | None:
-        fallback_profile, fixed_phase_safe = (
-            self._fixed_phase_tracking_attitude_profile(
-                antenna_boresight, target_vectors, track_utime
-            )
+        """Return the preferred profile for callers that do not select an ingress."""
+        result = self._constraint_safe_tracking_attitude_profiles(
+            antenna_boresight,
+            target_vectors,
+            track_utime,
         )
-        if fixed_phase_safe:
-            assert fallback_profile is not None
-            return fallback_profile, True
-
-        safe_attitudes = self._safe_tracking_attitudes_by_sample(
-            antenna_boresight, target_vectors, track_utime
-        )
-        if safe_attitudes is not None:
-            dynamic_profile = self._dynamic_phase_tracking_attitude_profile(
-                safe_attitudes, track_utime
-            )
-            if dynamic_profile is not None:
-                return dynamic_profile, True
-
-        if fallback_profile is None:
+        if result is None:
             return None
-        return fallback_profile, False
+        profiles, profile_safe = result
+        return profiles[0], profile_safe
 
     def _deconflict_overlapping_passes(self) -> None:
         selected: list[Pass] = []
@@ -833,12 +988,13 @@ class PassTimes:
         antenna_boresight = self._gsp_antenna_boresight_body()
         if antenna_boresight is None:
             return None
-        profile_result = self._constraint_safe_tracking_attitude_profile(
+        profile_result = self._constraint_safe_tracking_attitude_profiles(
             antenna_boresight, target_vectors, track_utime
         )
         if profile_result is None:
             return None
-        attitude_profile, profile_safe = profile_result
+        attitude_profiles, profile_safe = profile_result
+        attitude_profile = attitude_profiles[0]
         track_ra = [attitude[0] for attitude in attitude_profile]
         track_dec = [attitude[1] for attitude in attitude_profile]
         track_roll = [attitude[2] for attitude in attitude_profile]
@@ -856,6 +1012,7 @@ class PassTimes:
             gsenddec=track_dec[-1],
             gsendroll=track_roll[-1],
             length=passlen,
+            tracking_attitude_profiles=attitude_profiles,
         )
 
         # Record the path during the pass

--- a/conops/simulation/passes.py
+++ b/conops/simulation/passes.py
@@ -650,7 +650,15 @@ class PassTimes:
             track_ra = [attitude[0] for attitude in attitude_profile]
             track_dec = [attitude[1] for attitude in attitude_profile]
             track_roll = [attitude[2] for attitude in attitude_profile]
-            if not self._pass_profile_violates_scopes(
+            motion_feasible = all(
+                self._step_motion_feasible(
+                    attitude_profile[index - 1],
+                    attitude_profile[index],
+                    float(track_utime[index] - track_utime[index - 1]),
+                )
+                for index in range(1, len(attitude_profile))
+            )
+            if motion_feasible and not self._pass_profile_violates_scopes(
                 track_utime, track_ra, track_dec, track_roll
             ):
                 safe_profiles.append(attitude_profile)

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -755,6 +755,34 @@ class TestPassTimes:
         assert profile_safe is True
         assert [attitude[2] for attitude in profile] == [0.0, 90.0]
 
+    def test_dynamic_tracking_profiles_preserve_reachable_initial_phases(
+        self, mock_constraint, mock_config
+    ):
+        """Ingress selection can consider every phase with a feasible pass path."""
+        mock_config.spacecraft_bus.attitude_control = AttitudeControlSystem(
+            max_slew_rate=5.0,
+            slew_acceleration=5.0,
+            settle_time=0.0,
+        )
+        pt = PassTimes(config=mock_config)
+        pt._gsp_tracking_phase_candidates = Mock(return_value=[0.0, 90.0])
+        safe_attitudes = [
+            {
+                0.0: (0.0, 0.0, 0.0),
+                90.0: (90.0, 0.0, 90.0),
+            },
+            {
+                0.0: (1.0, 0.0, 0.0),
+                90.0: (91.0, 0.0, 90.0),
+            },
+        ]
+
+        profiles = pt._dynamic_phase_tracking_attitude_profiles(
+            safe_attitudes, [1000.0, 1060.0]
+        )
+
+        assert {profile[0][2] for profile in profiles} == {0.0, 90.0}
+
     def test_constraint_safe_tracking_profile_rejects_infeasible_dynamic_phase_path(
         self, mock_constraint, mock_config
     ):

--- a/tests/passes/test_passes.py
+++ b/tests/passes/test_passes.py
@@ -755,6 +755,34 @@ class TestPassTimes:
         assert profile_safe is True
         assert [attitude[2] for attitude in profile] == [0.0, 90.0]
 
+    def test_fixed_phase_tracking_profile_rejects_infeasible_motion(
+        self, mock_constraint, mock_config
+    ):
+        """Constraint-safe fixed phases must also fit within ACS motion limits."""
+        mock_config.spacecraft_bus.attitude_control = AttitudeControlSystem(
+            max_slew_rate=0.1,
+            slew_acceleration=0.1,
+            settle_time=0.0,
+        )
+        pt = PassTimes(config=mock_config)
+        pt._gsp_tracking_phase_candidates = Mock(return_value=[0.0, 90.0])
+        pt._tracking_attitude_profile_for_phase = Mock(
+            side_effect=lambda antenna, targets, phase_deg: [
+                (phase_deg, 0.0, phase_deg),
+                (phase_deg + 180.0, 0.0, phase_deg + 180.0),
+            ]
+        )
+        mock_constraint.in_constraint = Mock(return_value=False)
+
+        fallback, safe_profiles = pt._fixed_phase_tracking_attitude_profiles(
+            antenna_boresight=(0.0, 1.0, 0.0),
+            target_vectors=np.array([[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]], dtype=float),
+            track_utime=[1000.0, 1060.0],
+        )
+
+        assert fallback is not None
+        assert safe_profiles == []
+
     def test_dynamic_tracking_profiles_preserve_reachable_initial_phases(
         self, mock_constraint, mock_config
     ):

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -4217,6 +4217,31 @@ class TestCheckAndManagePasses:
         assert pass_obj.dec == [safe_profile[0][1]]
         assert pass_obj.roll == [safe_profile[0][2]]
 
+    def test_check_and_manage_passes_does_not_replan_reserved_ingress(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """A recorded GSP reservation keeps its selected tracking profile."""
+        pass_obj = Pass(
+            station="GS_TEST",
+            begin=1200.0,
+            length=600.0,
+            gsstartra=100.0,
+            gsstartdec=50.0,
+            gsstartroll=37.0,
+        )
+        queue_ditl.acs.passrequests.current_pass = Mock(return_value=None)
+        queue_ditl.acs.passrequests.next_pass = Mock(return_value=pass_obj)
+        queue_ditl.acs.acsmode = ACSMode.IDLE
+        queue_ditl._planned_gsp_keys.add(queue_ditl._ground_pass_key(pass_obj))
+
+        with patch.object(Pass, "time_to_slew") as time_to_slew:
+            assert not queue_ditl._check_and_manage_passes(
+                1100.0, ra=10.0, dec=20.0, roll=42.0
+            )
+
+        time_to_slew.assert_not_called()
+        queue_ditl.acs.enqueue_command.assert_not_called()
+
     def test_check_and_manage_passes_does_not_jump_to_tracking_at_aos(
         self, queue_ditl: QueueDITL
     ) -> None:

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -4174,6 +4174,74 @@ class TestCheckAndManagePasses:
         assert "Skipping pass slew to GS_TEST" in log_text
         assert "Ground Contact" in log_text
 
+    def test_check_and_manage_passes_selects_reachable_safe_tracking_profile(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """GSP ingress selects an alternate pass-safe profile when needed."""
+        utime = 1000.0
+        unsafe_profile = [(100.0, 50.0, 37.0)]
+        safe_profile = [(120.0, 30.0, 10.0)]
+        pass_obj = Pass(
+            config=queue_ditl.config,
+            ephem=queue_ditl.ephem,
+            station="GS_TEST",
+            begin=1200.0,
+            length=600.0,
+            utime=[1200.0],
+            ra=[100.0],
+            dec=[50.0],
+            roll=[37.0],
+            tracking_attitude_profiles=[unsafe_profile, safe_profile],
+        )
+        queue_ditl.acs.passrequests.current_pass = Mock(return_value=None)
+        queue_ditl.acs.passrequests.next_pass = Mock(return_value=pass_obj)
+        queue_ditl.acs.acsmode = ACSMode.SCIENCE
+
+        with (
+            patch.object(Pass, "time_to_slew", return_value=True),
+            patch.object(
+                queue_ditl,
+                "_slew_attitude_constraint_violation",
+                side_effect=[(1060.0, "Panel", "hardware_safety"), None],
+            ),
+        ):
+            assert queue_ditl._check_and_manage_passes(
+                utime, ra=10.0, dec=20.0, roll=42.0
+            )
+
+        command = queue_ditl.acs.enqueue_command.call_args[0][0]
+        assert command.slew.endra == safe_profile[0][0]
+        assert command.slew.enddec == safe_profile[0][1]
+        assert command.slew.endroll == safe_profile[0][2]
+        assert pass_obj.ra == [safe_profile[0][0]]
+        assert pass_obj.dec == [safe_profile[0][1]]
+        assert pass_obj.roll == [safe_profile[0][2]]
+
+    def test_check_and_manage_passes_does_not_jump_to_tracking_at_aos(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        """A pass cannot start unless its validated ingress attitude was reached."""
+        utime = 1200.0
+        pass_obj = Pass(
+            station="GS_TEST",
+            begin=utime,
+            length=600.0,
+            utime=[utime],
+            ra=[100.0],
+            dec=[50.0],
+            roll=[37.0],
+        )
+        queue_ditl.acs.passrequests.current_pass = Mock(return_value=pass_obj)
+        queue_ditl.acs.acsmode = ACSMode.SCIENCE
+
+        assert not queue_ditl._check_and_manage_passes(
+            utime, ra=10.0, dec=20.0, roll=42.0
+        )
+
+        queue_ditl.acs.enqueue_command.assert_not_called()
+        log_text = "\n".join(event.description for event in queue_ditl.log.events)
+        assert "did not reach the selected safe tracking attitude" in log_text
+
     def test_check_and_manage_passes_exports_gsp_plan_entry_for_pass_slew(
         self, queue_ditl, tmp_path
     ) -> None:


### PR DESCRIPTION
## Problem

Ground-pass planning validates tracking attitudes over the contact window, but ingress safety depends on the spacecraft attitude immediately before the pass. The scheduler previously retried the preferred profile even when another complete, constraint-safe profile was reachable. At AOS, the fallback could also start PASS without confirming that ACS reached the validated tracking attitude.

Multi-seed validation exposed two related continuity failures:

- fixed-phase profiles were constraint-checked but not checked against ACS motion limits between tracking samples; the reproduced profile stepped 127.75 deg in 60 s (2.13 deg/s against a 2 deg/s limit)
- after reserving an accepted ingress/profile, later scheduler ticks could select another profile and mutate the pass before AOS

## Change

- retain the preferred pass-safe profile and reachable alternatives
- reject fixed-phase profiles that violate the configured ACS motion model between samples
- compute dynamic alternatives with one backward pass over the phase graph
- select ingress against the actual incoming attitude and PASS constraint scopes
- make an accepted pass reservation idempotent
- refuse to start PASS unless ACS reached the selected tracking attitude
- preserve compatibility for externally constructed `Pass` objects with only legacy start-attitude fields

## Validation

- pass and queue scheduler suites: 334 passed
- seed 0: 2 GSPs, 1,380 s PASS-mode time, 66,420 s science, zero mission-gate failures, 7.69 s generation
- combined Coast suite: 2,243 passed, 1 skipped
- default Coast plan output matches baseline
- 100-seed combined continuity scan: zero failed seeds, plan/execution mismatches, hard-constraint events, or adjacent-attitude rate violations; every seed executes 960 s of actual contact

This branch is based directly on `main`; the PR contains only the ground-pass scheduler change and its tests.
