### PR TITLE
fix: reject attitude telemetry that exceeds slew-rate limit

### DIFF
--- a/conops/__init__.py
+++ b/conops/__init__.py
@@ -42,7 +42,6 @@ from .config import (
 from .ditl import (
     DITL,
     AttitudeRateContinuityError,
-    AttitudeRateViolation,
     DITLEvent,
     DITLLog,
     DITLLogStore,
@@ -100,7 +99,6 @@ __all__ = [
     "AttitudeControlSystem",
     "AttitudeConstraintScope",
     "AttitudeRateContinuityError",
-    "AttitudeRateViolation",
     "Battery",
     "ChargeState",
     "MissionConfig",

--- a/conops/__init__.py
+++ b/conops/__init__.py
@@ -41,6 +41,8 @@ from .config import (
 )
 from .ditl import (
     DITL,
+    AttitudeRateContinuityError,
+    AttitudeRateViolation,
     DITLEvent,
     DITLLog,
     DITLLogStore,
@@ -97,6 +99,8 @@ __all__ = [
     "OrbitStateTimeseriesSchema",
     "AttitudeControlSystem",
     "AttitudeConstraintScope",
+    "AttitudeRateContinuityError",
+    "AttitudeRateViolation",
     "Battery",
     "ChargeState",
     "MissionConfig",

--- a/conops/ditl/__init__.py
+++ b/conops/ditl/__init__.py
@@ -2,7 +2,11 @@ from .ditl import DITL, DITLs
 from .ditl_event import DITLEvent
 from .ditl_log import DITLLog
 from .ditl_log_store import DITLLogStore
-from .ditl_mixin import DITLMixin
+from .ditl_mixin import (
+    AttitudeRateContinuityError,
+    AttitudeRateViolation,
+    DITLMixin,
+)
 from .ditl_stats import DITLStats
 from .queue_ditl import PlanExecutionMismatchError, QueueDITL, TOORequest
 from .telemetry import Housekeeping, PayloadData, Telemetry
@@ -10,6 +14,8 @@ from .telemetry import Housekeeping, PayloadData, Telemetry
 __all__ = [
     "DITL",
     "DITLs",
+    "AttitudeRateContinuityError",
+    "AttitudeRateViolation",
     "DITLEvent",
     "DITLLog",
     "DITLLogStore",

--- a/conops/ditl/__init__.py
+++ b/conops/ditl/__init__.py
@@ -2,11 +2,7 @@ from .ditl import DITL, DITLs
 from .ditl_event import DITLEvent
 from .ditl_log import DITLLog
 from .ditl_log_store import DITLLogStore
-from .ditl_mixin import (
-    AttitudeRateContinuityError,
-    AttitudeRateViolation,
-    DITLMixin,
-)
+from .ditl_mixin import AttitudeRateContinuityError, DITLMixin
 from .ditl_stats import DITLStats
 from .queue_ditl import PlanExecutionMismatchError, QueueDITL, TOORequest
 from .telemetry import Housekeeping, PayloadData, Telemetry
@@ -15,7 +11,6 @@ __all__ = [
     "DITL",
     "DITLs",
     "AttitudeRateContinuityError",
-    "AttitudeRateViolation",
     "DITLEvent",
     "DITLLog",
     "DITLLogStore",

--- a/conops/ditl/ditl.py
+++ b/conops/ditl/ditl.py
@@ -134,7 +134,10 @@ class DITL(DITLMixin, DITLStats):
                 (missing ephemeris, missing plan, or invalid ephemeris date range).
 
         Raises:
-            No exceptions raised; errors are logged to stdout and return False.
+            ValueError: If the ephemeris or plan is missing, or the ephemeris does
+                not cover the simulation date range.
+            AttitudeRateContinuityError: If adjacent executed attitude samples
+                exceed the configured maximum slew rate.
 
         Note:
             The simulation respects the class attributes:
@@ -168,7 +171,6 @@ class DITL(DITLMixin, DITLStats):
         simlen = len(self.utime)
         self.ra = np.zeros(simlen).tolist()
         self.dec = np.zeros(simlen).tolist()
-        self.roll = np.zeros(simlen).tolist()
         self.mode = np.zeros(simlen).astype(int).tolist()
         self.panel = np.zeros(simlen).tolist()
         self.obsid = np.zeros(simlen).astype(int).tolist()
@@ -223,7 +225,6 @@ class DITL(DITLMixin, DITLStats):
             self.batteryalert[i] = self.battery.battery_alert
             self.ra[i] = ra
             self.dec[i] = dec
-            self.roll[i] = roll
             self.mode[i] = mode
             self.panel[i] = panel_illumination
             self.power[i] = power_usage

--- a/conops/ditl/ditl.py
+++ b/conops/ditl/ditl.py
@@ -168,6 +168,7 @@ class DITL(DITLMixin, DITLStats):
         simlen = len(self.utime)
         self.ra = np.zeros(simlen).tolist()
         self.dec = np.zeros(simlen).tolist()
+        self.roll = np.zeros(simlen).tolist()
         self.mode = np.zeros(simlen).astype(int).tolist()
         self.panel = np.zeros(simlen).tolist()
         self.obsid = np.zeros(simlen).astype(int).tolist()
@@ -222,6 +223,7 @@ class DITL(DITLMixin, DITLStats):
             self.batteryalert[i] = self.battery.battery_alert
             self.ra[i] = ra
             self.dec[i] = dec
+            self.roll[i] = roll
             self.mode[i] = mode
             self.panel[i] = panel_illumination
             self.power[i] = power_usage
@@ -374,6 +376,7 @@ class DITL(DITLMixin, DITLStats):
                 )
                 self.telemetry.data.append(pd)
 
+        self._assert_attitude_rate_continuity()
         self._attach_execution_timeseries_to_plan()
         return True
 

--- a/conops/ditl/ditl_mixin.py
+++ b/conops/ditl/ditl_mixin.py
@@ -1,10 +1,10 @@
 import math
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, cast
 
 import matplotlib.pyplot as plt
 import rust_ephem
+from pydantic import BaseModel, ConfigDict
 
 from conops.common.enums import ACSMode
 from conops.common.vector import quaternion_attitude_distance
@@ -19,9 +19,10 @@ from .telemetry import Telemetry
 ATTITUDE_RATE_NUMERICAL_TOLERANCE_DEG = 1e-9
 
 
-@dataclass(frozen=True)
-class _AttitudeRateViolation:
+class _AttitudeRateViolation(BaseModel):
     """An adjacent attitude sample pair that exceeds the configured slew rate."""
+
+    model_config = ConfigDict(frozen=True)
 
     previous_index: int
     index: int

--- a/conops/ditl/ditl_mixin.py
+++ b/conops/ditl/ditl_mixin.py
@@ -1,7 +1,7 @@
 import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, cast
 
 import matplotlib.pyplot as plt
 import rust_ephem
@@ -20,7 +20,7 @@ ATTITUDE_RATE_NUMERICAL_TOLERANCE_DEG = 1e-9
 
 
 @dataclass(frozen=True)
-class AttitudeRateViolation:
+class _AttitudeRateViolation:
     """An adjacent attitude sample pair that exceeds the configured slew rate."""
 
     previous_index: int
@@ -33,6 +33,7 @@ class AttitudeRateViolation:
     max_rate_deg_per_s: float
     previous_mode: str | None
     mode: str | None
+    obsid: int | None
     reason: str = "rate_limit_exceeded"
 
     @property
@@ -209,21 +210,8 @@ class DITLMixin:
             return dt.replace(tzinfo=timezone.utc)
         return dt.astimezone(timezone.utc)
 
-    def attitude_rate_violations(self) -> list[AttitudeRateViolation]:
-        """Return all adjacent attitude samples that violate the maximum slew rate."""
-        lengths = {
-            "utime": len(self.utime),
-            "ra": len(self.ra),
-            "dec": len(self.dec),
-            "roll": len(self.roll),
-            "mode": len(self.mode),
-        }
-        if len(set(lengths.values())) != 1:
-            raise ValueError(
-                "Cannot validate attitude rate with mismatched telemetry lengths: "
-                f"{lengths}"
-            )
-
+    def _attitude_rate_violations(self) -> list[_AttitudeRateViolation]:
+        """Validate the housekeeping samples used for attitude-timeseries export."""
         max_rate = float(self.config.spacecraft_bus.attitude_control.max_slew_rate)
         if not math.isfinite(max_rate) or max_rate < 0:
             raise ValueError(
@@ -231,18 +219,23 @@ class DITLMixin:
             )
 
         violations = []
-        for index in range(1, len(self.utime)):
+        samples = self.telemetry.housekeeping
+        for index in range(1, len(samples)):
             previous_index = index - 1
-            previous_utime = float(self.utime[previous_index])
-            utime = float(self.utime[index])
+            previous_sample = samples[previous_index]
+            sample = samples[index]
+            previous_utime = self._timestamp_to_utc(
+                previous_sample.timestamp
+            ).timestamp()
+            utime = self._timestamp_to_utc(sample.timestamp).timestamp()
             elapsed_seconds = utime - previous_utime
-            attitudes = (
-                float(self.ra[previous_index]),
-                float(self.dec[previous_index]),
-                float(self.roll[previous_index]),
-                float(self.ra[index]),
-                float(self.dec[index]),
-                float(self.roll[index]),
+            attitude_values = (
+                previous_sample.ra,
+                previous_sample.dec,
+                previous_sample.roll,
+                sample.ra,
+                sample.dec,
+                sample.roll,
             )
 
             timestamps_are_finite = math.isfinite(previous_utime) and math.isfinite(
@@ -252,10 +245,19 @@ class DITLMixin:
             if not timestamps_are_finite:
                 distance_deg = math.inf
                 reason = "non_finite_timestamp"
-            elif not all(math.isfinite(value) for value in attitudes):
+            elif any(value is None for value in attitude_values):
                 distance_deg = math.inf
-                reason = "non_finite_attitude"
+                reason = "missing_attitude"
             else:
+                attitudes = cast(
+                    tuple[float, float, float, float, float, float],
+                    attitude_values,
+                )
+                if not all(math.isfinite(value) for value in attitudes):
+                    distance_deg = math.inf
+                    reason = "non_finite_attitude"
+
+            if reason == "rate_limit_exceeded":
                 distance_deg = quaternion_attitude_distance(*attitudes)
 
             allowed_distance_deg = (
@@ -274,7 +276,7 @@ class DITLMixin:
                 > allowed_distance_deg + ATTITUDE_RATE_NUMERICAL_TOLERANCE_DEG
             ):
                 violations.append(
-                    AttitudeRateViolation(
+                    _AttitudeRateViolation(
                         previous_index=previous_index,
                         index=index,
                         previous_utime=previous_utime,
@@ -284,9 +286,10 @@ class DITLMixin:
                         allowed_distance_deg=allowed_distance_deg,
                         max_rate_deg_per_s=max_rate,
                         previous_mode=self._attitude_mode_name(
-                            self.mode[previous_index]
+                            previous_sample.acs_mode
                         ),
-                        mode=self._attitude_mode_name(self.mode[index]),
+                        mode=self._attitude_mode_name(sample.acs_mode),
+                        obsid=sample.obsid,
                         reason=reason,
                     )
                 )
@@ -294,7 +297,7 @@ class DITLMixin:
 
     def _assert_attitude_rate_continuity(self) -> None:
         """Fail plan generation when adjacent attitudes exceed the slew-rate limit."""
-        violations = self.attitude_rate_violations()
+        violations = self._attitude_rate_violations()
         if not violations:
             return
         examples = "; ".join(str(violation) for violation in violations[:5])

--- a/conops/ditl/ditl_mixin.py
+++ b/conops/ditl/ditl_mixin.py
@@ -1,3 +1,5 @@
+import math
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -5,6 +7,7 @@ import matplotlib.pyplot as plt
 import rust_ephem
 
 from conops.common.enums import ACSMode
+from conops.common.vector import quaternion_attitude_distance
 from conops.config.groundstation import GroundStation
 
 from ..config import MissionConfig
@@ -12,6 +15,49 @@ from ..simulation.acs import ACS
 from ..simulation.passes import Pass, PassTimes
 from ..targets import Plan, PlanEntry
 from .telemetry import Telemetry
+
+ATTITUDE_RATE_NUMERICAL_TOLERANCE_DEG = 1e-9
+
+
+@dataclass(frozen=True)
+class AttitudeRateViolation:
+    """An adjacent attitude sample pair that exceeds the configured slew rate."""
+
+    previous_index: int
+    index: int
+    previous_utime: float
+    utime: float
+    elapsed_seconds: float
+    distance_deg: float
+    allowed_distance_deg: float
+    max_rate_deg_per_s: float
+    previous_mode: str | None
+    mode: str | None
+    reason: str = "rate_limit_exceeded"
+
+    @property
+    def actual_rate_deg_per_s(self) -> float:
+        """Return the average angular rate over the sample interval."""
+        if not math.isfinite(self.elapsed_seconds) or self.elapsed_seconds <= 0:
+            return math.inf
+        return self.distance_deg / self.elapsed_seconds
+
+    def __str__(self) -> str:
+        """Return a concise diagnostic suitable for plan-generation errors."""
+        return (
+            f"attitude_rate_violation: samples {self.previous_index}->{self.index} "
+            f"at {self.previous_utime:.3f}->{self.utime:.3f}, "
+            f"modes {self.previous_mode}->{self.mode}, reason {self.reason}, "
+            f"rotation {self.distance_deg:.6f} deg over "
+            f"{self.elapsed_seconds:.3f} s "
+            f"({self.actual_rate_deg_per_s:.6f} deg/s), allowed "
+            f"{self.allowed_distance_deg:.6f} deg "
+            f"({self.max_rate_deg_per_s:.6f} deg/s)"
+        )
+
+
+class AttitudeRateContinuityError(RuntimeError):
+    """Raised when adjacent executed attitudes violate the configured slew rate."""
 
 
 class DITLMixin:
@@ -162,6 +208,100 @@ class DITLMixin:
         if dt.tzinfo is None:
             return dt.replace(tzinfo=timezone.utc)
         return dt.astimezone(timezone.utc)
+
+    def attitude_rate_violations(self) -> list[AttitudeRateViolation]:
+        """Return all adjacent attitude samples that violate the maximum slew rate."""
+        lengths = {
+            "utime": len(self.utime),
+            "ra": len(self.ra),
+            "dec": len(self.dec),
+            "roll": len(self.roll),
+            "mode": len(self.mode),
+        }
+        if len(set(lengths.values())) != 1:
+            raise ValueError(
+                "Cannot validate attitude rate with mismatched telemetry lengths: "
+                f"{lengths}"
+            )
+
+        max_rate = float(self.config.spacecraft_bus.attitude_control.max_slew_rate)
+        if not math.isfinite(max_rate) or max_rate < 0:
+            raise ValueError(
+                f"max_slew_rate must be a finite, non-negative value, got {max_rate}"
+            )
+
+        violations = []
+        for index in range(1, len(self.utime)):
+            previous_index = index - 1
+            previous_utime = float(self.utime[previous_index])
+            utime = float(self.utime[index])
+            elapsed_seconds = utime - previous_utime
+            attitudes = (
+                float(self.ra[previous_index]),
+                float(self.dec[previous_index]),
+                float(self.roll[previous_index]),
+                float(self.ra[index]),
+                float(self.dec[index]),
+                float(self.roll[index]),
+            )
+
+            timestamps_are_finite = math.isfinite(previous_utime) and math.isfinite(
+                utime
+            )
+            reason = "rate_limit_exceeded"
+            if not timestamps_are_finite:
+                distance_deg = math.inf
+                reason = "non_finite_timestamp"
+            elif not all(math.isfinite(value) for value in attitudes):
+                distance_deg = math.inf
+                reason = "non_finite_attitude"
+            else:
+                distance_deg = quaternion_attitude_distance(*attitudes)
+
+            allowed_distance_deg = (
+                max_rate * elapsed_seconds
+                if math.isfinite(elapsed_seconds) and elapsed_seconds > 0
+                else 0.0
+            )
+            if timestamps_are_finite and elapsed_seconds <= 0:
+                reason = "non_increasing_timestamp"
+
+            if (
+                not timestamps_are_finite
+                or elapsed_seconds <= 0
+                or not math.isfinite(distance_deg)
+                or distance_deg
+                > allowed_distance_deg + ATTITUDE_RATE_NUMERICAL_TOLERANCE_DEG
+            ):
+                violations.append(
+                    AttitudeRateViolation(
+                        previous_index=previous_index,
+                        index=index,
+                        previous_utime=previous_utime,
+                        utime=utime,
+                        elapsed_seconds=elapsed_seconds,
+                        distance_deg=distance_deg,
+                        allowed_distance_deg=allowed_distance_deg,
+                        max_rate_deg_per_s=max_rate,
+                        previous_mode=self._attitude_mode_name(
+                            self.mode[previous_index]
+                        ),
+                        mode=self._attitude_mode_name(self.mode[index]),
+                        reason=reason,
+                    )
+                )
+        return violations
+
+    def _assert_attitude_rate_continuity(self) -> None:
+        """Fail plan generation when adjacent attitudes exceed the slew-rate limit."""
+        violations = self.attitude_rate_violations()
+        if not violations:
+            return
+        examples = "; ".join(str(violation) for violation in violations[:5])
+        raise AttitudeRateContinuityError(
+            f"Attitude rate validation failed with {len(violations)} "
+            f"violation(s): {examples}"
+        )
 
     def _attach_execution_timeseries_to_plan(self) -> None:
         """Attach executed attitude and orbit-state timelines to the current plan."""

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1079,9 +1079,9 @@ class QueueDITL(DITLMixin, DITLStats):
             PlanExecutionMismatch(
                 utime=violation.utime,
                 message=str(violation),
-                obsid=int(self.obsid[violation.index]),
+                obsid=violation.obsid,
             )
-            for violation in self.attitude_rate_violations()
+            for violation in self._attitude_rate_violations()
         ]
         tolerance_deg = self._plan_execution_tolerance_deg()
         structure_mismatches = self._validate_plan_entry_structure()

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -541,6 +541,7 @@ class QueueDITL(DITLMixin, DITLStats):
         if self.plan and self.ppt is not None:
             self._close_last_plan_entry(self.uend)
 
+        self._assert_attitude_rate_continuity()
         self._assert_plan_matches_execution()
         self._attach_execution_timeseries_to_plan()
 

--- a/conops/ditl/queue_ditl.py
+++ b/conops/ditl/queue_ditl.py
@@ -1075,10 +1075,18 @@ class QueueDITL(DITLMixin, DITLStats):
         if mismatch is not None:
             return [mismatch]
 
+        mismatches = [
+            PlanExecutionMismatch(
+                utime=violation.utime,
+                message=str(violation),
+                obsid=int(self.obsid[violation.index]),
+            )
+            for violation in self.attitude_rate_violations()
+        ]
         tolerance_deg = self._plan_execution_tolerance_deg()
-        mismatches = self._validate_plan_entry_structure()
-        if mismatches:
-            return mismatches
+        structure_mismatches = self._validate_plan_entry_structure()
+        if structure_mismatches:
+            return mismatches + structure_mismatches
 
         for entry in self.plan:
             obstype = self._entry_obstype(entry)

--- a/tests/ditl/conftest.py
+++ b/tests/ditl/conftest.py
@@ -268,6 +268,7 @@ def mock_config_detailed():
     config.spacecraft_bus.attitude_control.__class__ = AttitudeControlSystem
     config.spacecraft_bus.attitude_control.predict_slew = Mock(return_value=(45.0, []))
     config.spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
+    config.spacecraft_bus.attitude_control.max_slew_rate = 10.0
     config.spacecraft_bus.star_trackers = Mock()
     config.spacecraft_bus.star_trackers.num_trackers = Mock(return_value=0)
     config.spacecraft_bus.radiators = Mock()

--- a/tests/ditl/test_ditl.py
+++ b/tests/ditl/test_ditl.py
@@ -77,7 +77,6 @@ class TestDITLCalc:
         ditl.calc()
         assert len(ditl.ra) > 0
         assert len(ditl.dec) > 0
-        assert len(ditl.roll) > 0
         assert len(ditl.mode) > 0
         assert len(ditl.panel) > 0
         assert len(ditl.obsid) > 0
@@ -91,7 +90,6 @@ class TestDITLCalc:
         simlen = len(ditl.utime)
         assert len(ditl.ra) == simlen
         assert len(ditl.dec) == simlen
-        assert len(ditl.roll) == simlen
         assert len(ditl.mode) == simlen
         assert len(ditl.panel) == simlen
         assert len(ditl.obsid) == simlen
@@ -160,7 +158,6 @@ class TestDITLSimulationLoop:
         # Check first recorded values
         assert ditl.ra[0] == 45.0
         assert ditl.dec[0] == 30.0
-        assert ditl.roll[0] == 90.0
         assert ditl.obsid[0] == 42
 
     def test_calc_rejects_attitude_rate_violation(self, ditl: DITL) -> None:

--- a/tests/ditl/test_ditl.py
+++ b/tests/ditl/test_ditl.py
@@ -5,7 +5,13 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pytest
 
-from conops import DITL, ACSMode, AttitudeConstraintScope, DITLs
+from conops import (
+    DITL,
+    ACSMode,
+    AttitudeConstraintScope,
+    AttitudeRateContinuityError,
+    DITLs,
+)
 
 
 class TestDITLInit:
@@ -71,6 +77,7 @@ class TestDITLCalc:
         ditl.calc()
         assert len(ditl.ra) > 0
         assert len(ditl.dec) > 0
+        assert len(ditl.roll) > 0
         assert len(ditl.mode) > 0
         assert len(ditl.panel) > 0
         assert len(ditl.obsid) > 0
@@ -84,6 +91,7 @@ class TestDITLCalc:
         simlen = len(ditl.utime)
         assert len(ditl.ra) == simlen
         assert len(ditl.dec) == simlen
+        assert len(ditl.roll) == simlen
         assert len(ditl.mode) == simlen
         assert len(ditl.panel) == simlen
         assert len(ditl.obsid) == simlen
@@ -152,7 +160,26 @@ class TestDITLSimulationLoop:
         # Check first recorded values
         assert ditl.ra[0] == 45.0
         assert ditl.dec[0] == 30.0
+        assert ditl.roll[0] == 90.0
         assert ditl.obsid[0] == 42
+
+    def test_calc_rejects_attitude_rate_violation(self, ditl: DITL) -> None:
+        """DITL must reject an impossible adjacent roll change."""
+        ditl.config.spacecraft_bus.attitude_control.max_slew_rate = 1.0
+        attitudes = iter(
+            [
+                (0.0, 0.0, 0.0, 0),
+                (0.0, 0.0, 61.0, 0),
+                (0.0, 0.0, 61.0, 0),
+                (0.0, 0.0, 61.0, 0),
+            ]
+        )
+        ditl.acs.pointing.side_effect = attitudes
+
+        with pytest.raises(
+            AttitudeRateContinuityError, match="attitude_rate_violation"
+        ):
+            ditl.calc()
 
     def test_simulation_loop_drains_battery(self, ditl: DITL) -> None:
         """Test that battery is drained each timestep."""

--- a/tests/scheduler_queue/conftest.py
+++ b/tests/scheduler_queue/conftest.py
@@ -136,6 +136,7 @@ def mock_config() -> Mock:
         return_value=100.0
     )  # Return slew time in seconds
     config.spacecraft_bus.attitude_control.slew_accuracy = 0.01
+    config.spacecraft_bus.attitude_control.max_slew_rate = 10.0
     config.spacecraft_bus.attitude_control.motion_time = Mock(
         side_effect=lambda distance: float(
             config.spacecraft_bus.attitude_control.slew_time(distance)

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -2109,6 +2109,107 @@ class TestPlanExecutionValidation:
         entry.ss_min = 60.0
         return entry
 
+    def test_validation_accepts_attitude_motion_at_rate_limit(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.config.spacecraft_bus.attitude_control.max_slew_rate = 1.0
+        queue_ditl.utime = [1000.0, 1060.0]
+        queue_ditl.mode = [ACSMode.IDLE, ACSMode.SLEWING]
+        queue_ditl.obsid = [0, 0]
+        queue_ditl.ra = [0.0, 60.0]
+        queue_ditl.dec = [0.0, 0.0]
+        queue_ditl.roll = [0.0, 0.0]
+
+        assert queue_ditl.attitude_rate_violations() == []
+
+    def test_validation_rejects_attitude_jump_across_mode_boundary(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.config.spacecraft_bus.attitude_control.max_slew_rate = 1.0
+        queue_ditl.utime = [1000.0, 1060.0]
+        queue_ditl.mode = [ACSMode.IDLE, ACSMode.PASS]
+        queue_ditl.obsid = [0, 42]
+        queue_ditl.ra = [0.0, 61.0]
+        queue_ditl.dec = [0.0, 0.0]
+        queue_ditl.roll = [0.0, 0.0]
+
+        mismatches = queue_ditl.validate_plan_matches_execution()
+
+        assert any("attitude_rate_violation" in str(item) for item in mismatches)
+        assert any("modes IDLE->PASS" in str(item) for item in mismatches)
+
+    def test_validation_rejects_roll_only_attitude_jump(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.config.spacecraft_bus.attitude_control.max_slew_rate = 1.0
+        queue_ditl.utime = [1000.0, 1060.0]
+        queue_ditl.mode = [ACSMode.SLEWING, ACSMode.SLEWING]
+        queue_ditl.obsid = [0, 0]
+        queue_ditl.ra = [0.0, 0.0]
+        queue_ditl.dec = [0.0, 0.0]
+        queue_ditl.roll = [0.0, 61.0]
+
+        violations = queue_ditl.attitude_rate_violations()
+
+        assert len(violations) == 1
+        assert violations[0].distance_deg == pytest.approx(61.0)
+
+    def test_validation_rejects_non_increasing_attitude_timestamps(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.utime = [1000.0, 1000.0]
+        queue_ditl.mode = [ACSMode.IDLE, ACSMode.IDLE]
+        queue_ditl.obsid = [0, 0]
+        queue_ditl.ra = [0.0, 0.0]
+        queue_ditl.dec = [0.0, 0.0]
+        queue_ditl.roll = [0.0, 0.0]
+
+        violations = queue_ditl.attitude_rate_violations()
+
+        assert len(violations) == 1
+        assert violations[0].reason == "non_increasing_timestamp"
+
+    @pytest.mark.parametrize(
+        ("field", "values", "reason"),
+        [
+            ("utime", [1000.0, float("nan")], "non_finite_timestamp"),
+            ("roll", [0.0, float("nan")], "non_finite_attitude"),
+        ],
+    )
+    def test_validation_rejects_non_finite_attitude_telemetry(
+        self,
+        queue_ditl: QueueDITL,
+        field: str,
+        values: list[float],
+        reason: str,
+    ) -> None:
+        queue_ditl.utime = [1000.0, 1060.0]
+        queue_ditl.mode = [ACSMode.IDLE, ACSMode.IDLE]
+        queue_ditl.obsid = [0, 0]
+        queue_ditl.ra = [0.0, 0.0]
+        queue_ditl.dec = [0.0, 0.0]
+        queue_ditl.roll = [0.0, 0.0]
+        setattr(queue_ditl, field, values)
+
+        violations = queue_ditl.attitude_rate_violations()
+
+        assert len(violations) == 1
+        assert violations[0].reason == reason
+
+    def test_assertion_fails_plan_generation_for_attitude_jump(
+        self, queue_ditl: QueueDITL
+    ) -> None:
+        queue_ditl.config.spacecraft_bus.attitude_control.max_slew_rate = 1.0
+        queue_ditl.utime = [1000.0, 1060.0]
+        queue_ditl.mode = [ACSMode.IDLE, ACSMode.PASS]
+        queue_ditl.obsid = [0, 42]
+        queue_ditl.ra = [0.0, 61.0]
+        queue_ditl.dec = [0.0, 0.0]
+        queue_ditl.roll = [0.0, 0.0]
+
+        with pytest.raises(PlanExecutionMismatchError, match="attitude_rate_violation"):
+            queue_ditl._assert_plan_matches_execution()
+
     def test_validation_passes_for_matching_science_execution(
         self, queue_ditl: QueueDITL
     ) -> None:

--- a/tests/scheduler_queue/test_queue_ditl.py
+++ b/tests/scheduler_queue/test_queue_ditl.py
@@ -2109,27 +2109,72 @@ class TestPlanExecutionValidation:
         entry.ss_min = 60.0
         return entry
 
+    def _set_attitude_telemetry(
+        self,
+        queue_ditl: QueueDITL,
+        *,
+        utime: list[float],
+        mode: list[ACSMode],
+        obsid: list[int],
+        ra: list[float | None],
+        dec: list[float | None],
+        roll: list[float | None],
+    ) -> None:
+        """Populate both legacy execution arrays and exported housekeeping."""
+        queue_ditl.utime = utime
+        queue_ditl.mode = mode
+        queue_ditl.obsid = obsid
+        queue_ditl.ra = [0.0 if value is None else value for value in ra]
+        queue_ditl.dec = [0.0 if value is None else value for value in dec]
+        queue_ditl.roll = [0.0 if value is None else value for value in roll]
+        queue_ditl.telemetry.housekeeping.clear()
+        for values in zip(utime, mode, obsid, ra, dec, roll, strict=True):
+            timestamp, acs_mode, sample_obsid, sample_ra, sample_dec, sample_roll = (
+                values
+            )
+            queue_ditl.telemetry.housekeeping.append(
+                Housekeeping(
+                    timestamp=datetime.fromtimestamp(timestamp, tz=timezone.utc),
+                    acs_mode=acs_mode,
+                    obsid=sample_obsid,
+                    ra=sample_ra,
+                    dec=sample_dec,
+                    roll=sample_roll,
+                )
+            )
+
     def test_validation_accepts_attitude_motion_at_rate_limit(
         self, queue_ditl: QueueDITL
     ) -> None:
         queue_ditl.config.spacecraft_bus.attitude_control.max_slew_rate = 1.0
-        queue_ditl.utime = [1000.0, 1060.0]
-        queue_ditl.mode = [ACSMode.IDLE, ACSMode.SLEWING]
-        queue_ditl.obsid = [0, 0]
-        queue_ditl.ra = [0.0, 60.0]
-        queue_ditl.dec = [0.0, 0.0]
-        queue_ditl.roll = [0.0, 0.0]
+        self._set_attitude_telemetry(
+            queue_ditl,
+            utime=[1000.0, 1060.0],
+            mode=[ACSMode.IDLE, ACSMode.SLEWING],
+            obsid=[0, 0],
+            ra=[0.0, 60.0],
+            dec=[0.0, 0.0],
+            roll=[0.0, 0.0],
+        )
 
-        assert queue_ditl.attitude_rate_violations() == []
+        assert queue_ditl._attitude_rate_violations() == []
 
     def test_validation_rejects_attitude_jump_across_mode_boundary(
         self, queue_ditl: QueueDITL
     ) -> None:
         queue_ditl.config.spacecraft_bus.attitude_control.max_slew_rate = 1.0
-        queue_ditl.utime = [1000.0, 1060.0]
-        queue_ditl.mode = [ACSMode.IDLE, ACSMode.PASS]
-        queue_ditl.obsid = [0, 42]
-        queue_ditl.ra = [0.0, 61.0]
+        self._set_attitude_telemetry(
+            queue_ditl,
+            utime=[1000.0, 1060.0],
+            mode=[ACSMode.IDLE, ACSMode.PASS],
+            obsid=[0, 42],
+            ra=[0.0, 61.0],
+            dec=[0.0, 0.0],
+            roll=[0.0, 0.0],
+        )
+        # The safety check must use the housekeeping stream exported to the
+        # attitude sidecar, not these parallel legacy arrays.
+        queue_ditl.ra = [0.0, 0.0]
         queue_ditl.dec = [0.0, 0.0]
         queue_ditl.roll = [0.0, 0.0]
 
@@ -2142,14 +2187,17 @@ class TestPlanExecutionValidation:
         self, queue_ditl: QueueDITL
     ) -> None:
         queue_ditl.config.spacecraft_bus.attitude_control.max_slew_rate = 1.0
-        queue_ditl.utime = [1000.0, 1060.0]
-        queue_ditl.mode = [ACSMode.SLEWING, ACSMode.SLEWING]
-        queue_ditl.obsid = [0, 0]
-        queue_ditl.ra = [0.0, 0.0]
-        queue_ditl.dec = [0.0, 0.0]
-        queue_ditl.roll = [0.0, 61.0]
+        self._set_attitude_telemetry(
+            queue_ditl,
+            utime=[1000.0, 1060.0],
+            mode=[ACSMode.SLEWING, ACSMode.SLEWING],
+            obsid=[0, 0],
+            ra=[0.0, 0.0],
+            dec=[0.0, 0.0],
+            roll=[0.0, 61.0],
+        )
 
-        violations = queue_ditl.attitude_rate_violations()
+        violations = queue_ditl._attitude_rate_violations()
 
         assert len(violations) == 1
         assert violations[0].distance_deg == pytest.approx(61.0)
@@ -2157,41 +2205,45 @@ class TestPlanExecutionValidation:
     def test_validation_rejects_non_increasing_attitude_timestamps(
         self, queue_ditl: QueueDITL
     ) -> None:
-        queue_ditl.utime = [1000.0, 1000.0]
-        queue_ditl.mode = [ACSMode.IDLE, ACSMode.IDLE]
-        queue_ditl.obsid = [0, 0]
-        queue_ditl.ra = [0.0, 0.0]
-        queue_ditl.dec = [0.0, 0.0]
-        queue_ditl.roll = [0.0, 0.0]
+        self._set_attitude_telemetry(
+            queue_ditl,
+            utime=[1000.0, 1000.0],
+            mode=[ACSMode.IDLE, ACSMode.IDLE],
+            obsid=[0, 0],
+            ra=[0.0, 0.0],
+            dec=[0.0, 0.0],
+            roll=[0.0, 0.0],
+        )
 
-        violations = queue_ditl.attitude_rate_violations()
+        violations = queue_ditl._attitude_rate_violations()
 
         assert len(violations) == 1
         assert violations[0].reason == "non_increasing_timestamp"
 
     @pytest.mark.parametrize(
-        ("field", "values", "reason"),
+        ("roll", "reason"),
         [
-            ("utime", [1000.0, float("nan")], "non_finite_timestamp"),
-            ("roll", [0.0, float("nan")], "non_finite_attitude"),
+            ([0.0, float("nan")], "non_finite_attitude"),
+            ([0.0, None], "missing_attitude"),
         ],
     )
     def test_validation_rejects_non_finite_attitude_telemetry(
         self,
         queue_ditl: QueueDITL,
-        field: str,
-        values: list[float],
+        roll: list[float | None],
         reason: str,
     ) -> None:
-        queue_ditl.utime = [1000.0, 1060.0]
-        queue_ditl.mode = [ACSMode.IDLE, ACSMode.IDLE]
-        queue_ditl.obsid = [0, 0]
-        queue_ditl.ra = [0.0, 0.0]
-        queue_ditl.dec = [0.0, 0.0]
-        queue_ditl.roll = [0.0, 0.0]
-        setattr(queue_ditl, field, values)
+        self._set_attitude_telemetry(
+            queue_ditl,
+            utime=[1000.0, 1060.0],
+            mode=[ACSMode.IDLE, ACSMode.IDLE],
+            obsid=[0, 0],
+            ra=[0.0, 0.0],
+            dec=[0.0, 0.0],
+            roll=roll,
+        )
 
-        violations = queue_ditl.attitude_rate_violations()
+        violations = queue_ditl._attitude_rate_violations()
 
         assert len(violations) == 1
         assert violations[0].reason == reason
@@ -2200,12 +2252,15 @@ class TestPlanExecutionValidation:
         self, queue_ditl: QueueDITL
     ) -> None:
         queue_ditl.config.spacecraft_bus.attitude_control.max_slew_rate = 1.0
-        queue_ditl.utime = [1000.0, 1060.0]
-        queue_ditl.mode = [ACSMode.IDLE, ACSMode.PASS]
-        queue_ditl.obsid = [0, 42]
-        queue_ditl.ra = [0.0, 61.0]
-        queue_ditl.dec = [0.0, 0.0]
-        queue_ditl.roll = [0.0, 0.0]
+        self._set_attitude_telemetry(
+            queue_ditl,
+            utime=[1000.0, 1060.0],
+            mode=[ACSMode.IDLE, ACSMode.PASS],
+            obsid=[0, 42],
+            ra=[0.0, 61.0],
+            dec=[0.0, 0.0],
+            roll=[0.0, 0.0],
+        )
 
         with pytest.raises(PlanExecutionMismatchError, match="attitude_rate_violation"):
             queue_ditl._assert_plan_matches_execution()


### PR DESCRIPTION
## Problem

Plan/execution validation checked task matching and attitude constraints, but did not check kinematic continuity between adjacent exported attitude samples. A mode transition could therefore replace the executed attitude with a distant attitude and still export a plan, effectively allowing a spacecraft attitude teleport.

## Solution

- validate the exact `Telemetry.housekeeping` stream used to write `attitude_timeseries.json`
- compute the shortest full SO(3) quaternion rotation between every adjacent RA/Dec/roll sample
- require `rotation_deg <= max_slew_rate_deg_per_s * elapsed_seconds` with no ACS-mode exemptions
- reject non-increasing/non-finite timestamps and non-finite attitudes
- run the invariant in both DITL implementations before sidecar export
- report sample indices, timestamps, modes, actual rotation/rate, and configured limit

This is a sampled-telemetry invariant. It complements command-boundary transition guards; it cannot prove what occurs between two samples when a discontinuity is smaller than the allowed motion over that whole interval.

## Validation

- `pytest -q`: 2,225 passed, 1 skipped
- focused DITL/QueueDITL tests: 305 passed
- all hooks pass, including Ruff and mypy
- default Coast plan output matches the golden baseline
- combined with #232, #234, and #235: 2,243 passed, 1 skipped; 100 Tamalpais seeds have zero failed seeds, plan/execution mismatches, hard-constraint events, and adjacent-attitude rate violations

The gate exposed three pre-existing mission intervals at 2.655, 2.167, and 2.129 deg/s against a 2.0 deg/s limit. #232 fixes internal pass tracking, #234 preserves the pass-end attitude, and #235 constrains continuous roll optimization to reachable candidates.