### PR TITLE
fix: preserve attitude continuity after ground passes

### DIFF
--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -283,17 +283,6 @@ class ACS:
         self.current_pass = None
         self.acsmode = ACSMode.IDLE
 
-        # Clear any stale slew that was issued during the pass. Such slews have
-        # start positions from pass tracking that don't reflect where the
-        # spacecraft actually is now. Keeping them would cause teleportation.
-        if self.last_slew is not None and self.last_slew.slewstart < utime:
-            self._log_or_print(
-                utime,
-                "PASS",
-                f"{unixtime2date(utime)}: Clearing stale slew (started {self.last_slew.slewstart:.0f})",
-            )
-            self.last_slew = None
-
         # Preserve the final tracked attitude until another command starts motion.
         # Future slew commands recalculate their start attitude when they execute.
         self._hold_idle_attitude(self.ra, self.dec, self.roll, utime)

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -294,11 +294,16 @@ class ACS:
             )
             self.last_slew = None
 
+        # Preserve the final tracked attitude until another command starts motion.
+        # Future slew commands recalculate their start attitude when they execute.
+        self._hold_idle_attitude(self.ra, self.dec, self.roll, utime)
+
         last_ppt_obsid = self.last_ppt.obsid if self.last_ppt is not None else "unknown"
         self._log_or_print(
             utime,
             "PASS",
-            f"{unixtime2date(utime)}: Pass over - returning to last PPT {last_ppt_obsid}",
+            f"{unixtime2date(utime)}: Pass over - holding final tracked attitude "
+            f"(last PPT {last_ppt_obsid})",
         )
 
     # Handle Safe Mode Command

--- a/tests/acs/test_acs_coverage.py
+++ b/tests/acs/test_acs_coverage.py
@@ -523,8 +523,8 @@ class TestEndPassCoverage:
         acs._end_pass(1514764800.0)
         assert len(acs.command_queue) == 0
 
-    def test_end_pass_clears_stale_slew(self, acs) -> None:
-        """Test that _end_pass clears slews that started before current time (stale slews)."""
+    def test_end_pass_replaces_stale_slew_with_attitude_hold(self, acs) -> None:
+        """A stale pass-ingress slew is replaced with the final tracked attitude."""
         from conops.simulation.slew import Slew
 
         # Create a slew that started in the past (stale)
@@ -535,19 +535,27 @@ class TestEndPassCoverage:
         # Set up pass state
         acs.current_pass = Mock(spec=Pass)
         acs.acsmode = ACSMode.PASS
+        acs.ra = 45.0
+        acs.dec = -30.0
+        acs.roll = 210.0
 
         # End the pass
         acs._end_pass(1514764800.0)
 
-        # Stale slew should be cleared
-        assert acs.last_slew is None
+        assert acs.last_slew is not None
+        assert acs.last_slew.obstype == ObsType.IDLE
+        assert (acs.last_slew.endra, acs.last_slew.enddec, acs.last_slew.endroll) == (
+            45.0,
+            -30.0,
+            210.0,
+        )
         # Pass should be cleared
         assert acs.current_pass is None
         # Mode should be IDLE
         assert acs.acsmode == ACSMode.IDLE
 
-    def test_end_pass_preserves_fresh_slew(self, acs) -> None:
-        """Test that _end_pass preserves slews that start in the future (fresh slews)."""
+    def test_end_pass_replaces_precomputed_slew_with_attitude_hold(self, acs) -> None:
+        """A future command must not change physical attitude before it executes."""
         from conops.simulation.slew import Slew
 
         # Create a slew that starts in the future (fresh)
@@ -558,12 +566,17 @@ class TestEndPassCoverage:
         # Set up pass state
         acs.current_pass = Mock(spec=Pass)
         acs.acsmode = ACSMode.PASS
+        acs.ra = 45.0
+        acs.dec = -30.0
+        acs.roll = 210.0
 
         # End the pass
         acs._end_pass(1514764800.0)
 
-        # Fresh slew should be preserved
-        assert acs.last_slew is mock_slew
+        assert acs.last_slew is not mock_slew
+        assert acs.last_slew is not None
+        assert acs.last_slew.obstype == ObsType.IDLE
+        assert acs._compute_roll(1514764800.0) == 210.0
         # Pass should still be cleared
         assert acs.current_pass is None
         # Mode should be IDLE
@@ -581,13 +594,14 @@ class TestEndPassCoverage:
         # End the pass (should not error)
         acs._end_pass(1514764800.0)
 
-        # Everything should work as expected
-        assert acs.last_slew is None
+        # The current attitude becomes an explicit IDLE hold.
+        assert acs.last_slew is not None
+        assert acs.last_slew.obstype == ObsType.IDLE
         assert acs.current_pass is None
         assert acs.acsmode == ACSMode.IDLE
 
-    def test_end_pass_clears_slew_starting_exactly_at_current_time(self, acs) -> None:
-        """Test edge case where slew starts exactly at current time."""
+    def test_end_pass_replaces_slew_starting_at_current_time(self, acs) -> None:
+        """END_PASS owns the boundary until a queued slew command executes."""
         from conops.simulation.slew import Slew
 
         # Create a slew that starts exactly at current time
@@ -602,9 +616,9 @@ class TestEndPassCoverage:
         # End the pass
         acs._end_pass(1514764800.0)
 
-        # Slew starting at current time should be cleared (< is not satisfied, so preserved)
-        assert acs.last_slew is mock_slew
-        # This documents the current behavior: slews at exactly utime are kept
+        assert acs.last_slew is not mock_slew
+        assert acs.last_slew is not None
+        assert acs.last_slew.obstype == ObsType.IDLE
 
 
 class TestProcessCommandsCoverage:


### PR DESCRIPTION
## Problem

Ending a ground-station pass cleared the stale ingress slew without preserving the final tracked attitude. The next ACS update could recompute roll before the following slew started, producing an instantaneous attitude jump. In the Tamalpais reproduction, the pass-exit sample moved 159.28 deg in 60 s (2.65 deg/s against a 2 deg/s limit).

## Change

- Replace stale/precomputed slew state at `END_PASS` with a zero-duration IDLE hold at the executed pass-end RA/Dec/roll.
- Keep future slew commands queued; `_start_slew()` still recalculates their start from the current physical attitude when they execute.
- Correct the pass-end log so it reports the hold instead of claiming an uncommanded return to the last PPT.

## Plan impact

Target selection after a pass now starts from the real pass-end roll instead of the previous discontinuous roll. The Tamalpais target sequence therefore changes. In the 100-seed combined safety run, science ranges from 64,080 to 65,700 s, so tamalpais-configuration#37 rebaselines the old 65,400 s scanner floor separately.

## Validation

- `pytest -q tests/acs/test_acs.py tests/acs/test_acs_coverage.py tests/scheduler_queue/test_queue_ditl.py` (368 passed)
- Combined continuity integration: 2,243 passed, 1 skipped
- Default Coast plan output matches baseline
- 100-seed Tamalpais integration with #232, #233, and #235: zero failed seeds, plan/execution mismatches, hard-constraint events, and adjacent-attitude rate violations; generation is 6.73-8.99 s.