### PR TITLE
fix: keep optimized roll within ACS motion limits

### DIFF
--- a/conops/config/acs.py
+++ b/conops/config/acs.py
@@ -80,6 +80,19 @@ class AttitudeControlSystem(ConfigModel):
         t_cruise = d_cruise / vmax
         return float(2 * t_accel + t_cruise)
 
+    def max_motion_angle(self, duration_s: float) -> float:
+        """Maximum rest-to-rest angular motion in the available time."""
+        if duration_s <= 0:
+            return 0.0
+        a = float(self.slew_acceleration)
+        vmax = float(self.max_slew_rate)
+        if a <= 0 or vmax <= 0:
+            return 0.0
+        t_accel = vmax / a
+        if duration_s <= 2 * t_accel:
+            return float(0.25 * a * duration_s**2)
+        return float(vmax * (duration_s - t_accel))
+
     def s_of_t(self, angle_deg: float, t: float) -> float:
         """Distance traveled (deg) along the slew after t seconds under bang-bang control.
 

--- a/conops/simulation/acs.py
+++ b/conops/simulation/acs.py
@@ -66,6 +66,8 @@ class ACS:
     radiator_earth_exposure: float
     radiator_heat_dissipation_w: float
     science_observation_active: bool
+    _last_roll_optimization_utime: float | None
+    _last_roll_optimization_mode: ACSMode | None
 
     def __init__(self, config: MissionConfig, log: "DITLLog | None" = None) -> None:
         """Initialize the Attitude Control System.
@@ -113,6 +115,8 @@ class ACS:
         self.radiator_sun_exposure = 0.0
         self.radiator_earth_exposure = 0.0
         self.radiator_heat_dissipation_w = 0.0
+        self._last_roll_optimization_utime = None
+        self._last_roll_optimization_mode = None
 
         # Command queue (sorted by execution_time)
         self.command_queue = []
@@ -643,11 +647,13 @@ class ACS:
         - Initial boundary condition (no real slew yet): use optimal roll.
         """
         if self._is_actively_slewing(utime) and self.current_slew is not None:
+            self._reset_roll_optimization()
             return self.current_slew.slew_roll(utime)
-        if self._is_in_charging_mode(utime) or self.in_safe_mode:
-            return optimum_roll(
-                self.ra, self.dec, utime, self.ephem, self.solar_panel, self.constraint
-            )
+        if self.in_safe_mode:
+            return self._continuous_optimum_roll(utime, ACSMode.SAFE)
+        if self._is_in_charging_mode(utime):
+            return self._continuous_optimum_roll(utime, ACSMode.CHARGING)
+        self._reset_roll_optimization()
         if self.current_pass is not None and self.current_pass.in_pass(utime):
             return self.current_pass.roll_at(utime)
         if self.last_slew is not None and self.last_slew.slewstart > 0:
@@ -655,6 +661,41 @@ class ACS:
         return optimum_roll(
             self.ra, self.dec, utime, self.ephem, self.solar_panel, self.constraint
         )
+
+    def _continuous_optimum_roll(self, utime: float, mode: ACSMode) -> float:
+        """Choose the best constrained roll reachable since the last dwell update."""
+        elapsed = 0.0
+        if (
+            self._last_roll_optimization_mode == mode
+            and self._last_roll_optimization_utime is not None
+        ):
+            elapsed = max(0.0, utime - self._last_roll_optimization_utime)
+        max_roll_delta = (
+            min(
+                180.0,
+                self.config.spacecraft_bus.attitude_control.max_motion_angle(elapsed),
+            )
+            if elapsed > 0.0
+            else 0.0
+        )
+        roll = optimum_roll(
+            self.ra,
+            self.dec,
+            utime,
+            self.ephem,
+            self.solar_panel,
+            self.constraint,
+            reference_roll=self.roll,
+            max_roll_delta=max_roll_delta,
+        )
+        self._last_roll_optimization_utime = utime
+        self._last_roll_optimization_mode = mode
+        return roll
+
+    def _reset_roll_optimization(self) -> None:
+        """Reset dwell-roll timing when another attitude controller is active."""
+        self._last_roll_optimization_utime = None
+        self._last_roll_optimization_mode = None
 
     def _enforce_idle_constraint_safe_attitude(self, utime: float) -> None:
         """Replace unsafe idle holds with an attitude that satisfies IDLE scopes."""

--- a/conops/simulation/roll.py
+++ b/conops/simulation/roll.py
@@ -71,6 +71,8 @@ def optimum_roll(
     ephem: rust_ephem.Ephemeris,
     solar_panel: SolarPanelSet | None = None,
     constraint: Constraint | None = None,
+    reference_roll: float | None = None,
+    max_roll_delta: float | None = None,
 ) -> float:
     """Calculate the optimum roll angle (degrees in [0,360)).
 
@@ -84,7 +86,15 @@ def optimum_roll(
       the combined constraint (via ``roll_range``).  If the constraint blocks all
       rolls (fully blocked pointing) the function falls back to the unconstrained
       optimum.
+    - If `reference_roll` and `max_roll_delta` are provided: restrict the search
+      to rolls within that shortest-path angular distance. If no integer-degree
+      candidate is reachable, hold the reference roll.
     """
+    if (reference_roll is None) != (max_roll_delta is None):
+        raise ValueError("reference_roll and max_roll_delta must be provided together")
+    if max_roll_delta is not None and max_roll_delta < 0:
+        raise ValueError("max_roll_delta must be non-negative")
+
     # Fetch ephemeris index and Sun vector from pre-computed arrays
     index = ephem.index(dtutcfromtimestamp(utime))
     sunvec = ephem.sun_pv.position[index] - ephem.gcrs_pv.position[index]  # km
@@ -95,7 +105,19 @@ def optimum_roll(
     s_norm = s / np.linalg.norm(s)
 
     # Build valid-roll mask from constraint (None if unconstrained or all valid)
-    valid_mask = _roll_valid_mask(ra, dec, utime, ephem, constraint)
+    candidate_mask = _roll_valid_mask(ra, dec, utime, ephem, constraint)
+    deg = np.arange(360.0, dtype=float)
+    if reference_roll is not None and max_roll_delta is not None:
+        reference_roll %= 360.0
+        roll_delta = np.abs((deg - reference_roll + 180.0) % 360.0 - 180.0)
+        reachable_mask = roll_delta <= max_roll_delta + 1e-9
+        candidate_mask = (
+            reachable_mask
+            if candidate_mask is None
+            else candidate_mask & reachable_mask
+        )
+        if not candidate_mask.any():
+            return reference_roll
 
     def _analytic_roll() -> float:
         roll_rad = np.arctan2(-s_norm[2], s_norm[1])
@@ -104,15 +126,12 @@ def optimum_roll(
     if solar_panel is None or not solar_panel.panels:
         # Analytic optimum for side-mounted panel (0,1,0): max y_body = cos(θ)*y0 - sin(θ)*z0
         # d/dθ = 0 → θ = atan2(-z0, y0)
-        if valid_mask is None:
+        if candidate_mask is None:
             return _analytic_roll()
         # Constraint present: scan 360° with illumination model for a (0,1,0) panel
-        deg = np.arange(360.0, dtype=float)
         ang = deg * DTOR
         illum = np.cos(ang) * s_norm[1] - np.sin(ang) * s_norm[2]
-        totals = np.where(valid_mask, illum, -np.inf)
-        if not valid_mask.any():
-            return _analytic_roll()
+        totals = np.where(candidate_mask, illum, -np.inf)
         return float(deg[int(np.argmax(totals))])
 
     # Weighted optimization using actual panel geometry (vectorized).
@@ -151,7 +170,6 @@ def optimum_roll(
     c_coef = n_mat[:, 2] * s_norm[1] - n_mat[:, 1] * s_norm[2]
 
     # Angles 0..359 degrees
-    deg = np.arange(360.0, dtype=float)
     ang = deg * DTOR
     cos_t = np.cos(ang)  # (360,)
     sin_t = np.sin(ang)  # (360,)
@@ -170,8 +188,8 @@ def optimum_roll(
     totals = totals.sum(axis=1)
 
     # Apply valid-roll mask if present
-    if valid_mask is not None and valid_mask.any():
-        totals = np.where(valid_mask, totals, -np.inf)
+    if candidate_mask is not None:
+        totals = np.where(candidate_mask, totals, -np.inf)
 
     # Argmax over angles
     best_idx = int(np.argmax(totals))

--- a/tests/acs/test_acs_roll.py
+++ b/tests/acs/test_acs_roll.py
@@ -6,7 +6,14 @@ import numpy as np
 import pytest
 import rust_ephem
 
-from conops import ACS, ACSMode, AttitudeConstraintScope, Constraint, MissionConfig
+from conops import (
+    ACS,
+    ACSMode,
+    AttitudeConstraintScope,
+    AttitudeControlSystem,
+    Constraint,
+    MissionConfig,
+)
 from conops.config.solar_panel import SolarPanel, SolarPanelSet
 
 
@@ -321,6 +328,31 @@ class TestACSRollMode:
         _, _, roll, _ = acs_roll.pointing(utime)
 
         assert 0.0 <= roll < 360.0
+
+    def test_charging_roll_search_is_limited_to_reachable_motion(
+        self, acs_roll
+    ) -> None:
+        acs_roll.config.spacecraft_bus.attitude_control = AttitudeControlSystem(
+            max_slew_rate=2.0,
+            slew_acceleration=0.125,
+            settle_time=0.0,
+        )
+        acs_roll.roll = 215.0
+
+        with (
+            patch.object(acs_roll, "_is_in_charging_mode", return_value=True),
+            patch(
+                "conops.simulation.acs.optimum_roll",
+                side_effect=lambda *args, **kwargs: kwargs["reference_roll"],
+            ) as mock_optimum_roll,
+        ):
+            acs_roll._compute_roll(1000.0)
+            acs_roll._compute_roll(1060.0)
+
+        first_call = mock_optimum_roll.call_args_list[0].kwargs
+        second_call = mock_optimum_roll.call_args_list[1].kwargs
+        assert first_call["max_roll_delta"] == 0.0
+        assert second_call["max_roll_delta"] == pytest.approx(88.0)
 
 
 class TestACSRollEdgeCases:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,9 @@ def mock_spacecraft_bus() -> Mock:
     spacecraft_bus.attitude_control.__class__ = conops.AttitudeControlSystem
     spacecraft_bus.attitude_control.predict_slew = Mock(return_value=(45.0, []))
     spacecraft_bus.attitude_control.slew_time = Mock(return_value=100.0)
+    spacecraft_bus.attitude_control.max_motion_angle = Mock(
+        side_effect=conops.AttitudeControlSystem().max_motion_angle
+    )
     spacecraft_bus.radiators = Mock()
     spacecraft_bus.radiators.num_radiators = Mock(return_value=0)
     spacecraft_bus.star_trackers = Mock()

--- a/tests/roll/test_roll.py
+++ b/tests/roll/test_roll.py
@@ -1,6 +1,6 @@
 """Tests for conops.roll module."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import numpy as np
 
@@ -68,6 +68,45 @@ class TestOptimumRoll:
             ra, dec, utime, mock_ephem, solar_panel=mock_solar_panel_canted
         )
         assert isinstance(roll, float) and 0 <= roll < 360
+
+    def test_optimum_roll_restricts_search_to_reachable_rolls(
+        self, mock_ephem, mock_sun_coord
+    ):
+        valid_mask = np.zeros(360, dtype=bool)
+        valid_mask[209] = True
+        valid_mask[345] = True
+
+        with patch("conops.simulation.roll._roll_valid_mask", return_value=valid_mask):
+            roll = optimum_roll(
+                45.0,
+                30.0,
+                1700000000.0,
+                mock_ephem,
+                constraint=Mock(),
+                reference_roll=215.0,
+                max_roll_delta=88.0,
+            )
+
+        assert roll == 209.0
+
+    def test_optimum_roll_holds_reference_when_no_candidate_is_reachable(
+        self, mock_ephem, mock_sun_coord
+    ):
+        valid_mask = np.zeros(360, dtype=bool)
+        valid_mask[345] = True
+
+        with patch("conops.simulation.roll._roll_valid_mask", return_value=valid_mask):
+            roll = optimum_roll(
+                45.0,
+                30.0,
+                1700000000.0,
+                mock_ephem,
+                constraint=Mock(),
+                reference_roll=215.5,
+                max_roll_delta=0.0,
+            )
+
+        assert roll == 215.5
 
 
 class TestOptimumRollSidemount:

--- a/tests/spacecraft_bus/test_spacecraft_bus.py
+++ b/tests/spacecraft_bus/test_spacecraft_bus.py
@@ -1,6 +1,7 @@
 """Unit tests for spacecraft_bus module."""
 
 import numpy as np
+import pytest
 
 from conops import AttitudeControlSystem, PowerDraw, SpacecraftBus
 
@@ -133,6 +134,27 @@ class TestAttitudeControlSystem:
         # total = 2*0.5 + 39.5 = 40.5
         expected = 2 * 0.5 + 9.875 / 0.25
         assert abs(motion_time - expected) < 1e-6
+
+    def test_max_motion_angle_inverts_triangular_profile(self):
+        acs = AttitudeControlSystem(slew_acceleration=0.125, max_slew_rate=2.0)
+
+        angle = acs.max_motion_angle(16.0)
+
+        assert angle == pytest.approx(8.0)
+        assert acs.motion_time(angle) == pytest.approx(16.0)
+
+    def test_max_motion_angle_inverts_trapezoidal_profile(self):
+        acs = AttitudeControlSystem(slew_acceleration=0.125, max_slew_rate=2.0)
+
+        angle = acs.max_motion_angle(60.0)
+
+        assert angle == pytest.approx(88.0)
+        assert acs.motion_time(angle) == pytest.approx(60.0)
+
+    def test_max_motion_angle_rejects_invalid_inputs(self):
+        assert AttitudeControlSystem().max_motion_angle(0.0) == 0.0
+        assert AttitudeControlSystem(slew_acceleration=0).max_motion_angle(60.0) == 0.0
+        assert AttitudeControlSystem(max_slew_rate=0).max_motion_angle(60.0) == 0.0
 
     def test_s_of_t_zero_angle(self, default_acs):
         """Test s_of_t returns 0 for zero angle."""


### PR DESCRIPTION
## Problem

Charging and safe-mode dwell recomputed the globally optimal constraint-safe roll at every telemetry sample without considering the previously executed roll. When the best valid interval moved, ACS could jump between valid intervals. The Tamalpais reproduction jumped 130 deg in 60 s (2.17 deg/s against a 2 deg/s limit), although a nearby safe roll was available.

## Change

- Add `AttitudeControlSystem.max_motion_angle()` as the inverse of the existing rest-to-rest bang-bang motion model.
- Allow `optimum_roll()` to restrict candidates to a shortest-path window around the executed roll.
- During continuous charging/safe roll optimization, search only sample-valid rolls reachable in the elapsed dwell time. The first update after another controller owned attitude has a zero-degree window.
- If no integer-degree valid candidate is reachable, hold the current roll instead of discontinuously jumping; normal constraint validation can then reject an infeasible plan.

For Tamalpais limits (2 deg/s, 0.125 deg/s²), a 60 s dwell update may move at most 88 deg under the configured acceleration/cruise/deceleration model. The reproduced case selects the nearby 209 deg safe roll instead of jumping from 215 deg to 345 deg.

This enforces endpoint reachability at the telemetry cadence. Continuous keepout safety between samples remains the responsibility of slew-path/constraint validation; this PR does not claim a sub-sample proof.

## Validation

- Focused ACS/roll/config/scheduler tests: 471 passed
- Combined continuity integration: 2,243 passed, 1 skipped
- Default Coast plan output matches baseline
- 100-seed Tamalpais integration with #232, #233, and #234: zero failed seeds, plan/execution mismatches, hard-constraint events, and adjacent-attitude rate violations; generation is 6.73-8.99 s.