### PR TITLE
fix: osculating element model integration

### DIFF
--- a/conops/targets/plan_metadata.py
+++ b/conops/targets/plan_metadata.py
@@ -216,14 +216,14 @@ def attach_osculating_elements_metadata(
         velocity_km_s=velocities[index],
     )
     serialized_elements = {
-        "SemimajorAxis_m": elements["semimajor_axis_km"] * 1_000.0,
-        "Eccentricity": elements["eccentricity"],
-        "Inclination_deg": elements["inclination_deg"],
-        "RightAscension_deg": elements["right_ascension_of_ascending_node_deg"],
-        "ArgPeriapsis_deg": elements["argument_of_periapsis_deg"],
-        "TrueAnomaly_deg": elements["true_anomaly_deg"],
+        "SemimajorAxis_m": elements.semimajor_axis_km * 1_000.0,
+        "Eccentricity": elements.eccentricity,
+        "Inclination_deg": elements.inclination_deg,
+        "RightAscension_deg": elements.right_ascension_of_ascending_node_deg,
+        "ArgPeriapsis_deg": elements.argument_of_periapsis_deg,
+        "TrueAnomaly_deg": elements.true_anomaly_deg,
         "GravitationalParameter_m3_s2": (
-            elements["gravitational_parameter_km3_s2"] * 1.0e9
+            elements.gravitational_parameter_km3_s2 * 1.0e9
         ),
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "pydantic>=2.12",
     "pyproj>=3.7.0",
     "pytz>=2025.2",
-    "rust-ephem @ git+https://github.com/CosmicFrontierLabs/rust-ephem.git@586eeff",
+    "rust-ephem>=0.13.0",
     "shapely>=2",
     "tqdm>=4.67",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "pydantic>=2.12",
     "pyproj>=3.7.0",
     "pytz>=2025.2",
-    "rust-ephem @ git+https://github.com/CosmicFrontierLabs/rust-ephem.git@7a60b00",
+    "rust-ephem @ git+https://github.com/CosmicFrontierLabs/rust-ephem.git@586eeff",
     "shapely>=2",
     "tqdm>=4.67",
 ]


### PR DESCRIPTION
## Problem

rust-ephem now returns `OsculatingElements` as a Pydantic model, but COAST still indexes the result as a dictionary. With current merged versions, `QueueDITL.calc()` fails while attaching orbit metadata:

```
TypeError: 'OsculatingElements' object is not subscriptable
```

The existing rust-ephem dependency pin points to the pre-review implementation that returned a `TypedDict`, so CI did not exercise the merged API.

## Solution

- require the released `rust-ephem>=0.13.0` package
- read the documented `OsculatingElements` model attributes directly
- keep the serialized COAST plan metadata schema unchanged

## Validation

- `pytest tests/plan/test_plan_metadata.py -q`: 14 passed
- `prek run --all-files`: passed
- full 24-hour plan generation: passed, 90 entries
- repeatability check: passed
- seed-0 mission scan: passed with zero hard-constraint events and zero validation/constraint mismatches
