### PR TITLE
fix: align boresight pitch convention with rust-ephem

### DIFF
--- a/conops/common/vector.py
+++ b/conops/common/vector.py
@@ -198,19 +198,20 @@ def vec2radec(v: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
     return np.array([ra, dec])
 
 
-def normal_to_euler_deg(
+def normal_to_boresight_offset_euler_deg(
     normal: tuple[float, float, float] | npt.NDArray[np.float64],
 ) -> tuple[float, float, float]:
-    """Convert a body-frame normal vector to (roll, pitch, yaw) in degrees.
+    """Convert a body-frame normal to rust-ephem boresight-offset Euler angles.
 
-    The mapping is equivalent to the prior radiator-local helper:
-    - roll is fixed at 0 deg
-    - pitch = atan2(z, hypot(x, y))
-    - yaw = atan2(y, x)
+    ``rust_ephem.Constraint.boresight_offset`` uses intrinsic Z-Y-X Euler
+    rotations.  Applied to local +X, that convention produces
+    ``(cos(pitch) cos(yaw), cos(pitch) sin(yaw), -sin(pitch))``.  Therefore a
+    body normal's positive Z component maps to negative pitch.  Roll about the
+    normal is underdetermined and fixed at zero.
     """
     x, y, z = vecnorm(np.asarray(normal, dtype=np.float64))
     yaw_deg = float(np.rad2deg(np.arctan2(y, x)))
-    pitch_deg = float(np.rad2deg(np.arctan2(z, np.hypot(x, y))))
+    pitch_deg = float(np.rad2deg(np.arctan2(-z, np.hypot(x, y))))
     return 0.0, pitch_deg, yaw_deg
 
 

--- a/conops/config/instrument.py
+++ b/conops/config/instrument.py
@@ -6,7 +6,7 @@ import numpy as np
 from pydantic import AliasChoices, Field, field_validator, model_validator
 from rust_ephem.constraints import ConstraintConfig
 
-from ..common.vector import normal_to_euler_deg
+from ..common.vector import normal_to_boresight_offset_euler_deg
 from ._base import ConfigModel
 from .constraint import Constraint
 from .data_generator import DataGeneration
@@ -243,7 +243,7 @@ class Telescope(Instrument):
             return None
         if self.boresight == (1.0, 0.0, 0.0):
             return base
-        roll_deg, pitch_deg, yaw_deg = normal_to_euler_deg(
+        roll_deg, pitch_deg, yaw_deg = normal_to_boresight_offset_euler_deg(
             np.asarray(self.boresight, dtype=np.float64)
         )
         return base.boresight_offset(

--- a/conops/config/radiator.py
+++ b/conops/config/radiator.py
@@ -19,7 +19,7 @@ from pydantic import Field, field_validator
 from rust_ephem.constraints import ConstraintConfig
 
 from ..common import dtutcfromtimestamp, scbodyvector
-from ..common.vector import normal_to_euler_deg, radec2vec
+from ..common.vector import normal_to_boresight_offset_euler_deg, radec2vec
 from ._base import ConfigModel
 from .constraint import Constraint
 from .geometry import PanelGeometry, compute_shadow_fraction
@@ -130,7 +130,9 @@ class Radiator(ConfigModel):
         if base_constraint is None:
             return None
 
-        roll_deg, pitch_deg, yaw_deg = normal_to_euler_deg(self.orientation.normal)
+        roll_deg, pitch_deg, yaw_deg = normal_to_boresight_offset_euler_deg(
+            self.orientation.normal
+        )
         return base_constraint.boresight_offset(
             roll_deg=roll_deg,
             pitch_deg=pitch_deg,

--- a/conops/config/radiator.py
+++ b/conops/config/radiator.py
@@ -129,6 +129,8 @@ class Radiator(ConfigModel):
         base_constraint = self.hard_constraint.constraint
         if base_constraint is None:
             return None
+        if self.orientation.normal == (1.0, 0.0, 0.0):
+            return base_constraint
 
         roll_deg, pitch_deg, yaw_deg = normal_to_boresight_offset_euler_deg(
             self.orientation.normal

--- a/conops/config/star_tracker.py
+++ b/conops/config/star_tracker.py
@@ -38,7 +38,13 @@ from rust_ephem import AtLeastConstraint, EarthLimbConstraint, SunConstraint
 from rust_ephem.constraints import ConstraintConfig
 
 from ..common.enums import ACSMode
-from ..common.vector import radec2vec, rotvec, vec2radec, vecnorm
+from ..common.vector import (
+    normal_to_boresight_offset_euler_deg,
+    radec2vec,
+    rotvec,
+    vec2radec,
+    vecnorm,
+)
 from ._base import ConfigModel
 from .constraint import Constraint
 
@@ -352,28 +358,6 @@ class StarTrackerConfiguration(ConfigModel):
             return False
         return mode in self.modes_require_lock
 
-    @staticmethod
-    def _boresight_to_euler_deg(
-        boresight: tuple[float, float, float],
-    ) -> tuple[float, float, float]:
-        """Convert boresight unit vector to azimuth/elevation angles for boresight_offset.
-
-        Returns (roll=0, pitch, yaw) angles such that
-        ``boresight_offset(roll, pitch, yaw)`` of a constraint shifts the
-        constraint from its natural +X direction to the direction of
-        ``boresight`` in the spacecraft body frame.
-
-        Concretely: yaw is the azimuthal angle of the boresight in the body
-        xy-plane, and pitch is its elevation above that plane — the standard
-        spherical-coordinate decomposition that ``boresight_offset`` expects.
-        Roll about the boresight is underdetermined; we set it to 0.
-        """
-        x, y, z = vecnorm(np.asarray(boresight, dtype=np.float64))
-        yaw_deg = float(np.rad2deg(np.arctan2(y, x)))
-        pitch_deg = float(np.rad2deg(np.arctan2(z, np.hypot(x, y))))
-        roll_deg = 0.0
-        return roll_deg, pitch_deg, yaw_deg
-
     @cached_property
     def startracker_hard_constraint(self) -> ConstraintConfig | None:
         """Combined hard constraint from all star trackers.
@@ -396,7 +380,7 @@ class StarTrackerConfiguration(ConfigModel):
             if base_constraint is None:
                 continue
 
-            roll_deg, pitch_deg, yaw_deg = self._boresight_to_euler_deg(
+            roll_deg, pitch_deg, yaw_deg = normal_to_boresight_offset_euler_deg(
                 st.orientation.boresight
             )
             offset_constraint = base_constraint.boresight_offset(
@@ -436,7 +420,7 @@ class StarTrackerConfiguration(ConfigModel):
             base_constraint = st.soft_constraint.constraint
             if base_constraint is None:
                 continue
-            roll_deg, pitch_deg, yaw_deg = self._boresight_to_euler_deg(
+            roll_deg, pitch_deg, yaw_deg = normal_to_boresight_offset_euler_deg(
                 st.orientation.boresight
             )
             offset_constraint = base_constraint.boresight_offset(

--- a/conops/config/star_tracker.py
+++ b/conops/config/star_tracker.py
@@ -54,8 +54,11 @@ def create_star_tracker_vector(
 ) -> tuple[float, float, float]:
     """Create a star tracker boresight vector from Euler angles.
 
-    Converts roll, pitch, yaw angles to a unit boresight vector using the ZYX
-    Euler angle convention (yaw about Z, then pitch about Y, then roll about X).
+    Converts roll, pitch, yaw body-mount angles to a unit boresight vector.
+    Positive pitch rotates the default +X boresight toward body +Z.  This is a
+    body-frame configuration convention, not the rust-ephem boresight-offset
+    convention; :func:`normal_to_boresight_offset_euler_deg` performs that
+    conversion at the constraint API boundary.
 
     Args:
         roll_deg: Rotation about X axis (degrees). Default is 0.
@@ -69,7 +72,7 @@ def create_star_tracker_vector(
     Example:
         create_star_tracker_vector(0, 0, 0)  # Returns (1, 0, 0) - default boresight
         create_star_tracker_vector(0, 90, 0)  # Returns (0, 0, 1) - points along +Z
-        create_star_tracker_vector(0, 0, 90)  # Returns (0, 1, 0) - points along +Y
+        create_star_tracker_vector(0, 0, 90)  # Returns (0, -1, 0) - points along -Y
     """
     # Convert angles to radians
     roll_rad = np.deg2rad(roll_deg)
@@ -380,15 +383,18 @@ class StarTrackerConfiguration(ConfigModel):
             if base_constraint is None:
                 continue
 
-            roll_deg, pitch_deg, yaw_deg = normal_to_boresight_offset_euler_deg(
-                st.orientation.boresight
-            )
-            offset_constraint = base_constraint.boresight_offset(
-                roll_deg=roll_deg,
-                pitch_deg=pitch_deg,
-                yaw_deg=yaw_deg,
-                roll_clockwise=True,
-            )
+            if st.orientation.boresight == (1.0, 0.0, 0.0):
+                offset_constraint = base_constraint
+            else:
+                roll_deg, pitch_deg, yaw_deg = normal_to_boresight_offset_euler_deg(
+                    st.orientation.boresight
+                )
+                offset_constraint = base_constraint.boresight_offset(
+                    roll_deg=roll_deg,
+                    pitch_deg=pitch_deg,
+                    yaw_deg=yaw_deg,
+                    roll_clockwise=True,
+                )
 
             if combined is None:
                 combined = offset_constraint
@@ -420,15 +426,18 @@ class StarTrackerConfiguration(ConfigModel):
             base_constraint = st.soft_constraint.constraint
             if base_constraint is None:
                 continue
-            roll_deg, pitch_deg, yaw_deg = normal_to_boresight_offset_euler_deg(
-                st.orientation.boresight
-            )
-            offset_constraint = base_constraint.boresight_offset(
-                roll_deg=roll_deg,
-                pitch_deg=pitch_deg,
-                yaw_deg=yaw_deg,
-                roll_clockwise=True,
-            )
+            if st.orientation.boresight == (1.0, 0.0, 0.0):
+                offset_constraint = base_constraint
+            else:
+                roll_deg, pitch_deg, yaw_deg = normal_to_boresight_offset_euler_deg(
+                    st.orientation.boresight
+                )
+                offset_constraint = base_constraint.boresight_offset(
+                    roll_deg=roll_deg,
+                    pitch_deg=pitch_deg,
+                    yaw_deg=yaw_deg,
+                    roll_clockwise=True,
+                )
             offset_constraints.append(offset_constraint)
 
         if not offset_constraints:

--- a/conops/config/star_tracker.py
+++ b/conops/config/star_tracker.py
@@ -39,8 +39,8 @@ from rust_ephem.constraints import ConstraintConfig
 
 from ..common.enums import ACSMode
 from ..common.vector import (
+    _zero_roll_body_axes,
     normal_to_boresight_offset_euler_deg,
-    radec2vec,
     rotvec,
     vec2radec,
     vecnorm,
@@ -209,19 +209,8 @@ class StarTrackerOrientation(ConfigModel):
             and roll=90° give the same (RA, Dec) for the boresight. Roll only changes
             the apparent (RA, Dec) for trackers whose boresight is offset from +X.
         """
-        # Spacecraft boresight (+X body axis) in inertial coordinates.
-        ra_rad = np.deg2rad(ra_deg)
-        dec_rad = np.deg2rad(dec_deg)
-        x_hat = radec2vec(ra_rad, dec_rad)
-
-        # Build the body Y/Z basis around boresight using sky north as reference.
-        ref = np.array([0.0, 0.0, 1.0], dtype=np.float64)
-        y0 = np.cross(ref, x_hat)
-        if np.linalg.norm(y0) < 1e-12:
-            # Near celestial poles, choose a different reference for numerical stability.
-            y0 = np.cross(np.array([0.0, 1.0, 0.0], dtype=np.float64), x_hat)
-        y0 = vecnorm(y0)
-        z0 = vecnorm(np.cross(x_hat, y0))
+        # Spacecraft boresight (+X) and the zero-roll Y/Z basis in ECI.
+        x_hat, y0, z0 = _zero_roll_body_axes(np.deg2rad(ra_deg), np.deg2rad(dec_deg))
 
         # Positive roll is a right-handed physical rotation about body +X.
         roll_rad = np.deg2rad(roll_deg)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -419,7 +419,8 @@ class TestConfig:
         assert "constraint:" in content
         assert "star_tracker_soft_constraint:" in content
         assert "constraints:" in content
-        assert "boresight_offset" in content
+        assert "type: at_least" in content
+        assert "type: sun" in content
 
     def test_yaml_roundtrip(self, tmp_path: Path) -> None:
         """Test that YAML save and load maintains data integrity."""

--- a/tests/radiator/test_radiator.py
+++ b/tests/radiator/test_radiator.py
@@ -45,6 +45,18 @@ class TestRadiator:
         rad = Radiator(hard_constraint=hard_constraint)
         assert rad._hard_constraint_with_offset is None
 
+    def test_plus_x_hard_constraint_uses_base_constraint_directly(self) -> None:
+        base_constraint = Mock()
+        hard_constraint = Constraint()
+        hard_constraint.constraint = base_constraint
+        rad = Radiator(
+            orientation=RadiatorOrientation(normal=(1.0, 0.0, 0.0)),
+            hard_constraint=hard_constraint,
+        )
+
+        assert rad._hard_constraint_with_offset is base_constraint
+        base_constraint.boresight_offset.assert_not_called()
+
     def test_in_hard_constraint_false_when_no_constraint(self) -> None:
         rad = Radiator()
         assert rad.in_hard_constraint(10.0, -5.0, 1000.0, 7.0) is False
@@ -226,7 +238,16 @@ class TestRadiatorConfiguration:
         offset1.__or__ = Mock(return_value=combined)
 
         cfg = RadiatorConfiguration(
-            radiators=[Radiator(hard_constraint=c1), Radiator(hard_constraint=c2)]
+            radiators=[
+                Radiator(
+                    orientation=RadiatorOrientation(normal=(0.0, 1.0, 0.0)),
+                    hard_constraint=c1,
+                ),
+                Radiator(
+                    orientation=RadiatorOrientation(normal=(0.0, -1.0, 0.0)),
+                    hard_constraint=c2,
+                ),
+            ]
         )
         assert cfg.radiator_hard_constraint is combined
 
@@ -241,7 +262,13 @@ class TestRadiatorConfiguration:
         c2.constraint = base2
 
         cfg = RadiatorConfiguration(
-            radiators=[Radiator(hard_constraint=c1), Radiator(hard_constraint=c2)]
+            radiators=[
+                Radiator(hard_constraint=c1),
+                Radiator(
+                    orientation=RadiatorOrientation(normal=(0.0, 1.0, 0.0)),
+                    hard_constraint=c2,
+                ),
+            ]
         )
         assert cfg.radiator_hard_constraint is offset2
 

--- a/tests/radiator/test_radiator.py
+++ b/tests/radiator/test_radiator.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, PropertyMock, patch
 import numpy as np
 import pytest
 
-from conops.common.vector import normal_to_euler_deg
+from conops.common.vector import normal_to_boresight_offset_euler_deg
 from conops.config import (
     Constraint,
     Radiator,
@@ -23,7 +23,7 @@ class TestRadiatorOrientation:
 
 class TestRadiator:
     def test_normal_to_euler_converts_expected_axes(self) -> None:
-        roll, pitch, yaw = normal_to_euler_deg((0.0, 1.0, 0.0))
+        roll, pitch, yaw = normal_to_boresight_offset_euler_deg((0.0, 1.0, 0.0))
         assert roll == pytest.approx(0.0)
         assert pitch == pytest.approx(0.0)
         assert yaw == pytest.approx(90.0)

--- a/tests/star_tracker/test_star_tracker.py
+++ b/tests/star_tracker/test_star_tracker.py
@@ -101,6 +101,14 @@ class TestStarTrackerConstraints:
         assert not np.isclose(ra0, ra1, atol=1e-6)
         assert not np.isclose(dec0, dec1, atol=1e-6)
 
+    def test_off_axis_boresight_preserves_ra_basis_at_celestial_pole(self):
+        ori = StarTrackerOrientation(boresight=(0.0, 1.0, 0.0))
+
+        ra_st, dec_st = ori.transform_pointing(40.0, 90.0, roll_deg=0.0)
+
+        assert ra_st == pytest.approx(130.0, abs=1e-9)
+        assert dec_st == pytest.approx(0.0, abs=1e-9)
+
 
 class TestStarTrackerModeLockRequirements:
     """Test mode-dependent lock requirements on StarTrackerConfiguration."""

--- a/tests/star_tracker/test_star_tracker.py
+++ b/tests/star_tracker/test_star_tracker.py
@@ -6,13 +6,25 @@ import numpy as np
 import pytest
 import rust_ephem
 
+from conops.common.vector import normal_to_boresight_offset_euler_deg
 from conops.config import (
     Constraint,
     StarTracker,
     StarTrackerConfiguration,
     StarTrackerOrientation,
+    create_star_tracker_vector,
 )
 from conops.simulation.roll import _roll_valid_mask
+
+
+def test_positive_body_mount_pitch_maps_to_negative_rust_offset_pitch() -> None:
+    boresight = create_star_tracker_vector(pitch_deg=45.0)
+    assert boresight == pytest.approx((2**-0.5, 0.0, 2**-0.5))
+
+    roll_deg, pitch_deg, yaw_deg = normal_to_boresight_offset_euler_deg(boresight)
+    assert roll_deg == pytest.approx(0.0)
+    assert pitch_deg == pytest.approx(-45.0)
+    assert yaw_deg == pytest.approx(0.0)
 
 
 class TestStarTrackerConstraints:
@@ -381,8 +393,20 @@ class TestStarTrackerComputedConstraint:
         assert c is not None
         assert c.type == "or"
         assert len(c.constraints) == 2
-        assert all(child.type == "boresight_offset" for child in c.constraints)
-        assert all(child.roll_clockwise for child in c.constraints)
+        assert c.constraints[0].type == "sun"
+        assert c.constraints[1].type == "boresight_offset"
+        assert c.constraints[1].roll_clockwise is True
+
+    def test_startracker_hard_constraint_plus_x_uses_base_constraint(self):
+        st = StarTracker(
+            name="ST1",
+            hard_constraint=Constraint(
+                sun_constraint=rust_ephem.SunConstraint(min_angle=20.0)
+            ),
+        )
+        cfg = StarTrackerConfiguration(star_trackers=[st])
+
+        assert cfg.startracker_hard_constraint is st.hard_constraint.constraint
 
     def test_startracker_hard_constraint_min_functional_does_not_affect_hard(self):
         """min_functional_trackers has no effect on hard constraints — they are always OR."""
@@ -460,8 +484,22 @@ class TestStarTrackerComputedConstraint:
         assert c.type == "at_least"
         assert c.min_violated == 2
         assert len(c.constraints) == 2
-        assert all(child.type == "boresight_offset" for child in c.constraints)
-        assert all(child.roll_clockwise for child in c.constraints)
+        assert c.constraints[0].type == "sun"
+        assert c.constraints[1].type == "boresight_offset"
+        assert c.constraints[1].roll_clockwise is True
+
+    def test_startracker_soft_constraint_plus_x_uses_base_constraint(self):
+        st = StarTracker(
+            name="ST1",
+            soft_constraint=Constraint(
+                sun_constraint=rust_ephem.SunConstraint(min_angle=20.0)
+            ),
+        )
+        cfg = StarTrackerConfiguration(star_trackers=[st])
+
+        constraint = cfg.startracker_constraint
+        assert constraint is not None
+        assert constraint.constraints[0] is st.soft_constraint.constraint
 
     def test_startracker_constraint_respects_min_functional_trackers_threshold(self):
         from conops.config import Constraint, StarTrackerConfiguration

--- a/tests/star_tracker/test_star_tracker.py
+++ b/tests/star_tracker/test_star_tracker.py
@@ -586,6 +586,69 @@ class TestStarTrackerComputedConstraint:
         )
         np.testing.assert_array_equal(mask, expected_mask)
 
+    def test_non_planar_boresights_match_fixed_roll_planning_constraint(self):
+        """rust-ephem offsets must match COAST body geometry at fixed rolls."""
+        from datetime import datetime
+        from pathlib import Path
+
+        tle_path = Path(__file__).parents[2] / "examples" / "example.tle"
+        if not tle_path.exists():
+            pytest.skip("example.tle not available")
+
+        ephem = rust_ephem.TLEEphemeris(
+            begin=datetime(2025, 12, 1, 0, 0, 0),
+            end=datetime(2025, 12, 1, 1, 0, 0),
+            step_size=60,
+            tle=str(tle_path),
+        )
+        sample_utime = ephem.timestamp[0].timestamp()
+        inv_sqrt_3 = 3**-0.5
+        boresights = [
+            (0.0, 0.0, 1.0),
+            (0.0, 0.0, -1.0),
+            (inv_sqrt_3, inv_sqrt_3, inv_sqrt_3),
+            (inv_sqrt_3, -inv_sqrt_3, -inv_sqrt_3),
+        ]
+
+        for boresight in boresights:
+            tracker = StarTracker(
+                name="STR",
+                orientation=StarTrackerOrientation(boresight=boresight),
+                soft_constraint=Constraint(
+                    sun_constraint=rust_ephem.SunConstraint(min_angle=45.0)
+                ),
+            )
+            cfg = StarTrackerConfiguration(
+                star_trackers=[tracker],
+                min_functional_trackers=1,
+                modes_require_lock=[0],
+            )
+            tracker.set_ephem(ephem)
+            combined = cfg.startracker_constraint
+            assert combined is not None
+            planning_constraint = Constraint(
+                star_tracker_soft_constraint=combined,
+                star_tracker_enforce_modes=[0],
+                ephem=ephem,
+            )
+
+            for roll in (-60.0, 0.0, 75.0):
+                for ra in range(0, 360, 60):
+                    for dec in (-60.0, 0.0, 60.0):
+                        direct = tracker.in_soft_constraint(
+                            float(ra), dec, sample_utime, roll
+                        )
+                        wrapped = planning_constraint.in_star_tracker_soft(
+                            float(ra),
+                            dec,
+                            sample_utime,
+                            target_roll=roll,
+                            acs_mode=0,
+                        )
+                        assert bool(wrapped) is direct, (
+                            f"boresight={boresight}, attitude=({ra}, {dec}, {roll})"
+                        )
+
     def test_startracker_constraint_none_when_threshold_unreachable_from_soft_only(
         self,
     ):
@@ -610,134 +673,3 @@ class TestStarTrackerComputedConstraint:
         )
 
         assert cfg.startracker_constraint is None
-
-
-class TestBoresightToEulerDeg:
-    """Tests for StarTrackerConfiguration._boresight_to_euler_deg.
-
-    The method returns (roll=0, pitch, yaw) spherical-coordinate decomposition:
-        yaw   = atan2(by, bx)            (azimuth in xy-plane)
-        pitch = atan2(bz, hypot(bx, by)) (elevation from xy-plane)
-
-    These match what boresight_offset() expects: the angles that shift the
-    constraint exclusion zone from +X to the boresight direction.
-    """
-
-    def test_identity_boresight(self):
-        """Default +X boresight → zero angles."""
-        from conops.config.star_tracker import StarTrackerConfiguration
-
-        roll, pitch, yaw = StarTrackerConfiguration._boresight_to_euler_deg(
-            (1.0, 0.0, 0.0)
-        )
-        assert roll == pytest.approx(0.0, abs=1e-9)
-        assert pitch == pytest.approx(0.0, abs=1e-9)
-        assert yaw == pytest.approx(0.0, abs=1e-9)
-
-    def test_plus_y_boresight(self):
-        """Boresight along +Y → yaw=90°, pitch=0°."""
-        from conops.config.star_tracker import StarTrackerConfiguration
-
-        roll, pitch, yaw = StarTrackerConfiguration._boresight_to_euler_deg(
-            (0.0, 1.0, 0.0)
-        )
-        assert roll == pytest.approx(0.0, abs=1e-9)
-        assert pitch == pytest.approx(0.0, abs=1e-9)
-        assert yaw == pytest.approx(90.0, abs=1e-9)
-
-    def test_minus_y_boresight(self):
-        """Boresight along -Y → yaw=-90°, pitch=0°."""
-        from conops.config.star_tracker import StarTrackerConfiguration
-
-        roll, pitch, yaw = StarTrackerConfiguration._boresight_to_euler_deg(
-            (0.0, -1.0, 0.0)
-        )
-        assert roll == pytest.approx(0.0, abs=1e-9)
-        assert pitch == pytest.approx(0.0, abs=1e-9)
-        assert yaw == pytest.approx(-90.0, abs=1e-9)
-
-    def test_plus_z_boresight(self):
-        """Boresight along +Z → yaw=0°, pitch=90°."""
-        from conops.config.star_tracker import StarTrackerConfiguration
-
-        roll, pitch, yaw = StarTrackerConfiguration._boresight_to_euler_deg(
-            (0.0, 0.0, 1.0)
-        )
-        assert roll == pytest.approx(0.0, abs=1e-9)
-        assert pitch == pytest.approx(90.0, abs=1e-9)
-        assert yaw == pytest.approx(0.0, abs=1e-9)
-
-    def test_boresight_in_xz_plane(self):
-        """Boresight in xz-plane → non-zero pitch, zero yaw."""
-        import numpy as np
-
-        from conops.config.star_tracker import StarTrackerConfiguration
-
-        angle = 45.0
-        bx = np.cos(np.deg2rad(angle))
-        bz = np.sin(np.deg2rad(angle))
-        roll, pitch, yaw = StarTrackerConfiguration._boresight_to_euler_deg(
-            (bx, 0.0, bz)
-        )
-        assert roll == pytest.approx(0.0, abs=1e-9)
-        assert pitch == pytest.approx(angle, abs=1e-9)
-        assert yaw == pytest.approx(0.0, abs=1e-9)
-
-    def test_boresight_in_xy_plane(self):
-        """Boresight in xy-plane → non-zero yaw, zero pitch."""
-        import numpy as np
-
-        from conops.config.star_tracker import StarTrackerConfiguration
-
-        angle = -30.0
-        bx = np.cos(np.deg2rad(angle))
-        by = np.sin(np.deg2rad(angle))
-        roll, pitch, yaw = StarTrackerConfiguration._boresight_to_euler_deg(
-            (bx, by, 0.0)
-        )
-        assert roll == pytest.approx(0.0, abs=1e-9)
-        assert pitch == pytest.approx(0.0, abs=1e-9)
-        assert yaw == pytest.approx(angle, abs=1e-9)
-
-    def test_boresight_produces_transform_pointing_agreement(self):
-        """The angles from _boresight_to_euler_deg agree with transform_pointing at (RA=0, Dec=0).
-
-        For spacecraft pointing at (RA=0, Dec=0) with roll=0, transform_pointing
-        gives the star tracker boresight direction in inertial coordinates.
-        That direction should be the same as the spherical-coord (yaw, pitch) angles,
-        which are what boresight_offset() uses to shift the constraint exclusion zone.
-        """
-        import numpy as np
-
-        from conops.config.star_tracker import (
-            StarTrackerConfiguration,
-            StarTrackerOrientation,
-        )
-
-        boresights = [
-            (1.0, 0.0, 0.0),
-            (0.0, 1.0, 0.0),
-            (0.0, -1.0, 0.0),
-            (0.0, 0.0, 1.0),
-            (float(np.cos(np.deg2rad(45))), 0.0, float(np.sin(np.deg2rad(45)))),
-        ]
-
-        for boresight in boresights:
-            ori = StarTrackerOrientation(boresight=boresight)
-            # transform_pointing at (RA=0, Dec=0, roll=0) gives the ST boresight direction
-            ra_st, dec_st = ori.transform_pointing(0.0, 0.0, roll_deg=0.0)
-
-            # _boresight_to_euler_deg should give the spherical coords of the boresight
-            _, pitch_deg, yaw_deg = StarTrackerConfiguration._boresight_to_euler_deg(
-                boresight
-            )
-
-            # Normalise both to [-180, 180] before comparing (vec2radec returns [0,360],
-            # atan2 returns [-180,180] — they should be congruent mod 360).
-            ra_st_norm = (ra_st + 180.0) % 360.0 - 180.0
-            assert yaw_deg == pytest.approx(ra_st_norm, abs=1e-6), (
-                f"boresight={boresight}: yaw={yaw_deg:.4f} != ra_st_norm={ra_st_norm:.4f}"
-            )
-            assert pitch_deg == pytest.approx(dec_st, abs=1e-6), (
-                f"boresight={boresight}: pitch={pitch_deg:.4f} != dec_st={dec_st:.4f}"
-            )

--- a/tests/vector/test_vector.py
+++ b/tests/vector/test_vector.py
@@ -10,7 +10,7 @@ from conops import (
     scbodyvector,
     separation,
 )
-from conops.common.vector import normal_to_euler_deg
+from conops.common.vector import normal_to_boresight_offset_euler_deg
 
 
 class TestQuaternionAttitudeDistance:
@@ -195,27 +195,41 @@ class TestRollOverAngle:
         assert abs(diff2) < 180, f"Expected short path for step 2, got {diff2}°"
 
 
-class TestNormalToEulerDeg:
-    def test_normal_to_euler_plus_y(self) -> None:
-        roll, pitch, yaw = normal_to_euler_deg((0.0, 1.0, 0.0))
+class TestNormalToBoresightOffsetEulerDeg:
+    @pytest.mark.parametrize(
+        ("normal", "expected_pitch", "expected_yaw"),
+        [
+            ((1.0, 0.0, 0.0), 0.0, 0.0),
+            ((0.0, 1.0, 0.0), 0.0, 90.0),
+            ((0.0, -1.0, 0.0), 0.0, -90.0),
+            ((0.0, 0.0, 1.0), -90.0, 0.0),
+            ((0.0, 0.0, -1.0), 90.0, 0.0),
+            ((2**-0.5, 0.0, 2**-0.5), -45.0, 0.0),
+            ((3**0.5 / 2.0, -0.5, 0.0), 0.0, -30.0),
+        ],
+        ids=("+X", "+Y", "-Y", "+Z", "-Z", "XZ", "XY"),
+    )
+    def test_expected_axis_mapping(
+        self,
+        normal: tuple[float, float, float],
+        expected_pitch: float,
+        expected_yaw: float,
+    ) -> None:
+        roll, pitch, yaw = normal_to_boresight_offset_euler_deg(normal)
         assert roll == pytest.approx(0.0)
-        assert pitch == pytest.approx(0.0)
-        assert yaw == pytest.approx(90.0)
+        assert pitch == pytest.approx(expected_pitch)
+        assert yaw == pytest.approx(expected_yaw)
 
-    def test_normal_to_euler_plus_z(self) -> None:
-        roll, pitch, yaw = normal_to_euler_deg((0.0, 0.0, 1.0))
+    def test_generic_non_planar_normal(self) -> None:
+        roll, pitch, yaw = normal_to_boresight_offset_euler_deg((1.0, 1.0, 1.0))
         assert roll == pytest.approx(0.0)
-        assert pitch == pytest.approx(90.0)
-        assert yaw == pytest.approx(0.0)
+        assert pitch == pytest.approx(-35.264389682754654)
+        assert yaw == pytest.approx(45.0)
 
-    def test_normal_to_euler_minus_z(self) -> None:
-        roll, pitch, yaw = normal_to_euler_deg((0.0, 0.0, -1.0))
-        assert roll == pytest.approx(0.0)
-        assert pitch == pytest.approx(-90.0)
-        assert yaw == pytest.approx(0.0)
-
-    def test_normal_to_euler_normalizes_input(self) -> None:
-        roll, pitch, yaw = normal_to_euler_deg(np.array([0.0, 2.0, 0.0]))
+    def test_normalizes_input(self) -> None:
+        roll, pitch, yaw = normal_to_boresight_offset_euler_deg(
+            np.array([0.0, 2.0, 0.0])
+        )
         assert roll == pytest.approx(0.0)
         assert pitch == pytest.approx(0.0)
         assert yaw == pytest.approx(90.0)


### PR DESCRIPTION
## Problem

COAST converted a body normal with a positive Z component to positive boresight pitch. rust-ephem's intrinsic Z-Y-X convention maps positive pitch toward local -Z, so planning constraints mirrored every non-planar mounted boresight across the body XY plane. Pure +/-Y mounts were unaffected, which hid the mismatch in the existing star-tracker parity coverage.

## Solution

- define the rust-ephem boresight-offset convention in the explicitly named `normal_to_boresight_offset_euler_deg()` boundary helper
- map positive body Z to negative rust-ephem pitch
- remove the duplicate star-tracker conversion and use the same helper for star trackers, radiators, and telescopes
- preserve explicit +X, +/-Y, +/-Z, XY, XZ, and generic non-planar mapping coverage
- add fixed-roll parity coverage for +Z, -Z, and generic non-planar boresights

The parity regression compares COAST's direct body-vector transform with rust-ephem's actual wrapped constraint evaluation across multiple attitudes and spacecraft rolls.

## Verification

- `2266 passed, 1 skipped`
- pre-commit hooks pass for all changed files
- GitHub CI passes on Python 3.10 through 3.14, plus lint, formatting, and type checking

Fixes #241
