### PR TITLE
fix: preserve compound roll constraint semantics

### DIFF
--- a/conops/config/constraint.py
+++ b/conops/config/constraint.py
@@ -6,7 +6,15 @@ from typing import cast
 import numpy as np
 import rust_ephem
 from pydantic import ConfigDict, Field, PrivateAttr
-from rust_ephem.constraints import ConstraintConfig
+from rust_ephem.constraints import (
+    AndConstraint,
+    AtLeastConstraint,
+    BoresightOffsetConstraint,
+    ConstraintConfig,
+    NotConstraint,
+    OrConstraint,
+    XorConstraint,
+)
 
 from ..common import dtutcfromtimestamp
 from ..common.enums import ACSMode
@@ -406,41 +414,54 @@ class Constraint(ConfigModel):
                 self.ground_contact_constraint,
             )
             if constraint is not None
-            and not self._boresight_offset_constraints(constraint)
+            and not self._contains_boresight_offset(constraint)
         )
         return self._combine_constraints(components)
 
     @staticmethod
-    def _boresight_offset_constraints(
-        constraint: ConstraintConfig,
-    ) -> list[ConstraintConfig]:
-        """Return roll-dependent boresight-offset leaves from a constraint tree."""
-        from rust_ephem.constraints import BoresightOffsetConstraint
-
+    def _contains_boresight_offset(constraint: ConstraintConfig) -> bool:
+        """Return whether a constraint tree contains a boresight-offset node."""
         if isinstance(constraint, BoresightOffsetConstraint):
-            return [constraint]
-        leaves: list[ConstraintConfig] = []
-        if hasattr(constraint, "constraints"):
-            for subconstraint in constraint.constraints:
-                leaves.extend(Constraint._boresight_offset_constraints(subconstraint))
-        return leaves
+            return True
+        if isinstance(constraint, NotConstraint):
+            return Constraint._contains_boresight_offset(constraint.constraint)
+        if isinstance(
+            constraint,
+            (AndConstraint, OrConstraint, XorConstraint, AtLeastConstraint),
+        ):
+            return any(
+                Constraint._contains_boresight_offset(subconstraint)
+                for subconstraint in constraint.constraints
+            )
+        return False
+
+    @staticmethod
+    def _roll_dependent_subtree(
+        constraint: ConstraintConfig,
+    ) -> ConstraintConfig | None:
+        """Return a roll-dependent tree without changing its boolean semantics.
+
+        Pure roll-independent trees impose no roll-dependent restriction and are
+        omitted. If any descendant depends on roll, retain the complete tree:
+        roll-independent siblings may be either violated or clear for a given
+        target and time, so removing them would change AND, OR, NOT, XOR, or
+        AtLeast behavior. ``roll_range()`` evaluates those siblings as constants
+        while sweeping the roll-dependent descendants.
+        """
+        if Constraint._contains_boresight_offset(constraint):
+            return constraint
+        return None
 
     @cached_property
     def roll_dependent_constraint(self) -> ConstraintConfig | None:
         """Combined constraint from roll-dependent components only.
 
-        Walks the constraint trees of the boresight-offset-capable fields and
-        collects every ``BoresightOffsetConstraint`` leaf node, then OR-combines
-        them.  Only ``BoresightOffsetConstraint`` implements ``roll_range()``
-        correctly; ``AtLeastConstraint`` returns ``True`` for ``_is_roll_dependent``
-        but has an unimplemented ``roll_range()``, so we filter by concrete type
-        rather than the flag.
-
-        Roll-independent constraints (sun/earth/moon/panel on the main boresight)
-        contain no ``BoresightOffsetConstraint`` nodes and are therefore excluded
-        automatically.
+        Projects each configured tree onto its boresight-offset-dependent portion
+        while preserving compound violation logic and AtLeast thresholds. The
+        projected field trees are OR-combined because the fields themselves are
+        independent constraint scopes.
         """
-        leaves: list[ConstraintConfig] = []
+        subtrees: list[ConstraintConfig | None] = []
         for field in (
             self.star_tracker_hard_constraint,
             self.star_tracker_soft_constraint,
@@ -451,14 +472,11 @@ class Constraint(ConfigModel):
             self.safety_constraint,
         ):
             if field is not None:
-                leaves.extend(self._boresight_offset_constraints(field))
+                subtree = self._roll_dependent_subtree(field)
+                if subtree is not None:
+                    subtrees.append(subtree)
 
-        if not leaves:
-            return None
-        combined: ConstraintConfig = leaves[0]
-        for c in leaves[1:]:
-            combined = combined | c
-        return combined
+        return self._combine_constraints(subtrees)
 
     def in_sun(
         self, ra: float, dec: float, time: float, target_roll: float | None = None

--- a/tests/constraint/test_roll_dependent_projection.py
+++ b/tests/constraint/test_roll_dependent_projection.py
@@ -1,0 +1,186 @@
+"""Tests for preserving compound logic in roll-dependent constraints."""
+
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rust_ephem
+from rust_ephem.constraints import (
+    AndConstraint,
+    AtLeastConstraint,
+    BoresightOffsetConstraint,
+    NotConstraint,
+    OrConstraint,
+    XorConstraint,
+)
+
+from conops.common.enums import ACSMode
+from conops.config import (
+    Constraint,
+    StarTracker,
+    StarTrackerConfiguration,
+    StarTrackerOrientation,
+)
+from conops.simulation.roll import _roll_valid_mask
+
+
+def _offset(yaw_deg: float) -> BoresightOffsetConstraint:
+    return rust_ephem.SunConstraint(min_angle=45.0).boresight_offset(yaw_deg=yaw_deg)
+
+
+class TestRollDependentProjection:
+    def test_retains_complete_mixed_compound_trees(self) -> None:
+        first = _offset(45.0)
+        second = _offset(-45.0)
+        independent = rust_ephem.MoonConstraint(min_angle=10.0)
+        cases = [
+            AndConstraint(constraints=[first, independent]),
+            OrConstraint(constraints=[first, independent]),
+            NotConstraint(constraint=OrConstraint(constraints=[first, independent])),
+            XorConstraint(constraints=[first, independent]),
+            AtLeastConstraint(
+                min_violated=2,
+                constraints=[first, independent, second],
+            ),
+        ]
+
+        for tree in cases:
+            assert Constraint._roll_dependent_subtree(tree) is tree
+
+    def test_omits_pure_roll_independent_tree(self) -> None:
+        tree = NotConstraint(constraint=rust_ephem.MoonConstraint(min_angle=10.0))
+
+        assert Constraint._roll_dependent_subtree(tree) is None
+
+
+def _fixed_roll_validity(
+    tree: AtLeastConstraint,
+    ephem: rust_ephem.TLEEphemeris,
+) -> np.ndarray:
+    sample_time = ephem.timestamp[0]
+    return np.array(
+        [
+            not bool(
+                tree.in_constraint(
+                    ephemeris=ephem,
+                    target_ra=0.0,
+                    target_dec=-60.0,
+                    time=sample_time,
+                    target_roll=float(roll),
+                )
+            )
+            for roll in range(360)
+        ],
+        dtype=bool,
+    )
+
+
+def _assert_optimized_mask_matches_fixed_rolls(
+    tree: AtLeastConstraint,
+    ephem: rust_ephem.TLEEphemeris,
+) -> np.ndarray:
+    constraint = Constraint(
+        star_tracker_soft_constraint=tree,
+        star_tracker_enforce_modes=[ACSMode.SCIENCE],
+        ignore_roll=True,
+        ephem=ephem,
+    )
+    sample_utime = ephem.timestamp[0].timestamp()
+    actual = _roll_valid_mask(0.0, -60.0, sample_utime, ephem, constraint)
+    fixed_valid = _fixed_roll_validity(tree, ephem)
+
+    if fixed_valid.all() or not fixed_valid.any():
+        assert actual is None
+    else:
+        assert actual is not None
+        np.testing.assert_array_equal(actual, fixed_valid)
+    return fixed_valid
+
+
+def _test_ephemeris() -> rust_ephem.TLEEphemeris:
+    tle_path = Path(__file__).parents[2] / "examples" / "example.tle"
+    return rust_ephem.TLEEphemeris(
+        begin=datetime(2025, 12, 1, 0, 0, 0),
+        end=datetime(2025, 12, 1, 1, 0, 0),
+        step_size=60,
+        tle=str(tle_path),
+    )
+
+
+@pytest.mark.parametrize(
+    ("min_functional_trackers", "expected_threshold"),
+    [(1, 2), (2, 1)],
+    ids=("one-functional-tracker", "both-functional-trackers"),
+)
+def test_two_tracker_roll_mask_matches_fixed_roll_evaluation(
+    min_functional_trackers: int,
+    expected_threshold: int,
+) -> None:
+    ephem = _test_ephemeris()
+    tracker_constraint = Constraint(
+        sun_constraint=rust_ephem.SunConstraint(min_angle=45.0)
+    )
+    diagonal = 2**-0.5
+    tracker_config = StarTrackerConfiguration(
+        star_trackers=[
+            StarTracker(
+                name="STR_pY",
+                orientation=StarTrackerOrientation(boresight=(diagonal, diagonal, 0.0)),
+                soft_constraint=tracker_constraint,
+            ),
+            StarTracker(
+                name="STR_nY",
+                orientation=StarTrackerOrientation(
+                    boresight=(diagonal, -diagonal, 0.0)
+                ),
+                soft_constraint=tracker_constraint,
+            ),
+        ],
+        min_functional_trackers=min_functional_trackers,
+        modes_require_lock=[ACSMode.SCIENCE],
+    )
+    tree = tracker_config.startracker_constraint
+    assert isinstance(tree, AtLeastConstraint)
+    assert tree.min_violated == expected_threshold
+
+    _assert_optimized_mask_matches_fixed_rolls(tree, ephem)
+
+
+@pytest.mark.parametrize(
+    ("independent_constraint", "expected_violated", "expected_all_valid"),
+    [
+        (rust_ephem.SunConstraint(min_angle=0.0), False, True),
+        (rust_ephem.SunConstraint(min_angle=179.0), True, False),
+    ],
+    ids=("independent-clear", "independent-violated"),
+)
+def test_mixed_at_least_roll_mask_matches_fixed_roll_evaluation(
+    independent_constraint: rust_ephem.SunConstraint,
+    expected_violated: bool,
+    expected_all_valid: bool,
+) -> None:
+    ephem = _test_ephemeris()
+    sample_time = ephem.timestamp[0]
+    independent_violated = bool(
+        independent_constraint.in_constraint(
+            ephemeris=ephem,
+            target_ra=0.0,
+            target_dec=-60.0,
+            time=sample_time,
+            target_roll=0.0,
+        )
+    )
+    assert independent_violated is expected_violated
+
+    tree = AtLeastConstraint(
+        min_violated=2,
+        constraints=[
+            _offset(45.0),
+            independent_constraint,
+            _offset(-45.0),
+        ],
+    )
+    fixed_valid = _assert_optimized_mask_matches_fixed_rolls(tree, ephem)
+
+    assert bool(fixed_valid.all()) is expected_all_valid


### PR DESCRIPTION
## Problem

`Constraint.roll_dependent_constraint` flattened every nested
`BoresightOffsetConstraint` into one OR tree. That changed the meaning of
compound constraints. In particular, a two-tracker `AtLeast(min_violated=2)`
tree became "reject when either tracker is constrained" instead of "reject
when both trackers are constrained."

## Solution

- detect boresight-offset descendants without flattening their parent tree
- omit a tree only when it is entirely roll-independent
- retain a complete mixed tree whenever any descendant depends on roll
- let rust-ephem's compound `roll_range()` evaluate roll-independent siblings as
  constants for the current target and time

Retaining mixed trees is required for exact semantics. A roll-independent child
can be either violated or clear at runtime, which changes AND, OR, NOT, XOR, and
AtLeast results. It therefore cannot be removed by static extraction. AtLeast
thresholds and all parent structure remain unchanged.

## Regression coverage

The optimized mask is compared with fixed-roll evaluation across all 360 integer
rolls for:

- two trackers with one functional tracker required (`min_violated=2`)
- two trackers with both functional trackers required (`min_violated=1`)
- a mixed AtLeast tree whose roll-independent child is clear
- the same mixed tree whose roll-independent child is violated

The old flattened implementation allows only 242 of 360 rolls in the first
two-tracker case. The earlier static-reduction approach also produced 118 mask
mismatches when the mixed tree's independent child was violated.

## Verification

- full COAST suite on current `main`: `2273 passed, 1 skipped`
- lint, formatting, and strict mypy checks passed
- Tamalpais seed 0 passes mission gates
- detailed seed statistics remain unchanged: 90 entries, 65,100 science
  seconds, 960 contact seconds, 11,220 slew seconds, and zero hard-constraint or
  validation-mismatch events

Closes #242
